### PR TITLE
Mirror: Drink from closed container fix

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -311,6 +311,9 @@ public sealed class DrinkSystem : EntitySystem
         if (args.Used is null || !_solutionContainer.TryGetSolution(args.Used.Value, args.Solution, out var soln, out var solution))
             return;
 
+        if (_openable.IsClosed(args.Used.Value, args.Target.Value))
+            return;
+
         // TODO this should really be checked every tick.
         if (_food.IsMouthBlocked(args.Target.Value))
             return;


### PR DESCRIPTION
## Mirror of  PR #26103: [Drink from closed container fix](https://github.com/space-wizards/space-station-14/pull/26103) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `2f2cd4aab70703717541e5db3f46ae4831b4129d`

PR opened by <img src="https://avatars.githubusercontent.com/u/88361930?v=4" width="16"/><a href="https://github.com/maylokana"> maylokana</a> at 2024-03-14 03:59:47 UTC

---

PR changed 1 files with 3 additions and 0 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> All drink containers now check if the container is closed once the do-after is done, and will stop you from trying to drink from it if it is closed
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Bug fix. I think
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> In `DrinkSystem.cs`, added an `_openable.IsClosed()` method to `OnDoAfter()`, which returns if true
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> https://github.com/space-wizards/space-station-14/assets/88361930/cf983879-5073-407a-98fc-2004692a8d08
> 
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> N/A
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - fix: Entities can no longer drink from closed containers


</details>