### PR TITLE
Mirror: Contraband Storage Crate

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -285,6 +285,18 @@
 
 - type: entity
   parent: CrateBaseSecure
+  suffix: Armory, Secure
+  id: CrateContrabandStorageSecure
+  name: contraband storage crate
+  description: An armory access locked crate for storing contraband confiscated from suspects or prisoners.
+  components:
+  - type: Sprite
+    sprite: Structures/Storage/Crates/sec_gear.rsi
+  - type: AccessReader
+    access: [["Armory"]]
+
+- type: entity
+  parent: CrateBaseSecure
   id: CrateCommandSecure
   name: command crate
   components:


### PR DESCRIPTION
## Mirror of  PR #25974: [Contraband Storage Crate](https://github.com/space-wizards/space-station-14/pull/25974) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `49c819373919d6ad2c7e1d802025782ecdce370b`

PR opened by <img src="https://avatars.githubusercontent.com/u/91865152?v=4" width="16"/><a href="https://github.com/PursuitInAshes"> PursuitInAshes</a> at 2024-03-10 18:12:13 UTC

---

PR changed 1 files with 12 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Adds a Contraband Storage Crate for the armory. This can be used by mappers to provide better and more suitable storage then an empty rack.
> 
> ## Why / Balance
> Dumping items that were confiscated from the syndicate on the ground or in exposed racks felt wrong and unfitting for more stations. This provides an armory locked crate to fill that purpose.
> 
> ## Media
> ![Content Client_JYZIEQmEgm](https://github.com/space-wizards/space-station-14/assets/91865152/e458cda6-791c-4145-92c3-ae052482813a)
> 
> **Changelog**
> 
> No CL, not really player facing.
> 


</details>