### PR TITLE
Remove Launcher Bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We however would like to invite anyone wishing to create a server to make a fork
 
 ## Links
 
-[Website](https://simplestation.org) | [Discord](https://discord.gg/X4QEXxUrsJ) | [Steam](https://store.steampowered.com/app/2585480/Space_Station_Multiverse/) | [Standalone](https://spacestationmultiverse.com/downloads/)
+[Website](https://simplestation.org) | [Discord](https://discord.gg/X4QEXxUrsJ) | [Steam(SSMV Launcher)](https://store.steampowered.com/app/2585480/Space_Station_Multiverse/) | [Steam(Wizden Launcher)](https://store.steampowered.com/app/1255460/Space_Station_14/) | [Standalone](https://spacestationmultiverse.com/downloads/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We however would like to invite anyone wishing to create a server to make a fork
 
 ## Links
 
-[Website](https://simplestation.org) | [Discord](https://discord.gg/X4QEXxUrsJ) | [Steam(SSMV Launcher)](https://store.steampowered.com/app/2585480/Space_Station_Multiverse/) | [Steam(Wizden Launcher)](https://store.steampowered.com/app/1255460/Space_Station_14/) | [Standalone](https://spacestationmultiverse.com/downloads/)
+[Website](https://simplestation.org) | [Discord](https://discord.gg/X4QEXxUrsJ) | [Steam(SSMV Launcher)](https://store.steampowered.com/app/2585480/Space_Station_Multiverse/) | [Steam(WizDen Launcher)](https://store.steampowered.com/app/1255460/Space_Station_14/) | [Standalone](https://spacestationmultiverse.com/downloads/)
 
 ## Contributing
 


### PR DESCRIPTION
It was just recently brought to my attention that we had listed a link on our Readme for the SSMV launcher. I'm not opposed to having it, but it's possible that this might be perceived as a form of bias that we don't have. For the sake of impartiality, I've listed both launchers side by side. 