### PR TITLE
Adds pre-set warp points

### DIFF
--- a/Resources/Locale/en-US/deltav/warp-points/warp-points.ftl
+++ b/Resources/Locale/en-US/deltav/warp-points/warp-points.ftl
@@ -1,0 +1,41 @@
+warp-point-evac = Evac
+warp-point-shuttle = Shuttle
+warp-point-debris = Space Debris
+warp-point-ruin = Space Ruin
+
+warp-point-bridge = Bridge
+warp-point-vault = Vault
+
+warp-point-sec = Security
+warp-point-perma = Perma
+warp-point-detective = Detective
+warp-point-court = Courtroom
+
+warp-point-medical = Medical
+warp-point-morgue = Morgue
+
+warp-point-epistemics = Epistemics
+
+warp-point-logistics = Logistics
+warp-point-salvage = Salvage
+
+warp-point-engineering = Engineering
+warp-point-singularity = Singularity
+warp-point-atmospherics = Atmos
+
+warp-point-hop = HoP
+warp-point-kitchen = Kitchen
+warp-point-bar = Bar
+warp-point-botany = Botany
+warp-point-janitor = Janitor
+warp-point-reporter = Reporter
+warp-point-lawyer = Lawyer
+
+warp-point-ai = AI
+warp-point-arrivals = Arrivals
+warp-point-evac = Evac
+warp-point-cryo = Cryo
+warp-point-chapel = Chapel
+warp-point-library = Library
+warp-point-dorms = Dorms
+warp-point-disposals = Disposals

--- a/Resources/Prototypes/DeltaV/Entities/Markers/warp_points.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/warp_points.yml
@@ -1,0 +1,272 @@
+# Off station
+- type: entity
+  id: WarpPointEvacShuttle
+  parent: WarpPoint
+  suffix: Evac Shuttle
+  components:
+  - type: WarpPoint
+    location: warp-point-evac
+
+- type: entity
+  id: WarpPointShuttle
+  parent: WarpPoint
+  suffix: Shuttle
+  components:
+  - type: WarpPoint
+    location: warp-point-shuttle
+
+- type: entity
+  id: WarpPointDebris
+  parent: WarpPoint
+  suffix: Space Debris
+  components:
+  - type: WarpPoint
+    location: warp-point-debris
+
+- type: entity
+  id: WarpPointRuin
+  parent: WarpPoint
+  suffix: Space Ruin
+  components:
+  - type: WarpPoint
+    location: warp-point-ruin
+
+# Command
+- type: entity
+  id: WarpPointBridge
+  parent: WarpPoint
+  suffix: Bridge
+  components:
+  - type: WarpPoint
+    location: warp-point-bridge
+
+- type: entity
+  id: WarpPointVault
+  parent: WarpPoint
+  suffix: Vault
+  components:
+  - type: WarpPoint
+    location: warp-point-vault
+
+# Security
+- type: entity
+  id: WarpPointSecurity
+  parent: WarpPoint
+  suffix: Security
+  components:
+  - type: WarpPoint
+    location: warp-point-sec
+
+- type: entity
+  id: WarpPointPerma
+  parent: WarpPoint
+  suffix: Perma
+  components:
+  - type: WarpPoint
+    location: warp-point-perma
+
+- type: entity
+  id: WarpPointDetective
+  parent: WarpPoint
+  suffix: Detective
+  components:
+  - type: WarpPoint
+    location: warp-point-detective
+
+- type: entity
+  id: WarpPointCourt
+  parent: WarpPoint
+  suffix: Courtroom
+  components:
+  - type: WarpPoint
+    location: warp-point-court
+
+#Medical
+- type: entity
+  id: WarpPointMedical
+  parent: WarpPoint
+  suffix: Medical
+  components:
+  - type: WarpPoint
+    location: warp-point-medical
+
+- type: entity
+  id: WarpPointMorgue
+  parent: WarpPoint
+  suffix: Morgue
+  components:
+  - type: WarpPoint
+    location: warp-point-morgue
+
+#Epistemics
+- type: entity
+  id: WarpPointEpistemics
+  parent: WarpPoint
+  suffix: Epistemics
+  components:
+  - type: WarpPoint
+    location: warp-point-epistemics
+
+#Logistics
+- type: entity
+  id: WarpPointLogistics
+  parent: WarpPoint
+  suffix: Logistics
+  components:
+  - type: WarpPoint
+    location: warp-point-logistics
+
+- type: entity
+  id: WarpPointSalvage
+  parent: WarpPoint
+  suffix: Salvage
+  components:
+  - type: WarpPoint
+    location: warp-point-salvage
+
+#Engineering
+- type: entity
+  id: WarpPointEngineering
+  parent: WarpPoint
+  suffix: Engineering
+  components:
+  - type: WarpPoint
+    location: warp-point-engineering
+
+- type: entity
+  id: WarpPointSingulo
+  parent: WarpPoint
+  suffix: Singularity
+  components:
+  - type: WarpPoint
+    location: warp-point-singularity
+
+- type: entity
+  id: WarpPointAtmos
+  parent: WarpPoint
+  suffix: Atmos
+  components:
+  - type: WarpPoint
+    location: warp-point-atmospherics
+
+#Service
+- type: entity
+  id: WarpPointHOP
+  parent: WarpPoint
+  suffix: HoP
+  components:
+  - type: WarpPoint
+    location: warp-point-hop
+
+- type: entity
+  id: WarpPointKitchen
+  parent: WarpPoint
+  suffix: Kitchen
+  components:
+  - type: WarpPoint
+    location: warp-point-kitchen
+
+- type: entity
+  id: WarpPointBar
+  parent: WarpPoint
+  suffix: Bar
+  components:
+  - type: WarpPoint
+    location: warp-point-bar
+
+- type: entity
+  id: WarpPointBotany
+  parent: WarpPoint
+  suffix: Botany
+  components:
+  - type: WarpPoint
+    location: warp-point-botany
+
+- type: entity
+  id: WarpPointJanitor
+  parent: WarpPoint
+  suffix: Janitor
+  components:
+  - type: WarpPoint
+    location: warp-point-janitor
+
+- type: entity
+  id: WarpPointReporter
+  parent: WarpPoint
+  suffix: Reporter
+  components:
+  - type: WarpPoint
+    location: warp-point-reporter
+
+- type: entity
+  id: WarpPointLawyer
+  parent: WarpPoint
+  suffix: Lawyer
+  components:
+  - type: WarpPoint
+    location: warp-point-lawyer
+
+#Misc
+- type: entity
+  id: WarpPointAI
+  parent: WarpPoint
+  suffix: AI
+  components:
+  - type: WarpPoint
+    location: warp-point-ai
+
+- type: entity
+  id: WarpPointArrivals
+  parent: WarpPoint
+  suffix: Arrivals
+  components:
+  - type: WarpPoint
+    location: warp-point-arrivals
+
+- type: entity
+  id: WarpPointEvac
+  parent: WarpPoint
+  suffix: Evac
+  components:
+  - type: WarpPoint
+    location: warp-point-evac
+
+- type: entity
+  id: WarpPointCryo
+  parent: WarpPoint
+  suffix: Cryo
+  components:
+  - type: WarpPoint
+    location: warp-point-cryo
+
+- type: entity
+  id: WarpPointChapel
+  parent: WarpPoint
+  suffix: Chapel
+  components:
+  - type: WarpPoint
+    location: warp-point-chapel
+
+- type: entity
+  id: WarpPointLibrary
+  parent: WarpPoint
+  suffix: Library
+  components:
+  - type: WarpPoint
+    location: warp-point-library
+
+- type: entity
+  id: WarpPointDorms
+  parent: WarpPoint
+  suffix: Dorms
+  components:
+  - type: WarpPoint
+    location: warp-point-dorms
+
+- type: entity
+  id: WarpPointDisposals
+  parent: WarpPoint
+  suffix: Disposals
+  components:
+  - type: WarpPoint
+    location: warp-point-disposals


### PR DESCRIPTION
## Mirror of  PR #991: [Adds pre-set warp points](https://github.com/DeltaV-Station/Delta-v/pull/991) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-21 18:53:11 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-22 01:35:14 UTC</aside>
<sup>

`2ad986dddd855df06eb430b0640340b9f14a79ee`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: YML
- Changes: Localization


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Title
> Will work together with [this](https://github.com/DeltaV-Station/Delta-v/pull/968) to create a cleaner more straightforward WP/Beacon mapping system.
> 
> ## Why / Balance
> Easier for mappers. Better for players


</details>