### PR TITLE
Mirror: Add "Juice that makes you Weh" to moths eating Lizard plushies

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -279,6 +279,15 @@
       reagents:
       - ReagentId: JuiceThatMakesYouWeh
         Quantity: 30
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
+        - ReagentId: JuiceThatMakesYouWeh
+          Quantity: 10
 
 - type: entity
   parent: PlushieLizard
@@ -322,6 +331,15 @@
       reagents:
       - ReagentId: JuiceThatMakesYouWeh
         Quantity: 30
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
+        - ReagentId: JuiceThatMakesYouWeh
+          Quantity: 10
 
 - type: entity
   parent: BasePlushie


### PR DESCRIPTION
## Mirror of  PR #26003: [Add "Juice that makes you Weh" to moths eating Lizard plushies](https://github.com/space-wizards/space-station-14/pull/26003) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `6d1f07a375a5d3f973d279a5d356b1f185d07cd5`

PR opened by <img src="https://avatars.githubusercontent.com/u/83650252?v=4" width="16"/><a href="https://github.com/SlamBamActionman"> SlamBamActionman</a> at 2024-03-11 15:42:49 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-11 23:05:25 UTC

---

PR changed 1 files with 18 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> Eating a Lizard Plushie as a moth now also makes you consume 10u _Juice that makes you Weh_.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> 10u was chosen for 2 reasons:
> 
> - Just finding and eating a plushie shouldn't be as rewarding as having to go through the additional process of juicing the plushie. 10u Wehjuice lasts for 40 seconds, while 30u Wehjuice lasts for 2 minutes. See it as juicing the plushie gives a higher, purer yield.
> - Each bite removes 5u of the food's reagents. Having 10u fiber, 30u Wehjuice would take a whole 8 bites to get through. 10 fiber, 10u Wehjuice takes 4 bites, which is more manageable. 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> Just edits the SolutionContainer for those plushies. Plushies can't be drawn/injected with a syringe.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - tweak: Moths eating lizard plushies will now start to Weh!
> 


</details>