### PR TITLE
[PORT] Harpy & Moth Clothing Fixes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -62,3 +62,4 @@
   - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
     tags:
     - Skirt
+    - ClothMade

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -63,3 +63,4 @@
     tags:
     - Skirt
     - ClothMade
+    - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -281,6 +281,7 @@
     - ClothMade
     - WhitelistChameleon
     - PrisonUniform
+    - Skirt
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -276,12 +276,6 @@
     controlsLocked: true
     randomMode: false
     mode: SensorCords
-  - type: Tag
-    tags:
-    - ClothMade
-    - WhitelistChameleon
-    - PrisonUniform
-    - Skirt
 
 - type: entity
   parent: ClothingUniformSkirtBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Ports: https://github.com/DeltaV-Station/Delta-v/pull/976
Ports: https://github.com/DeltaV-Station/Delta-v/pull/975


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

"PrisonJumpsuit" component is removed from jumpskirts, so none of the tags are needed hence PrisonJumpskirt no longer needs to overwrite any tags. WhitelistChameleon, ClothMade and Skirt are added to fix Harpy, Cloth and Chameleon issues.

## ( I haven't tested the jumpskirts in the chameleon menu )

## Media

- [X] this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

PrisonUniform no longer used on Jumpskirts

**Changelog**

:cl: DangerRevolution
- fix: Fixed Harpies being unable to wear prison jumpskirts
- fix: Moths can now eat jumpskirts
- fix: Jumpskirts are now a chameleon option.
