### PR TITLE
Revert "Revert "Revert AME buff""

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -182,7 +182,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Fuel is squared so more fuel vastly increases power and efficiency
         // We divide by the number of cores so a larger AME is less efficient at the same fuel settings
         // this results in all AMEs having the same efficiency at the same fuel-per-core setting
-        return 2000000f * fuel * fuel / cores;
+        return 20000f * fuel * fuel / cores; // Delt V - Revert upstream buff for normal AME operation
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
## Mirror of  PR #996: [Revert "Revert "Revert AME buff""](https://github.com/DeltaV-Station/Delta-v/pull/996) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-23 00:07:05 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-23 00:16:26 UTC</aside>
<sup>

`b4fc2e342be6ef395b1ca21f27787ac08a89df59`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Reverts DeltaV-Station/Delta-v#939
> 
> We might revert this again if everything burns but it's worth a shot. Let's gooo
> 
> 
> **Changelog**
> :cl: Velcroboy
> - tweak: Reverted AME buff. AME will require more than 1 core again to function properly. 


</details>