### PR TITLE
Mirror: Atmospherics thermomachines now properly excite the gas mixture they add heat to

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 _atmosphereSystem.AddHeat(heatExchangeGasMixture, dQPipe);
                 thermoMachine.LastEnergyDelta = dQPipe;
 
-                if (dQLeak != 0f && _atmosphereSystem.GetContainingMixture(uid) is { } containingMixture)
+                if (dQLeak != 0f && _atmosphereSystem.GetContainingMixture(uid, excite: true) is { } containingMixture)
                     _atmosphereSystem.AddHeat(containingMixture, dQLeak);
             }
 
@@ -126,7 +126,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             heatExchangeGasMixture = null;
             if (thermoMachine.Atmospheric)
             {
-                heatExchangeGasMixture = _atmosphereSystem.GetContainingMixture(uid);
+                heatExchangeGasMixture = _atmosphereSystem.GetContainingMixture(uid, excite: true);
             }
             else
             {


### PR DESCRIPTION
## Mirror of  PR #25916: [Atmospherics thermomachines now properly excite the gas mixture they add heat to](https://github.com/space-wizards/space-station-14/pull/25916) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `1e62e445f0b5298c50dc0ab7ff20f88563a13d5f`

PR opened by <img src="https://avatars.githubusercontent.com/u/7117411?v=4" width="16"/><a href="https://github.com/Menshin"> Menshin</a> at 2024-03-07 20:16:52 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-07 21:05:43 UTC

---

PR changed 1 files with 2 additions and 2 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Atmospherics thermomachines now properly invalidate the tile they are exchanging heat with.
> Fixes #25827.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Atmospherics thermomachines were retrieving the gas mixture from the tile they were on without invalidating the tile, so no atmos update was done apart from the temperature of the tile gas mixture rising. They now do so.
> 
> Note that this was affecting hellfire heater/freezer too.
> 
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> Not needed i think
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> 


</details>