### PR TITLE
Mirror: Typo in guidebook for cyro pressure

### DIFF
--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -41,7 +41,7 @@ Once things have been set up, you're going to require a specific medication, Cry
 
 ## Additional Information:
 
-The standard pressure for a gas pump is 1.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
+The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>


### PR DESCRIPTION
## Mirror of  PR #26094: [Typo in guidebook for cyro pressure](https://github.com/space-wizards/space-station-14/pull/26094) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `0cba172130488766cdde8334308a5627ab3e5fc2`

PR opened by <img src="https://avatars.githubusercontent.com/u/47093363?v=4" width="16"/><a href="https://github.com/Titian3"> Titian3</a> at 2024-03-13 23:35:30 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Super small typo in Cryogenics guidebook, feel bad its such small PR let me know if there is a better way.
> 
> ## Why / Balance
> It's currently wrong value, got someone killed in game as player followed wrong instructions.
> 
> ## Technical details
> Guidebook update.
> 
> ## Media
> NA
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> NA
> 
> **Changelog**
> NA
> 


</details>