### PR TITLE
Mirror: Remove recycling for Syndicate implanters

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -119,6 +119,8 @@
           implantOnly:
             True: {state: broken}
             False: {state: implanter1}
+    - type: Tag
+      tags: []
 
 #Fun implanters
 


### PR DESCRIPTION
## Mirror of  PR #26047: [Remove recycling for Syndicate implanters](https://github.com/space-wizards/space-station-14/pull/26047) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `a8e1489ddb56450cb3a689b95c4c1b407fe3c136`

PR opened by <img src="https://avatars.githubusercontent.com/u/83650252?v=4" width="16"/><a href="https://github.com/SlamBamActionman"> SlamBamActionman</a> at 2024-03-12 17:58:45 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-13 02:02:36 UTC

---

PR changed 1 files with 2 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> This PR removes the Trash tag for Syndicate implanters, stopping them from being recycled. This means they can no longer be destroyed with the station's Recycler/Material Reclaimer. Non-Syndicate implanters can still be recycled as normal.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> Being able to recycle implanters completely trivializes the disposal of evidence; if a Material Reclaimer is mapped on the station, it's literally a single button click to fully remove any signs of a contraband having been used, and a Recycler isn't much harder to get going. 
> 
> We already have other systems in the game to hide and alter evidence, such as soap (cleans fingerprints/DNA), stashing in plants, using a storage implant, throwing out of an airlock or just hiding it in a remote place in maintenance. All those methods have some sort of downside or counterplay the antag needs to consider and work around. However, since the recycling is simple, non-suspicious, easily accessible and leaves no trace there is no point in engaging with those other systems as the recycling is always the optimal choice.
> 
> This change is only limited to Syndicate implanters. Non-Syndicate implanters (e.g. bike horn) can be acquired in much larger qualities and thus serve a need to be properly disposed of, in additional to being visually distinct. 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> The base implanter prototype has only the Trash tag, so for the base Syndicate implanter the .yaml just sets its tags to blank.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - tweak: Syndicate implanters can no longer be recycled.
> 


</details>