### PR TITLE
Mirror: Buff Zombie Infection

### DIFF
--- a/Content.Server/Zombies/PendingZombieComponent.cs
+++ b/Content.Server/Zombies/PendingZombieComponent.cs
@@ -16,8 +16,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Blunt", 0.25 },
-            { "Poison", 0.1 },
+            { "Poison", 0.3 },
         }
     };
 

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -20,14 +20,14 @@ public sealed partial class ZombieComponent : Component, IAntagStatusIconCompone
     /// The baseline infection chance you have if you are completely nude
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MaxZombieInfectionChance = 0.50f;
+    public float MaxZombieInfectionChance = 0.80f;
 
     /// <summary>
     /// The minimum infection chance possible. This is simply to prevent
     /// being invincible by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.20f;
+    public float MinZombieInfectionChance = 0.50f;
 
     [ViewVariables(VVAccess.ReadWrite)]
     public float ZombieMovementSpeedDebuff = 0.70f;


### PR DESCRIPTION
## Mirror of  PR #25954: [Buff Zombie Infection](https://github.com/space-wizards/space-station-14/pull/25954) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `56ac86a5c19182b2216e73787b47525ffe0b1cba`

PR opened by <img src="https://avatars.githubusercontent.com/u/104418166?v=4" width="16"/><a href="https://github.com/liltenhead"> liltenhead</a> at 2024-03-10 01:40:46 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-12 18:44:09 UTC

---

PR changed 2 files with 3 additions and 4 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> This PR changes the damage numbers of the zombie infection. It also increases the chances of getting infected per bite, with and without clothing.
> 
> ## Why / Balance
> Most zombies are created through people getting bit to death, or infecting already dead bodies. Wearing full clothing makes it very unlikely you'll actually get infected before you fall into a critical condition. The zombie infection doing blunt damage means you constantly bleed, making it very obvious you are infected, and makes it very easy to self treat and avoid turning as long as you have Band-Aids. Pure poison damage is much harder to self treat, and overall somewhat slows down the zombie virus from taking hold if you are receiving proper medical care.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> 
> 
> :cl:
> - tweak: Buffed the zombie virus to do purely poison damage, and more likely to spread the infection per bite. 
> 
> 
> 


</details>