### PR TITLE
Revert WizDen "Crack syndicate skulls!" Sectech Message

### DIFF
--- a/Resources/Locale/en-US/advertisements/vending/sectech.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/sectech.ftl
@@ -1,4 +1,4 @@
-﻿advertisement-sectech-1 = Crack syndicate skulls!
+﻿advertisement-sectech-1 = Crack communist skulls!
 advertisement-sectech-2 = Beat some heads in!
 advertisement-sectech-3 = Don't forget - harm is good!
 advertisement-sectech-4 = Your weapons are right here.


### PR DESCRIPTION
# Description

Reverts [a WizDen change](https://github.com/space-wizards/space-station-14/pull/24965) to the sectech specifically calling out the Syndicate even though the Syndicate terrorist attacks are supposed to be unexpected and uncommon even if that is not reflected in gameplay.

# Changelog

:cl:
- tweak: Sectech now says "Crack communist skulls!" instead of "Crack syndicate skulls!"
