### PR TITLE
Mirror: Remove Hamlet, Smile and Pun Pun from Thief objective

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -593,8 +593,6 @@
     - CannotSuicide
     - Hamster
     - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalHamlet
 
 - type: entity
   name: Shiva
@@ -767,8 +765,6 @@
     attributes:
       proper: true
       gender: female
-  - type: StealTarget
-    stealGroup: AnimalSmile
 
 - type: entity
   name: Pun Pun
@@ -803,8 +799,6 @@
     attributes:
       proper: true
       gender: male
-  - type: StealTarget
-    stealGroup: AnimalPunPun
 
 - type: entity
   name: Tropico

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -125,10 +125,7 @@
     WalterStealObjective: 1
     MortyStealObjective: 1
     RenaultStealObjective: 1
-    HamletStealObjective: 1
     ShivaStealObjective: 1
-    SmileStealObjective: 1
-    PunPunStealObjective: 1
     TropicoStealObjective: 1
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -387,32 +387,11 @@
     state: fox
 
 - type: stealTargetGroup
-  id: AnimalHamlet
-  name: Hamlet
-  sprite:
-    sprite: Mobs/Pets/hamlet.rsi
-    state: hamster-0
-
-- type: stealTargetGroup
   id: AnimalShiva
   name: Shiva
   sprite:
     sprite: Mobs/Pets/shiva.rsi
     state: shiva
-
-- type: stealTargetGroup
-  id: AnimalSmile
-  name: Smile
-  sprite:
-    sprite: Mobs/Aliens/slimes.rsi
-    state: rainbow_baby_slime
-
-- type: stealTargetGroup
-  id: AnimalPunPun
-  name: Pun Pun
-  sprite:
-    sprite: Mobs/Animals/monkey.rsi
-    state: monkey
 
 - type: stealTargetGroup
   id: AnimalTropico

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -536,48 +536,12 @@
 - type: entity
   noSpawn: true
   parent: BaseThiefStealAnimalObjective
-  id: HamletStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Captain
-  - type: StealCondition
-    stealGroup: AnimalHamlet
-  - type: Objective
-    difficulty: 1
-
-- type: entity
-  noSpawn: true
-  parent: BaseThiefStealAnimalObjective
   id: ShivaStealObjective
   components:
   - type: NotJobRequirement
     job: SecurityOfficer
   - type: StealCondition
     stealGroup: AnimalShiva
-  - type: Objective
-    difficulty: 2
-
-- type: entity
-  noSpawn: true
-  parent: BaseThiefStealAnimalObjective
-  id: SmileStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Scientist
-  - type: StealCondition
-    stealGroup: AnimalSmile
-  - type: Objective
-    difficulty: 1
-
-- type: entity
-  noSpawn: true
-  parent: BaseThiefStealAnimalObjective
-  id: PunPunStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Bartender
-  - type: StealCondition
-    stealGroup: AnimalPunPun
   - type: Objective
     difficulty: 2
 


### PR DESCRIPTION
## Mirror of  PR #25921: [Remove Hamlet, Smile and Pun Pun from Thief objective](https://github.com/space-wizards/space-station-14/pull/25921) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `faed7a3746c90db98538958d0332c778092eb377`

PR opened by <img src="https://avatars.githubusercontent.com/u/96445749?v=4" width="16"/><a href="https://github.com/TheShuEd"> TheShuEd</a> at 2024-03-07 22:07:40 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-07 23:53:36 UTC

---

PR changed 4 files with 0 additions and 66 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> title
> 
> ## Why / Balance
> stealing ghostrole is asspain 
> 
> **Changelog**
> :cl:
> - remove: Removed Hamlet, Smile and Pun Pun from Thief objectives
> 


</details>