### PR TITLE
Mirror: buff cargo hydroponics crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
@@ -56,10 +56,14 @@
       - id: PlantBGoneSpray
       - id: WeedSpray
       - id: PestSpray
+      - id: HydroponicsToolClippers
       - id: HydroponicsToolScythe
+      - id: HydroponicsToolSpade
       - id: HydroponicsToolHatchet
       - id: ClothingOuterApronBotanist
       - id: ClothingHandsGlovesLeather
+      - id: EZNutrientChemistryBottle
+        amount: 2
 
 - type: entity
   id: CrateHydroponicsSeeds


### PR DESCRIPTION
## Mirror of  PR #25878: [buff cargo hydroponics crate](https://github.com/space-wizards/space-station-14/pull/25878) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `88f8da465b65a2c8682fb8bbc59f088f8aa6babd`

PR opened by <img src="https://avatars.githubusercontent.com/u/39013340?v=4" width="16"/><a href="https://github.com/deltanedas"> deltanedas</a> at 2024-03-06 11:49:30 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-11 04:52:22 UTC

---

PR changed 1 files with 4 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> adds:
> - clippers
> - spade
> - 2 bottles of ez nutrient
> 
> to hydroponics crate order
> 
> ## Why / Balance
> right now the crate only has 2 useful things, plant b gone and the hoe. with these you can actually use it to kickstart a farm. the ez nutrient is much more efficiently made by buying chemical crates rather than $500 for 60u
> 
> ## Technical details
> no
> 
> ## Media
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> no
> 
> **Changelog**
> no cl no fun


</details>