### PR TITLE
Mirror: Syringe doafter based on Syringe contents

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -128,9 +128,21 @@ public sealed class InjectorSystem : SharedInjectorSystem
             return;
 
         var actualDelay = MathHelper.Max(injector.Comp.Delay, TimeSpan.FromSeconds(1));
+        float amountToInject;
+        if (injector.Comp.ToggleState == InjectorToggleMode.Draw)
+        {
+            // additional delay is based on actual volume left to draw in syringe when smaller than transfer amount
+            amountToInject = Math.Min(injector.Comp.TransferAmount.Float(), (solution.MaxVolume - solution.Volume).Float());
+        }
+        else
+        {
+            // additional delay is based on actual volume left to inject in syringe when smaller than transfer amount
+            amountToInject = Math.Min(injector.Comp.TransferAmount.Float(), solution.Volume.Float());
+        }
 
-        // Injections take 0.5 seconds longer per additional 5u
-        actualDelay += TimeSpan.FromSeconds(injector.Comp.TransferAmount.Float() / injector.Comp.Delay.TotalSeconds - 0.5f);
+        // Injections take 0.5 seconds longer per 5u of possible space/content
+        actualDelay += TimeSpan.FromSeconds(amountToInject / 10);
+
 
         var isTarget = user != target;
 


### PR DESCRIPTION
## Mirror of  PR #25890: [Syringe doafter based on Syringe contents](https://github.com/space-wizards/space-station-14/pull/25890) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `37cd12524e85b6a3b31827e4751a94ca51268694`

PR opened by <img src="https://avatars.githubusercontent.com/u/58439124?v=4" width="16"/><a href="https://github.com/Plykiya"> Plykiya</a> at 2024-03-06 21:57:17 UTC
PR merged by <img src="https://avatars.githubusercontent.com/u/19864447?v=4" width="16"/><a href="https://github.com/web-flow"> web-flow</a> at 2024-03-13 09:35:48 UTC

---

PR changed 1 files with 14 additions and 2 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Altered the **additional doafter time penalty** to be based on what's actually in the syringe rather than what you have the TransferAmount set to for both drawing and injecting.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> It just makes sense.. honestly though, if I could change the total do-after time to something less than five seconds I would, but I know that for balance reasons it's probably not good to be able to inject someone in like one second with 1u of content. That would be infringing on the territory of hypospray speed for self-injections...
> 
> I think the equation for calculating the additional do-after was wrong or I'm just really bad at math. I fixed it based on what the comment intended.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Altered do-after equation to be based on empty space when drawing and current content amount when injecting.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - tweak: Additional syringe doafter delay is now based on syringe contents rather than transfer amount setting.


</details>