### PR TITLE
Change map prefix to DV

### DIFF
--- a/Resources/Prototypes/Maps/arena.yml
+++ b/Resources/Prototypes/Maps/arena.yml
@@ -12,7 +12,7 @@
           mapNameTemplate: '{0} Arena Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_UCLB.yml
         - type: StationJobs

--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -14,7 +14,7 @@
           mapNameTemplate: '{0} Asterisk Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'DV'
         - type: StationJobs
           overflowJobs:
             - Passenger

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -14,7 +14,7 @@
           mapNameTemplate: '{0} Edge Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'DV'
         - type: StationJobs
           overflowJobs:
             - Passenger

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -11,7 +11,7 @@
           mapNameTemplate: '{0} Hammurabi Prison Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Centipede.yml
         - type: StationJobs

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -12,7 +12,7 @@
           mapNameTemplate: 'The Hive'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Seal.yml
         - type: StationJobs

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -12,7 +12,7 @@
           mapNameTemplate: '{0} Pebble Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'DV'
         - type: StationJobs
           overflowJobs:
             - Passenger

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -12,7 +12,7 @@
           mapNameTemplate: '{0} Shōkō "Little Port" {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Delta.yml
         - type: StationJobs

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -11,7 +11,7 @@
           mapNameTemplate: '{0} Submarine {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_BC20.yml
         - type: StationJobs

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -11,7 +11,7 @@
           mapNameTemplate: '{0} Tortuga Station {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: 'TG'
+            prefixCreator: 'DV'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Seal.yml
         - type: StationJobs


### PR DESCRIPTION
## Mirror of  PR #979: [Change map prefix to DV](https://github.com/DeltaV-Station/Delta-v/pull/979) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-19 00:13:41 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-19 02:19:48 UTC</aside>
<sup>

`1f6cb805d63ec66194dbcc04a8cd4cb20b389711`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: Map


---

<details open="true"><summary><h1>Original Body</h1></summary>

> **About**
> Title(I honestly thought this pulled from a random string until yesterday)
> 
> We'll use DV for our maps from here out. 


</details>