### PR TITLE
Standardized location tags

### DIFF
--- a/Resources/ConfigPresets/DeltaV/apoapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/apoapsis.toml
@@ -1,5 +1,5 @@
 [game]
-hostname         = "[EN][MRP] Delta-v (Ψ) | Apoapsis"
+hostname         = "[EN][MRP] Delta-v (Ψ) | Apoapsis [US East 1]"
 soft_max_players = 100
 
 [server]
@@ -15,7 +15,7 @@ min_players = 90
 emergency_early_launch_allowed = true
 
 [hub]
-tags = "lang:en-US,region:am_n_e,rp:med"
+tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"
 
 [atmos]
 monstermos_rip_tiles = false

--- a/Resources/ConfigPresets/DeltaV/inclination.toml
+++ b/Resources/ConfigPresets/DeltaV/inclination.toml
@@ -1,5 +1,5 @@
 [game]
-hostname         = "[EN][EU][MRP] Delta-v (Ψ) | Inclination"
+hostname         = "[EN][MRP] Delta-v (Ψ) | Inclination [EU West]"
 soft_max_players = 50
 
 [server]
@@ -14,4 +14,4 @@ map_enabled = true
 enable_during_round = true
 
 [hub]
-tags = "lang:en-US,region:eu_w,rp:med"
+tags = "lang:en-US,region:eu_w,rp:med,no_tag_infer"

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -1,5 +1,5 @@
 [game]
-hostname         = "[EN][MRP] Delta-v (Ψ) | Periapsis"
+hostname         = "[EN][MRP] Delta-v (Ψ) | Periapsis [US East 2]"
 soft_max_players = 50
 
 [server]
@@ -19,4 +19,4 @@ min_players = 10
 enable_during_round = true
 
 [hub]
-tags = "lang:en-US,region:am_n_e,rp:med"
+tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"


### PR DESCRIPTION
## Mirror of  PR #1054: [Standardized location tags](https://github.com/DeltaV-Station/Delta-v/pull/1054) from <img src="https://avatars.githubusercontent.com/u/131613340?v=4" alt="DeltaV-Station" width="22"/> [DeltaV-Station](https://github.com/DeltaV-Station)/[Delta-v](https://github.com/DeltaV-Station/Delta-v)

<aside>PR opened by <img src="https://avatars.githubusercontent.com/u/56081759?v=4" width="16"/><a href="https://github.com/NullWanderer"> NullWanderer</a> at 2024-04-03 19:38:43 UTC</aside>
<aside>PR merged by <img src="https://avatars.githubusercontent.com/u/56081759?v=4" width="16"/><a href="https://github.com/NullWanderer"> NullWanderer</a> at 2024-04-03 19:47:43 UTC</aside>
<sup>

`c17c74c5a1f7909e7a7a1a7e323bb76ae6aa4843`

</sup>

---

PR changed 0 files with 0 additions and 0 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Just matches what seems to be more common on the hub, and for the entirely selfish reason of having my favorites tab be lined up perfectly 


</details>