### PR TITLE
Add Anti Anomaly Zone

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Markers/anti_anomaly_zone.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/anti_anomaly_zone.yml
@@ -1,0 +1,33 @@
+- type: entity
+  name: anti anomaly zone
+  description: Anomalies will not be able to appear within a 10 block radius of this point.
+  id: AntiAnomalyZone
+  suffix: "range 10"
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    sprite: Structures/Specific/Anomalies/ice_anom.rsi
+    layers:
+      - state: anom
+      - sprite: Markers/cross.rsi
+        state: pink
+  - type: AntiAnomalyZone
+    zoneRadius: 10
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone20
+  suffix: "range 20"
+  description: Anomalies will not be able to appear within a 20 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 20
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone50
+  suffix: "range 50"
+  description: Anomalies will not be able to appear within a 50 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 50


### PR DESCRIPTION
## Mirror of  PR #944: [Add Anti Anomaly Zone](https://github.com/DeltaV-Station/Delta-v/pull/944) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/52761126?v=4" width="16"/><a href="https://github.com/rosieposieeee"> rosieposieeee</a> at 2024-03-08 19:07:59 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/52761126?v=4" width="16"/><a href="https://github.com/rosieposieeee"> rosieposieeee</a> at 2024-03-17 13:35:52 UTC</aside>
<sup>

`7abdf9a19fe59243201336e6b586ee4780a4722e`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: YML
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> https://github.com/space-wizards/space-station-14/pull/24634
> 
> Upstream added, then removed this, saying "Remove[d] mapping markers as everything should be ingame entities and this is functioning as an area." They left in the code for downstreams. While an ingame object that can perform this function might be useful, this would be best used for arrivals and inside the atmos gas chambers, to prevent those areas that are supposed to be ungriefed from getting griefed by the game itself. If it were an entity, people would probably game it and move those around, and if it were powered, it would fail at its target function. And regardless, upstream removed this *without adding in that entity to replace it.*
> 
> Additionally, some maps have areas where an anom could fully go crit without anyone noticing and it would never affect anybody... which is really boring, such as this area on arena. I have one or two areas like that on Submarine I'd like to use this for.
> 
> ![image](https://github.com/DeltaV-Station/Delta-v/assets/52761126/a27a85f0-4676-4d62-bc10-6b0da6f77342)
> 


</details>