### PR TITLE
Mirror: Enable multiple Solution Editor windows

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private readonly StationSystem _stations = default!;
         [Dependency] private readonly StationSpawningSystem _spawning = default!;
 
-        private readonly Dictionary<ICommonSession, EditSolutionsEui> _openSolutionUis = new();
+        private readonly Dictionary<ICommonSession, List<EditSolutionsEui>> _openSolutionUis = new();
 
         public override void Initialize()
         {
@@ -486,10 +486,13 @@ namespace Content.Server.Administration.Systems
         #region SolutionsEui
         private void OnSolutionChanged(Entity<SolutionContainerManagerComponent> entity, ref SolutionContainerChangedEvent args)
         {
-            foreach (var eui in _openSolutionUis.Values)
+            foreach (var list in _openSolutionUis.Values)
             {
-                if (eui.Target == entity.Owner)
-                    eui.StateDirty();
+                foreach (var eui in list)
+                {
+                    if (eui.Target == entity.Owner)
+                        eui.StateDirty();
+                }
             }
         }
 
@@ -498,21 +501,33 @@ namespace Content.Server.Administration.Systems
             if (session.AttachedEntity == null)
                 return;
 
-            if (_openSolutionUis.ContainsKey(session))
-                _openSolutionUis[session].Close();
-
-            var eui = _openSolutionUis[session] = new EditSolutionsEui(uid);
+            var eui = new EditSolutionsEui(uid);
             _euiManager.OpenEui(eui, session);
             eui.StateDirty();
+
+            if (!_openSolutionUis.ContainsKey(session)) {
+                _openSolutionUis[session] = new List<EditSolutionsEui>();
+            }
+
+            _openSolutionUis[session].Add(eui);
         }
 
-        public void OnEditSolutionsEuiClosed(ICommonSession session)
+        public void OnEditSolutionsEuiClosed(ICommonSession session, EditSolutionsEui eui)
         {
-            _openSolutionUis.Remove(session, out var eui);
+            _openSolutionUis[session].Remove(eui);
+            if (_openSolutionUis[session].Count == 0)
+              _openSolutionUis.Remove(session);
         }
 
         private void Reset(RoundRestartCleanupEvent ev)
         {
+            foreach (var euis in _openSolutionUis.Values)
+            {
+                foreach (var eui in euis.ToList())
+                {
+                    eui.Close();
+                }
+            }
             _openSolutionUis.Clear();
         }
         #endregion

--- a/Content.Server/Administration/UI/EditSolutionsEui.cs
+++ b/Content.Server/Administration/UI/EditSolutionsEui.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Administration.UI
         public override void Closed()
         {
             base.Closed();
-            _entityManager.System<AdminVerbSystem>().OnEditSolutionsEuiClosed(Player);
+            _entityManager.System<AdminVerbSystem>().OnEditSolutionsEuiClosed(Player, this);
         }
 
         public override EuiStateBase GetNewState()


### PR DESCRIPTION
## Mirror of  PR #26005: [Enable multiple Solution Editor windows](https://github.com/space-wizards/space-station-14/pull/26005) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `0da09db99ac556e0efdce40268e60eb5a06a0694`

PR opened by <img src="https://avatars.githubusercontent.com/u/83650252?v=4" width="16"/><a href="https://github.com/SlamBamActionman"> SlamBamActionman</a> at 2024-03-11 17:16:10 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-12 12:10:10 UTC

---

PR changed 2 files with 26 additions and 11 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> Makes it so that you can have multiple debug Solution Editor/Add Reagent windows open at once.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> Admin request. Useful if you want to multitask editing multiple solution containers and their contents.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> Previously the open Solution Editor window was being tracked by a Dictionary which mapped the window entity to a session ID. That Dictionary instead uses a list of window entities mapped to the session ID, allowing for multiple windows.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> ![image](https://github.com/space-wizards/space-station-14/assets/83650252/d93b722f-d2a5-4523-8b39-fcdc0edc7175)
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> no cl no fun


</details>