### PR TITLE
Mirror: Disable the publish and preview buttons on news management console when bounds are exceeded

### DIFF
--- a/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
+++ b/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
@@ -56,11 +56,17 @@ public sealed partial class ArticleEditorPanel : Control
         {
             control.ModulateSelfOverride = Color.Red;
             control.ToolTip = Loc.GetString("news-writer-text-length-exceeded");
+
+            ButtonPublish.Disabled = true;
+            ButtonPreview.Disabled = true;
         }
         else
         {
             control.ModulateSelfOverride = null;
             control.ToolTip = string.Empty;
+
+            ButtonPublish.Disabled = false;
+            ButtonPreview.Disabled = false;
         }
     }
 


### PR DESCRIPTION
## Mirror of  PR #25939: [Disable the publish and preview buttons on news management console when bounds are exceeded](https://github.com/space-wizards/space-station-14/pull/25939) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `08e1b79a7f6d75441bf50ead268e4b852d270172`

PR opened by <img src="https://avatars.githubusercontent.com/u/103440971?v=4" width="16"/><a href="https://github.com/Brandon-Huu"> Brandon-Huu</a> at 2024-03-09 07:48:04 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-09 08:26:02 UTC

---

PR changed 1 files with 6 additions and 0 deletions.

The PR had the following labels:
- Changes: UI


---

<details open="true"><summary><h1>Original Body</h1></summary>

> disable buttons when out of bounds
> 
> disable buttons when excedded
> 
> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Disable buttons when outside of bounds
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Articles not being published even though users were allowed is VV annoying.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> 


</details>