### PR TITLE
Mirror: Fix game.role_timers not effecting the antag menu

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -89,12 +89,6 @@ public sealed partial class JobRequirementsManager
             return false;
         }
 
-        if (job.Requirements == null ||
-            !_cfg.GetCVar(CCVars.GameRoleTimers))
-        {
-            return true;
-        }
-
         var player = _playerManager.LocalSession;
         if (player == null)
             return true;
@@ -106,7 +100,7 @@ public sealed partial class JobRequirementsManager
     {
         reason = null;
 
-        if (requirements == null)
+        if (requirements == null || !_cfg.GetCVar(CCVars.GameRoleTimers))
             return true;
 
         var reasons = new List<string>();


### PR DESCRIPTION
## Mirror of  PR #25964: [Fix game.role_timers not effecting the antag menu](https://github.com/space-wizards/space-station-14/pull/25964) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `1eb2bcf45532c4200c1f2606d1759fe335a636f7`

PR opened by <img src="https://avatars.githubusercontent.com/u/34938708?v=4" width="16"/><a href="https://github.com/VasilisThePikachu"> VasilisThePikachu</a> at 2024-03-10 14:11:20 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-10 16:30:16 UTC

---

PR changed 1 files with 1 additions and 7 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Closes #21404
> 
> The server checked this fine and would let you join correctly as the antag. Just the client prevented you.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


</details>