### PR TITLE
Mirror: Fix Sky Blue carpet making red tables

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
@@ -15,7 +15,7 @@
   - type: Stack
     stackType: FloorCarpetRed
   - type: Tag
-    tags: 
+    tags:
     - CarpetRed
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: Carpet
@@ -34,7 +34,7 @@
   - type: Stack
     stackType: FloorCarpetBlack
   - type: Tag
-    tags: 
+    tags:
     - CarpetBlack
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetBlack
@@ -53,7 +53,7 @@
   - type: Stack
     stackType: FloorCarpetBlue
   - type: Tag
-    tags: 
+    tags:
     - CarpetBlue
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetBlue
@@ -72,7 +72,7 @@
   - type: Stack
     stackType: FloorCarpetGreen
   - type: Tag
-    tags: 
+    tags:
     - CarpetGreen
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetGreen
@@ -91,7 +91,7 @@
   - type: Stack
     stackType: FloorCarpetOrange
   - type: Tag
-    tags: 
+    tags:
     - CarpetOrange
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetOrange
@@ -109,6 +109,9 @@
     heldPrefix: carpet-skyblue
   - type: Stack
     stackType: FloorCarpetSkyBlue
+  - type: Tag
+    tags:
+    - CarpetSBlue
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetSBlue
     doAfter: 0.5
@@ -126,7 +129,7 @@
   - type: Stack
     stackType: FloorCarpetPurple
   - type: Tag
-    tags: 
+    tags:
     - CarpetPurple
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetPurple
@@ -145,7 +148,7 @@
   - type: Stack
     stackType: FloorCarpetPink
   - type: Tag
-    tags: 
+    tags:
     - CarpetPink
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetPink
@@ -164,7 +167,7 @@
   - type: Stack
     stackType: FloorCarpetCyan
   - type: Tag
-    tags: 
+    tags:
     - CarpetCyan
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetCyan
@@ -183,7 +186,7 @@
   - type: Stack
     stackType: FloorCarpetWhite
   - type: Tag
-    tags: 
+    tags:
     - CarpetWhite
   - type: SpawnAfterInteract #Nuke after convert to FloorTile
     prototype: CarpetWhite

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -272,6 +272,9 @@
   id: CarpetPurple
 
 - type: Tag
+  id: CarpetSBlue
+
+- type: Tag
   id: CarpetPink
 
 - type: Tag


### PR DESCRIPTION
## Mirror of  PR #26049: [Fix Sky Blue carpet making red tables](https://github.com/space-wizards/space-station-14/pull/26049) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `559d7ac59379c4c01faafaec3213380d8ae0be9f`

PR opened by <img src="https://avatars.githubusercontent.com/u/62253058?v=4" width="16"/><a href="https://github.com/Gyrandola"> Gyrandola</a> at 2024-03-12 18:19:09 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-13 02:03:04 UTC

---

PR changed 2 files with 15 additions and 9 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Adding Sky Blue carpets to tables no longer results in red carpet ones.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Fixes #26040 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> CarpetSBlue tag was missing.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ![Screenshot 2024-03-12 190805](https://github.com/space-wizards/space-station-14/assets/62253058/69f3bc37-4ba6-4cac-bd9f-9adaecefdf15)
> 
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - fix: Adding Sky Blue carpets to tables no longer results in red carpet ones.
> 


</details>