### PR TITLE
Mirror: zombie wideswing and misc fix

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -141,7 +141,10 @@ namespace Content.Server.Zombies
             var melee = EnsureComp<MeleeWeaponComponent>(target);
             melee.Animation = zombiecomp.AttackAnimation;
             melee.WideAnimation = zombiecomp.AttackAnimation;
+            melee.AltDisarm = false;
             melee.Range = 1.2f;
+            melee.Angle = 0.0f;
+            melee.HitSound = zombiecomp.BiteSound;
 
             if (mobState.CurrentState == MobState.Alive)
             {

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// Does this entity do a disarm on alt attack.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public bool AltDisarm = true;
 
     /// <summary>

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -141,6 +141,12 @@ public sealed partial class ZombieComponent : Component, IAntagStatusIconCompone
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/zombie_start.ogg");
 
     /// <summary>
+    ///     Hit sound on zombie bite.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier BiteSound = new SoundPathSpecifier("/Audio/Effects/bite.ogg");
+
+    /// <summary>
     /// The blood reagent of the humanoid to restore in case of cloning
     /// </summary>
     [DataField("beforeZombifiedBloodReagent")]


### PR DESCRIPTION
## Mirror of  PR #26064: [zombie wideswing and misc fix](https://github.com/space-wizards/space-station-14/pull/26064) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `3981173a1546dd1d4a21b1c85451ea7eaf69c6f8`

PR opened by <img src="https://avatars.githubusercontent.com/u/45323883?v=4" width="16"/><a href="https://github.com/Dutch-VanDerLinde"> Dutch-VanDerLinde</a> at 2024-03-13 00:13:44 UTC

---

PR changed 3 files with 10 additions and 1 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> zombies wideswing, also makes the bite sound into the carp biting sound on zombified (human zombies will bite you, but it sounds like punching?)
> 
> ## Why / Balance
> hard to hit moving target as a zombie
> 
> ## Technical details
> made AltDisarm an AutoNetworkedField in MeleeWeaponComponent
> 
> ## Media
> 
> https://github.com/space-wizards/space-station-14/assets/45323883/8e1a2d17-a0a0-4320-92f2-d40efe88c7b7
> 
> 
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> 
> :cl:
> - tweak: Zombies can now wideswing, similar to how a space carp would.


</details>