### PR TITLE
Mirror: Prevents FloorOcclusion from breaking rendering

### DIFF
--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -43,9 +43,14 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
     private void SetShader(SpriteComponent sprite, bool enabled)
     {
+        var shader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
+
+        if (sprite.PostShader is not null && sprite.PostShader != shader)
+            return;
+
         if (enabled)
         {
-            sprite.PostShader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
+            sprite.PostShader = shader;
         }
         else
         {


### PR DESCRIPTION
## Mirror of  PR #25960: [Prevents FloorOcclusion from breaking rendering](https://github.com/space-wizards/space-station-14/pull/25960) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `717da4a8f3b6d68cb17d6bf75c84eae6ce46e1b5`

PR opened by <img src="https://avatars.githubusercontent.com/u/68350815?v=4" width="16"/><a href="https://github.com/DoutorWhite"> DoutorWhite</a> at 2024-03-10 08:16:46 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-10 17:07:24 UTC

---

PR changed 1 files with 6 additions and 1 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> 
> This PR adds a condition so that FloorOcclusionSystem does not overwrite existing PostShaders.
> 
> ## Why / Balance
> 
> Because if a Mutable PostShader already exists, the FloorOcclusionSystem will simply replace it with its own, which is Immutable, which creates conflict with other systems and breaks the game's rendering and UI, to the point that all clients are immediately left with a black screen and the FPS drops to 0, eventually resulting in a crash. There is an in-game situation where this bug is replicable and I will not address it publicly in this PR because it is potentially game breaking, if you want you can chat with me via DM on discord (my name is the same).
> 
> ## Technical details
> 
> Adds an extra condition so that the FloorOcclusionSystem does not replace the PostShader of other systems. Honestly this is a workaround, this system should be redone in the engine, but I don't have the knowledge to do so.
> 
> ## Media
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> The FloorOcclusionSystem should no longer work if there is already another PostShader in sprite.
> 
> **Changelog**
> 
> :cl:
> - fix: Prevents rendering from crashing in certain scenarios
> 


</details>