### PR TITLE
Light Replacer Fix

### DIFF
--- a/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
+++ b/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
@@ -233,7 +233,7 @@ public sealed class LightReplacerSystem : SharedLightReplacerSystem
         // show some message if success
         if (insertedBulbs > 0 && userUid != null)
         {
-            var msg = Loc.GetString("comp-light-replacer-refill-from-storage", ("light-replacer", storageUid));
+            var msg = Loc.GetString("comp-light-replacer-refill-from-storage", ("light-replacer", replacerUid));
             _popupSystem.PopupEntity(msg, replacerUid, userUid.Value, PopupType.Medium);
         }
 


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/26136


# Description

Light Replacer no longer sends out the wrong locale string. Read PR above for details ^

Cherrypicked from Wizden in the gap between last merge and right now.