### PR TITLE
Mirror: Add admin logs for butchering

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Server.Body.Systems;
 using Content.Server.Kitchen.Components;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Components;
+using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Popups;
@@ -26,6 +28,7 @@ public sealed class SharpSystem : EntitySystem
     [Dependency] private readonly ContainerSystem _containerSystem = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
     {
@@ -73,7 +76,6 @@ public sealed class SharpSystem : EntitySystem
                 BreakOnDamage = true,
                 NeedHand = true
             };
-
         _doAfterSystem.TryStartDoAfter(doAfter);
     }
 
@@ -121,6 +123,11 @@ public sealed class SharpSystem : EntitySystem
         _destructibleSystem.DestroyEntity(args.Args.Target.Value);
 
         args.Handled = true;
+
+        _adminLogger.Add(LogType.Gib,
+            $"{EntityManager.ToPrettyString(args.User):user} " +
+            $"has butchered {EntityManager.ToPrettyString(args.Target):target} " +
+            $"with {EntityManager.ToPrettyString(args.Used):knife}");
     }
 
     private void OnGetInteractionVerbs(EntityUid uid, ButcherableComponent component, GetVerbsEvent<InteractionVerb> args)


### PR DESCRIPTION
## Mirror of  PR #25980: [Add admin logs for butchering](https://github.com/space-wizards/space-station-14/pull/25980) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f9bb70aea170f8f02b5245a256a5136f3da70509`

PR opened by <img src="https://avatars.githubusercontent.com/u/62253058?v=4" width="16"/><a href="https://github.com/Gyrandola"> Gyrandola</a> at 2024-03-10 22:13:55 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-11 01:41:02 UTC

---

PR changed 1 files with 8 additions and 1 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Adds an admin log for when someone successfully butchers something. The attempt was already logged.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Fixes #25278 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Added a couple dependencies and the log at the end of SharpSystem's OnDoAfter.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> ![Screenshot 2024-03-10 230442](https://github.com/space-wizards/space-station-14/assets/62253058/1e1739b9-1d59-46e2-bb77-79c16382afa0)
> 


</details>