### PR TITLE
Revert "AME buff"

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -182,7 +182,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Fuel is squared so more fuel vastly increases power and efficiency
         // We divide by the number of cores so a larger AME is less efficient at the same fuel settings
         // this results in all AMEs having the same efficiency at the same fuel-per-core setting
-        return 2000000f * fuel * fuel / cores;
+        return 20000f * fuel * fuel / cores; // Delt V - Revert upstream buff for normal AME operation
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
This reverts commit e271a5da59284954600fa174e96451340a806f86.

# Description

The AME buff made by Wizden is a bandaid solution to Engineers refusing / being inept at / getting killed while setting up the round's power source, that being Singulo or AME or Tesla. As a result, the station quickly runs out of power and everyone suffers as their AME rooms are quite small, due to the philosophy of AME being a placeholder.

As a result, they cranked up the AME power so it can handle the station while Engineers set up power.

Delta stations, and quite literally any non-Wizden station don't give the antimatter engine a broom closet to be set up in so this is never an issue. As a result, this update does nothing for us but make AME so OP that other power is unnecessary.
## TODO:
Wait for:
- [ ] https://github.com/space-wizards/space-station-14/pull/25898

# Changelog
:cl: DangerRevolution
- tweak: AME is now back to it's Delta-V power values