### PR TITLE
Whitelistremoves now requires either ban or whitelist, not both

### DIFF
--- a/Content.Server/Whitelist/WhitelistCommands.cs
+++ b/Content.Server/Whitelist/WhitelistCommands.cs
@@ -71,7 +71,7 @@ public sealed class AddWhitelistCommand : LocalizedCommands
     }
 }
 
-[AdminCommand(AdminFlags.Ban | AdminFlags.Whitelist)] // DeltaV - Custom permission for whitelist. Hopefully this is an or, not an and
+[AdminCommand(AdminFlags.Ban), AdminCommand(AdminFlags.Whitelist)] // DeltaV - Custom permission for whitelist.
 public sealed class RemoveWhitelistCommand : LocalizedCommands
 {
     public override string Command => "whitelistremove";


### PR DESCRIPTION
## Mirror of  PR #994: [Whitelistremoves now requires either ban or whitelist, not both](https://github.com/DeltaV-Station/Delta-v/pull/994) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/56081759?v=4" width="16"/><a href="https://github.com/NullWanderer"> NullWanderer</a> at 2024-03-21 23:16:47 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/56081759?v=4" width="16"/><a href="https://github.com/NullWanderer"> NullWanderer</a> at 2024-03-27 23:53:10 UTC</aside>
<sup>

`a2a3bcbb869530aa1511af8339d8abc2cc84eba8`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:
- Changes: C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Admins asked for it, and it looks to be a mistake in the code
> 
> **Changelog**
> :cl:
> DELTAVADMIN:
> - fix: whitelistremove now requires either ban or whitelist, not both.
> 
> 


</details>