### PR TITLE
Removes a random `1` from SiliconPolice lawset

### DIFF
--- a/Resources/Prototypes/DeltaV/siliconlaws.yml
+++ b/Resources/Prototypes/DeltaV/siliconlaws.yml
@@ -284,7 +284,7 @@
   lawString: law-silicon-police-6
 
 - type: siliconLawset
-  id: SiliconPolice1
+  id: SiliconPolice
   laws:
   - SiliconPolice1
   - SiliconPolice2


### PR DESCRIPTION
## Mirror of  PR #963: [Removes a random `1` from SiliconPolice lawset](https://github.com/DeltaV-Station/Delta-v/pull/963) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/142105406?v=4" width="16"/><a href="https://github.com/DangerRevolution"> DangerRevolution</a> at 2024-03-14 17:13:03 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/142105406?v=4" width="16"/><a href="https://github.com/DangerRevolution"> DangerRevolution</a> at 2024-03-17 13:47:48 UTC</aside>
<sup>

`155fc7d7515238afde3718c1451b51e1a0870cee`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: YML
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> <!-- What did you change in this PR? -->
> 
> Removed a rogue 1 from SiliconPolice ID
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> No other lawset has a 1


</details>