### PR TITLE
Mirror: Cycle injector transfer amount on alt. use

### DIFF
--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -53,8 +53,7 @@ public sealed partial class InjectorComponent : Component
     ///     The maximum amount of solution that can be transferred at once from this solution.
     /// </summary>
     [DataField("maxTransferAmount")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 MaximumTransferAmount = FixedPoint2.New(50);
+    public FixedPoint2 MaximumTransferAmount = FixedPoint2.New(15);
 
     /// <summary>
     /// Amount to inject or draw on each usage. If the injector is inject only, it will

--- a/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
@@ -39,12 +39,34 @@ public abstract class SharedInjectorSystem : EntitySystem
 
         if (!HasComp<ActorComponent>(args.User))
             return;
+        var user = args.User;
 
         var (_, component) = entity;
 
-        // Add specific transfer verbs according to the container's size
+        var min = component.MinimumTransferAmount;
+        var max = component.MaximumTransferAmount;
+        var cur = component.TransferAmount;
+        var toggleAmount = cur == max ? min : max;
+
         var priority = 0;
-        var user = args.User;
+        AlternativeVerb toggleVerb = new()
+        {
+            Text = Loc.GetString("comp-solution-transfer-verb-toggle", ("amount", toggleAmount)),
+            Category = VerbCategory.SetTransferAmount,
+            Act = () =>
+            {
+                component.TransferAmount = toggleAmount;
+                Popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", toggleAmount)), user, user);
+                Dirty(entity);
+            },
+
+            Priority = priority
+        };
+        args.Verbs.Add(toggleVerb);
+
+        priority -= 1;
+
+        // Add specific transfer verbs according to the container's size
         foreach (var amount in TransferAmounts)
         {
             if (amount < component.MinimumTransferAmount || amount > component.MaximumTransferAmount)

--- a/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/solution-transfer-component.ftl
@@ -11,6 +11,7 @@ comp-solution-transfer-is-full = {THE($target)} is full!
 ## Displayed in change transfer amount verb's name
 comp-solution-transfer-verb-custom-amount = Custom
 comp-solution-transfer-verb-amount = {$amount}u
+comp-solution-transfer-verb-toggle = Toggle to {$amount}u
 
 ## Displayed after you successfully change a solution's amount using the BUI
 comp-solution-transfer-set-amount = Transfer amount set to {$amount}u.


### PR DESCRIPTION
## Mirror of  PR #25566: [Cycle injector transfer amount on alt. use](https://github.com/space-wizards/space-station-14/pull/25566) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `ad6ac73f6f41d1cbd3fe80a43c8bf4b83e03f392`

PR opened by <img src="https://avatars.githubusercontent.com/u/68151557?v=4" width="16"/><a href="https://github.com/veprolet"> veprolet</a> at 2024-02-25 19:37:49 UTC

---

PR changed 3 files with 26 additions and 3 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> When the user tries to use alternative interaction on an injector capable of changing transfer volume, this will cycle between the maximal and minimal transfer amount (defaulting to maximum if the value was in-between the extremes).
> 
> The interaction is only available with in-hand usage or empty-handed usage. This is deliberate (but not necessarily correct).
> The interaction is only implemented for injectors and not arbitrary containers capable of solution transfers. This is to limit the scope of this PR.
> 
> ## Why / Balance
> Changing the transfer amount was only possible using the context menu. This was difficult and slow, but this tedium didn't seem to be a valuable part of the gameplay experience.
> 
> Instead of cycling over all the possible transfer amounts, the choice has been made to only cycle between the two extremes. This is for two reasons:
>  - Scalability: If this is merged, we'll probably want the same behavior for the other solution containers like jugs. It would be very tedious (probably more tedious than using the context menu) to cycle to the correct transfer amount with more available transfer amount steps. It would also be IMO unintuitive to have a different behavior between the two types of solution containers.
>  - Simplicity: It is easier to reason about the next state this way. Otherwise, one would have to figure out how many times to perform the interaction to cycle to the desired amount, which involves knowing the total number of steps for each injector/container, order of the current step and modular arithmetic (or just cycling until you are at the correct one, which is slow, error-prone and frustrating whenever you overshoot).
> 
> This decision has obviously some tradeoffs, but I feel like those are manageable. If you need to transfer the in-between amounts, you can usually switch to the minimal amount (I assume the property of in-between amounts being a multiple of the minimum will be upheld in the future) and click a few times. This is generally as tedious or less tedious than cycling the amounts. There are some instances where you can't do that. One example would be manual mixing of the advanced brute medications. This is a niche use-case and can be still solved using the context menu verb system and is supposed to be a bit more difficult anyway.
> 
> This also makes the alternative interaction a bit less predictable, as it no longer always uses the first context menu verb. I think the interaction is similar enough and inconsequential enough to justify this.
> 
> It makes the syringe marginally more powerful, but as this doesn't introduce any previously unavailable actions, I believe this to be perfectly acceptable and heavily outweighed by the convenience.
> 
> ## Technical details
> ~~This introduces a new concept of "special alternative" interactions. Those interactions have their own events and handlers.~~
> 
> Please scrutinize the code hard ~~, because it touches some quite fundamental parts of the game, and~~ I'm not too knowledgeable about C# or the conventions of this repo. I tried to follow guidelines where possible while not impacting the existing code too much, but maybe this leads to too much weirdness in some places.
> 
> ## Media
> ![optimized](https://github.com/space-wizards/space-station-14/assets/68151557/c445b535-e4c6-49ff-b712-d540dd7fe57b)
> 
> - [X] I acknowledge that I have no idea how to showcase or record this feature well, **or** I'm trying my best.
> 
> ## Breaking changes
> N/A
> 
> **Changelog**
> :cl:
> - tweak: Injectors like the syringe can now toggle their transfer amount using alternative interactions.
> 


</details>