### PR TITLE
Mirror: Green alert shuttle time change

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -5,7 +5,6 @@
     green:
       announcement: alert-level-green-announcement
       color: Green
-      sound: /Audio/Announcements/Alerts/code_green.ogg
       shuttleTime: 600
     blue:
       announcement: alert-level-blue-announcement


### PR DESCRIPTION
## Mirror of  PR #25906: [Green alert shuttle time change](https://github.com/space-wizards/space-station-14/pull/25906) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `77f969af0efe5095c3684ee6d51b31c8cc05551b`

PR opened by <img src="https://avatars.githubusercontent.com/u/45946146?v=4" width="16"/><a href="https://github.com/NakataRin"> NakataRin</a> at 2024-03-07 10:20:37 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-07 21:01:53 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Set shuttle arrive time on green code to 10 minutes.
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Green alert shuttle time is set to 20 mins, while blue, red etc. set to 10. I can see why this is a good thing, but everyone just sets alert to blue to call the shuttle. So instead of people setting alert level to blue every time they want to call a shuttle, why not just make it 10 minutes to green as well.
> I'm not sure if this is a correct way of addressing the issue of _blue→call evac→green_, but I don't have any better idea for now.
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> N/A
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> :cl:
> - tweak: Evacuation shuttle arrives 10 minutes on green alert now.
> 


</details>