### PR TITLE
Mirror: Slimes can drink fourteenloko

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -162,6 +162,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
         damage:
           types:
             Poison: 1


### PR DESCRIPTION
## Mirror of  PR #25889: [Slimes can drink fourteenloko](https://github.com/space-wizards/space-station-14/pull/25889) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `a846966515e3051c131f00dc56743c360a91766e`

PR opened by <img src="https://avatars.githubusercontent.com/u/128169402?v=4" width="16"/><a href="https://github.com/Nimfar11"> Nimfar11</a> at 2024-03-06 21:30:38 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-07 20:50:10 UTC

---

PR changed 1 files with 4 additions and 0 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> 
> Slimes can drink FourteenLoko not 1 time or even 2, but as much as they want. Their stomachs can process this obscure slurry without harming their bodies. 
> 
> ## Why / Balance
> 
> Strange finding legal poison, that way they'll have at least one consumer in them. Interesting feature for the slime people.
> 
> ## Media
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> :cl: Nimfar11
> 
> - tweak: Slimes can now drink FourteenLoko without harming their bodies.
> 


</details>