### PR TITLE
Mirror: Fix Butcherable handling, ItemSlots for clown shoes

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Kitchen.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition.Components;
+using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Content.Shared.Verbs;
@@ -31,7 +32,7 @@ public sealed class SharpSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SharpComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<SharpComponent, AfterInteractEvent>(OnAfterInteract, before: new[] { typeof(UtensilSystem) });
         SubscribeLocalEvent<SharpComponent, SharpDoAfterEvent>(OnDoAfter);
 
         SubscribeLocalEvent<ButcherableComponent, GetVerbsEvent<InteractionVerb>>(OnGetInteractionVerbs);
@@ -39,31 +40,34 @@ public sealed class SharpSystem : EntitySystem
 
     private void OnAfterInteract(EntityUid uid, SharpComponent component, AfterInteractEvent args)
     {
+        if (args.Handled)
+            return;
+
         if (args.Target is null || !args.CanReach)
             return;
 
-        TryStartButcherDoafter(uid, args.Target.Value, args.User);
+        args.Handled = TryStartButcherDoAfter(uid, args.Target.Value, args.User);
     }
 
-    private void TryStartButcherDoafter(EntityUid knife, EntityUid target, EntityUid user)
+    private bool TryStartButcherDoAfter(EntityUid knife, EntityUid target, EntityUid user)
     {
         if (!TryComp<ButcherableComponent>(target, out var butcher))
-            return;
+            return false;
 
         if (!TryComp<SharpComponent>(knife, out var sharp))
-            return;
+            return false;
+
+        if (TryComp<MobStateComponent>(target, out var mobState) && !_mobStateSystem.IsDead(target, mobState))
+            return false;
 
         if (butcher.Type != ButcheringType.Knife)
         {
             _popupSystem.PopupEntity(Loc.GetString("butcherable-different-tool", ("target", target)), knife, user);
-            return;
+            return true;
         }
 
-        if (TryComp<MobStateComponent>(target, out var mobState) && !_mobStateSystem.IsDead(target, mobState))
-            return;
-
         if (!sharp.Butchering.Add(target))
-            return;
+            return true;
 
         var doAfter =
             new DoAfterArgs(EntityManager, user, sharp.ButcherDelayModifier * butcher.ButcherDelay, new SharpDoAfterEvent(), knife, target: target, used: knife)
@@ -75,6 +79,7 @@ public sealed class SharpSystem : EntitySystem
             };
 
         _doAfterSystem.TryStartDoAfter(doAfter);
+        return true;
     }
 
     private void OnDoAfter(EntityUid uid, SharpComponent component, DoAfterEvent args)
@@ -154,7 +159,7 @@ public sealed class SharpSystem : EntitySystem
             Act = () =>
             {
                 if (!disabled)
-                    TryStartButcherDoafter(args.Using!.Value, args.Target, args.User);
+                    TryStartButcherDoAfter(args.Using!.Value, args.Target, args.User);
             },
             Message = message,
             Disabled = disabled,

--- a/Content.Server/Nutrition/EntitySystems/UtensilSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/UtensilSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Containers.ItemSlots;
 using Content.Server.Nutrition.Components;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
@@ -25,7 +26,7 @@ namespace Content.Server.Nutrition.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<UtensilComponent, AfterInteractEvent>(OnAfterInteract);
+            SubscribeLocalEvent<UtensilComponent, AfterInteractEvent>(OnAfterInteract, after: new[] { typeof(ItemSlotsSystem) });
         }
 
         /// <summary>
@@ -33,6 +34,9 @@ namespace Content.Server.Nutrition.EntitySystems
         /// </summary>
         private void OnAfterInteract(EntityUid uid, UtensilComponent component, AfterInteractEvent ev)
         {
+            if (ev.Handled)
+                return;
+
             if (ev.Target == null || !ev.CanReach)
                 return;
 

--- a/Resources/Locale/en-US/clothing/boots.ftl
+++ b/Resources/Locale/en-US/clothing/boots.ftl
@@ -1,1 +1,1 @@
-clothing-military-boots-sidearm = Sidearm
+clothing-boots-sidearm = Sidearm

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -45,7 +45,7 @@
   - type: ItemSlots
     slots:
       item:
-        name: clothing-military-boots-sidearm
+        name: clothing-boots-sidearm
         whitelist:
           tags:
           - Knife

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -9,8 +9,26 @@
   - type: Clothing
     sprite: Clothing/Shoes/Specific/chef.rsi
 
+# stuff common to all clown & jester shoes
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  abstract: true
+  parent: [ClothingShoesBaseButcherable, ClothingSlotBase]
+  id: ClothingShoesClownBase
+  components:
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-boots-sidearm
+        whitelist:
+          tags:
+          - Knife
+          - ToySidearm
+        blacklist:
+          components:
+          - Sharp
+
+- type: entity
+  parent: ClothingShoesClownBase
   id: ClothingShoesClown
   name: clown shoes
   description: "The prankster's standard-issue clowning shoes. Damn they're huge!"
@@ -49,7 +67,7 @@
     acceleration: 5
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesClownBase
   id: ClothingShoesBling
   name: bling clown shoes
   description: Made of refined bananium and shined with the pulp of a fresh banana peel. These make a flashy statement.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -400,6 +400,9 @@
           Quantity: 3
         - ReagentId: Fat
           Quantity: 3
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatCutlet
 
 - type: entity
   name: raw lizard meat

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -882,6 +882,7 @@
   - type: Tag
     tags:
     - Sidearm
+    - ToySidearm
   - type: Gun
     selectedMode: SemiAuto
     availableModes:
@@ -914,14 +915,14 @@
   suffix: Fake
   description: Looks almost like the real thing! Ages 8 and up.
   components:
-    - type: RevolverAmmoProvider
-      whitelist:
-        tags:
-          - CartridgeCap
-          - SpeedLoaderCap
-          - CartridgeMagnum
-          - SpeedLoaderMagnum
-      proto: CartridgeMagnumAP
+  - type: RevolverAmmoProvider
+    whitelist:
+      tags:
+        - CartridgeCap
+        - SpeedLoaderCap
+        - CartridgeMagnum
+        - SpeedLoaderMagnum
+    proto: CartridgeMagnumAP
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -7,9 +7,6 @@
     sprite: Objects/Misc/utensils.rsi
   - type: Item # TODO add inhand sprites for all utensils
     sprite: Objects/Misc/utensils.rsi
-  - type: Tag
-    tags:
-    - Metal
   - type: SpaceGarbage
 
 - type: entity
@@ -23,8 +20,14 @@
     price: 0
   - type: Tag
     tags:
-     - Plastic
-     - Trash
+    - Plastic
+    - Trash
+  - type: MeleeWeapon
+    wideAnimationRotation: 180
+    attackRate: 1.5
+    damage:
+      types:
+        Blunt: 0
 
 - type: entity
   parent: UtensilBase
@@ -66,6 +69,9 @@
   name: spoon
   description: There is no spoon.
   components:
+  - type: Tag
+    tags:
+    - Metal
   - type: Sprite
     state: spoon
   - type: Item
@@ -99,7 +105,7 @@
     speedModifier: 0.1 # you can try
 
 - type: entity
-  parent: UtensilBase
+  parent: UtensilBasePlastic
   id: KnifePlastic
   name: plastic knife
   description: That's not a knife. This is a knife.
@@ -108,4 +114,9 @@
     state: plastic_knife
   - type: Utensil
     types:
+    - Knife
+  - type: Tag
+    tags:
+    - Plastic
+    - Trash
     - Knife

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1179,6 +1179,9 @@
   id: Torch
 
 - type: Tag
+  id: ToySidearm
+
+- type: Tag
   id: Trash
 
 - type: Tag


### PR DESCRIPTION
## Mirror of  PR #25661: [Fix Butcherable handling, ItemSlots for clown shoes](https://github.com/space-wizards/space-station-14/pull/25661) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `674b42b3a0ab9fa607887c1401f38ca1f8bb3911`

PR opened by <img src="https://avatars.githubusercontent.com/u/42424291?v=4" width="16"/><a href="https://github.com/Krunklehorn"> Krunklehorn</a> at 2024-02-28 02:04:52 UTC

---

PR changed 9 files with 75 additions and 30 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> 
> - Fixes improper popups with edible+butcherable items, and sharp+utensil items
> - Clown shoes have item slots
>   - Intended for non-harmful items other than their job specific gun
>   - Currently supports plastic knives, cap gun & fake cap gun
> 
> Minor stuff...
> - Spoons are metal
> - Plastic knives are actually plastic knives
> - Plastic utensils are now zero damage weapons
> - Raw rat meat is sliceable
> 
> 
> ## Why / Balance
> 
> Funny suggestion, but also a legitimate way for a Clown to sneak their job specific gun into a holding cell/perma.
> 
> 
> ## Media
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> 
> **Changelog**
> 
> :cl: Krunk
> - add: Clown & Jester shoes can now hold plastic knives and cap guns! All clowning, all the time!
> 


</details>