### PR TITLE
Mirror: Space damage now causes heat along with blunt

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -240,7 +240,8 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.55 #per second, scales with pressure and other constants.
+        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Heat: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -38,7 +38,8 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.60 #per second, scales with pressure and other constants. Slighty more than humans.
+        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Heat: 0.2 # 0.1 more than humans, i feel like low pressure would make slime boil more than blunt stretch them so i decided on this instead.
   - type: Reactive
     groups:
       Flammable: [ Touch ]


### PR DESCRIPTION
## Mirror of  PR #25770: [Space damage now causes heat along with blunt](https://github.com/space-wizards/space-station-14/pull/25770) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `c2d52e45404f09b95f87dbb8e12d2a0c7217a023`

PR opened by <img src="https://avatars.githubusercontent.com/u/134914314?v=4" width="16"/><a href="https://github.com/UbaserB"> UbaserB</a> at 2024-03-02 07:11:43 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-12 02:38:40 UTC

---

PR changed 2 files with 4 additions and 2 deletions.

The PR had the following labels:
- Needs Discussion
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> <!-- What did you change in this PR? -->
> 
> Space burns your skin from the ionizing radiation and intense light. Also, your blood boils. Radiation would be too difficult to implement and generally not a good idea, so i decided to just do burn. The reason why it's under barotrauma instead of general space damage is because even if you're not in space your blood still boils from lack of pressure (aka barotrauma)
> 
> Makes space a tiny teensy little bit more dangerous by 0.5 damage increase per second along with making treatment more complex considering there is another added damage type.
> 
> ![image](https://github.com/space-wizards/space-station-14/assets/134914314/3a8b25c7-306c-4157-9da0-2ed334fbc3bb)
> 
> **Changelog**
> 
> :cl: Ubaser
> - tweak: Unpressurized areas now deal heat damage along with blunt.


</details>