### PR TITLE
Mirror: Add magnet pickup system from Frontier

### DIFF
--- a/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Shared.Frontier.Storage.Components;
+
+/// <summary>
+/// Applies an ongoing pickup area around the attached entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MaterialReclaimerMagnetPickupComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    public TimeSpan NextScan = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("range")]
+    public float Range = 1f;
+
+    /// <summary>
+    /// Frontier - Is the magnet currently enabled?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
+    public bool MagnetEnabled = false;
+}

--- a/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Shared.Frontier.Storage.Components;
+
+/// <summary>
+/// Applies an ongoing pickup area around the attached entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MaterialStorageMagnetPickupComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    public TimeSpan NextScan = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("range")]
+    public float Range = 1f;
+
+    /// <summary>
+    /// Frontier - Is the magnet currently enabled?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
+    public bool MagnetEnabled = false;
+}

--- a/Content.Shared/Frontier/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
+++ b/Content.Shared/Frontier/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
@@ -1,0 +1,107 @@
+using Content.Shared.Frontier.Storage.Components;
+using Content.Shared.Materials;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Content.Shared.Examine;   // Frontier
+using Content.Shared.Hands.Components;  // Frontier
+using Content.Shared.Verbs;     // Frontier
+using Robust.Shared.Utility;    // Frontier
+
+namespace Content.Shared.Frontier.Storage.EntitySystems;
+
+/// <summary>
+/// <see cref="MaterialReclaimerMagnetPickupComponent"/>
+/// </summary>
+public sealed class MaterialReclaimerMagnetPickupSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMaterialReclaimerSystem _storage = default!;
+
+    private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, EntityUnpausedEvent>(OnMagnetUnpaused);
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, ExaminedEvent>(OnExamined);  // Frontier
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb);    // Frontier
+    }
+
+    private void OnMagnetUnpaused(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, ref EntityUnpausedEvent args)
+    {
+        component.NextScan += args.PausedTime;
+    }
+
+    private void OnMagnetMapInit(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, MapInitEvent args)
+    {
+        component.NextScan = _timing.CurTime + TimeSpan.FromSeconds(1); // Need to add 1 sec to fix a weird time bug with it that make it never start the magnet
+    }
+
+    // Frontier, used to add the magnet toggle to the context menu
+    private void AddToggleMagnetVerb(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!HasComp<HandsComponent>(args.User)
+            || !args.CanInteract
+            || !args.CanAccess)
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () =>
+            {
+                component.MagnetEnabled = !component.MagnetEnabled;
+            },
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
+            Priority = 3
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    // Frontier, used to show the magnet state on examination
+    private void OnExamined(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
+                        ("stateText", Loc.GetString(component.MagnetEnabled
+                        ? "magnet-pickup-component-magnet-on"
+                        : "magnet-pickup-component-magnet-off"))));
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<MaterialReclaimerMagnetPickupComponent, MaterialReclaimerComponent, TransformComponent>();
+        var currentTime = _timing.CurTime;
+
+        while (query.MoveNext(out var uid, out var comp, out var storage, out var xform))
+        {
+            if (comp.NextScan < currentTime)
+                continue;
+
+            comp.NextScan += ScanDelay;
+
+            // Frontier - magnet disabled
+            if (!comp.MagnetEnabled)
+                continue;
+
+            var parentUid = xform.ParentUid;
+
+            foreach (var near in _lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries))
+            {
+                if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)
+                    continue;
+
+                if (near == parentUid)
+                    continue;
+
+                _storage.TryStartProcessItem(uid, near);
+            }
+        }
+    }
+}

--- a/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
+++ b/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
@@ -1,0 +1,107 @@
+using Content.Shared.Frontier.Storage.Components;
+using Content.Shared.Materials;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Content.Shared.Examine;   // Frontier
+using Content.Shared.Hands.Components;  // Frontier
+using Content.Shared.Verbs;     // Frontier
+using Robust.Shared.Utility;    // Frontier
+
+namespace Content.Shared.Frontier.Storage.EntitySystems;
+
+/// <summary>
+/// <see cref="MaterialStorageMagnetPickupComponent"/>
+/// </summary>
+public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMaterialStorageSystem _storage = default!;
+
+    private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, EntityUnpausedEvent>(OnMagnetUnpaused);
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, ExaminedEvent>(OnExamined);  // Frontier
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb);    // Frontier
+    }
+
+    private void OnMagnetUnpaused(EntityUid uid, MaterialStorageMagnetPickupComponent component, ref EntityUnpausedEvent args)
+    {
+        component.NextScan += args.PausedTime;
+    }
+
+    private void OnMagnetMapInit(EntityUid uid, MaterialStorageMagnetPickupComponent component, MapInitEvent args)
+    {
+        component.NextScan = _timing.CurTime + TimeSpan.FromSeconds(1); // Need to add 1 sec to fix a weird time bug with it that make it never start the magnet
+    }
+
+    // Frontier, used to add the magnet toggle to the context menu
+    private void AddToggleMagnetVerb(EntityUid uid, MaterialStorageMagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!HasComp<HandsComponent>(args.User)
+            || !args.CanInteract
+            || !args.CanAccess)
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () =>
+            {
+                component.MagnetEnabled = !component.MagnetEnabled;
+            },
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
+            Priority = 3
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    // Frontier, used to show the magnet state on examination
+    private void OnExamined(EntityUid uid, MaterialStorageMagnetPickupComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
+                        ("stateText", Loc.GetString(component.MagnetEnabled
+                        ? "magnet-pickup-component-magnet-on"
+                        : "magnet-pickup-component-magnet-off"))));
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<MaterialStorageMagnetPickupComponent, MaterialStorageComponent, TransformComponent>();
+        var currentTime = _timing.CurTime;
+
+        while (query.MoveNext(out var uid, out var comp, out var storage, out var xform))
+        {
+            if (comp.NextScan < currentTime)
+                continue;
+
+            comp.NextScan += ScanDelay;
+
+            // Frontier - magnet disabled
+            if (!comp.MagnetEnabled)
+                continue;
+
+            var parentUid = xform.ParentUid;
+
+            foreach (var near in _lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries))
+            {
+                if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)
+                    continue;
+
+                if (near == parentUid)
+                    continue;
+
+                _storage.TryInsertMaterialEntity(uid, near, uid, storage);
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/frontier/storage/components/magnet-pickup-components.ftl
+++ b/Resources/Locale/en-US/frontier/storage/components/magnet-pickup-components.ftl
@@ -1,0 +1,4 @@
+magnet-pickup-component-toggle-verb = Toggle magnet
+magnet-pickup-component-on-examine-main = The magnet appears to be {$stateText}.
+magnet-pickup-component-magnet-on = [color=darkgreen]on[/color]
+magnet-pickup-component-magnet-off =  [color=darkred]off[/color]

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1180,6 +1180,9 @@
         - IngotGold30
         - IngotSilver30
         - MaterialBananium10
+    - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
+      magnetEnabled: True
+      range: 0.30 # Delta V - End Magnet Pull
 
 - type: entity
   parent: OreProcessor

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -103,3 +103,6 @@
     solution: output
   - type: StaticPrice
     price: 500
+  - type: MaterialReclaimerMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
+    magnetEnabled: True
+    range: 0.30 # Delta V - End Magnet Pull


### PR DESCRIPTION
## Mirror of  PR-949: [Add magnet pickup system from Frontier](https://github.com/DeltaV-Station/Delta-v/pull/949) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="24"/>[DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" alt=IamVelcroboy width="16"/>[IamVelcroboy](https://github.com/IamVelcroboy) at 2024-03-10 20:17:18 UTC</aside>
<aside>PR merged by <img src="" alt= width="16"/>[]() at 2024-03-17 13:38:11 UTC</aside>
<sup>5acb90a4eb6b8e8436d06cffe92169d07e38d140</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: YML
- Status: Needs Review
- Changes: C#
- Changes: Localization


---

# Original Body

## About the PR
- Title: Machines will automatically pull in tagged items for processing, allowing to set them up on conveyor belts.
- Adds to Ore Processors
- Adds to Material Reclaimer

## Why / Balance
Better gameplay and Factorio mapping

## Technical details
n/a

## Media
https://github.com/DeltaV-Station/Delta-v/assets/107660393/defb8724-acaf-4897-9d5a-4edb5ba17edd

https://github.com/DeltaV-Station/Delta-v/assets/107660393/725a74a3-3978-4097-bdf4-d84ff2f55f38



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- add: Added magnet pickup to Ore Processors and Material Reclaimer