### PR TITLE
Mirror: Fix vox custom sprites

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -14,6 +14,8 @@
   - type:  HumanoidAppearance
     species: Vox
     #- type: VoxAccent # Not yet coded
+  - type: Inventory
+    speciesId: vox
   - type: Speech
     speechVerb: Vox
     speechSounds: Vox


### PR DESCRIPTION
## Mirror of  PR #25989: [Fix vox custom sprites](https://github.com/space-wizards/space-station-14/pull/25989) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `8a77722f91a94846f0027f56b8d8f2ec76254d81`

PR opened by <img src="https://avatars.githubusercontent.com/u/35878406?v=4" width="16"/><a href="https://github.com/Errant-4"> Errant-4</a> at 2024-03-11 09:29:16 UTC

---

PR changed 1 files with 2 additions and 0 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Clothing with custom sprites for vox have been displaying the default sprites due to a component accident.
> 
> ## Media
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> :cl: Errant
> - fix: Clothes with alternate sprites for vox once again show the alternate sprites, instead of the defaults.
> 


</details>