### PR TITLE
Mirror: Make fireaxe & shotgun cabinets destructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -3,9 +3,27 @@
   name: fire axe cabinet
   description: There is a small label that reads "For Emergency use only" along with details for safe use of the axe. As if.
   components:
-  - type: Damageable # adding destructible causes the entity inside to be deleted when the cabinet is destroyed :(
+  - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 200 #20ish crowbar hits
+        behaviors:
+        - !type:EmptyAllContainersBehaviour
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalGlassBreak
   - type: MeleeSound
     soundGroups:
       Brute:


### PR DESCRIPTION
## Mirror of  PR #25962: [Make fireaxe & shotgun cabinets destructible](https://github.com/space-wizards/space-station-14/pull/25962) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `6574681bcb88e9c524b998c525d1980e88884e96`

PR opened by <img src="https://avatars.githubusercontent.com/u/62253058?v=4" width="16"/><a href="https://github.com/Gyrandola"> Gyrandola</a> at 2024-03-10 12:10:09 UTC

---

PR changed 1 files with 19 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Makes fireaxe and shotgun cabinets destructible.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Fixes #25525. 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Simply added the component to the fireaxe cabinet base entity.
> Glass breaking sounds regardless of state.
> Damage thresholds:
> min: 200
> max: 300 (The axe will be destroyed as well).
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ![Screenshot 2024-03-10 123916](https://github.com/space-wizards/space-station-14/assets/62253058/2ef7f962-8bac-4f6d-b97e-99efc3205b86)
> 
> ![Screenshot 2024-03-10 124912](https://github.com/space-wizards/space-station-14/assets/62253058/984b8d3d-d073-4fe8-a66f-b7db18b23725)
> 
> 
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - add: Fireaxe and Shotgun cabinets can now be destroyed.
> 
> 


</details>