### PR TITLE
Mirror: Add fancy table spawner

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/fancytables.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/fancytables.yml
@@ -1,0 +1,22 @@
+- type: entity
+  name: random fancy table spawner
+  id: FancyTableSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Furniture/Tables/Fancy/blue.rsi
+          state: full
+    - type: RandomSpawner
+      prototypes:
+        - TableFancyBlue
+        - TableFancyCyan
+        - TableFancyBlack
+        - TableFancyRed
+        - TableFancyPurple
+        - TableFancyPink
+        - TableFancyGreen
+        - TableFancyOrange
+        - TableFancyWhite
+      offset: 0.0


### PR DESCRIPTION
## Mirror of  PR #26044: [Add fancy table spawner](https://github.com/space-wizards/space-station-14/pull/26044) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f5f5eebeeeee005a955ebd2814b4b9d6204e72ef`

PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-12 16:09:24 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-13 06:21:51 UTC

---

PR changed 1 files with 22 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Adds fancy table spawner for mapping random fancy tables
> 
> ## Why / Balance
> Nice
> 
> ## Technical details
> n/a
> 
> ## Media
> n/a
> - [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase
> 
> ## Breaking changes
> n/a
> 
> **Changelog**
> n/a
> 


</details>