### PR TITLE
Mirror: Sort agents by success rate in end game summary

### DIFF
--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
+using System.Text;
 
 namespace Content.Server.Objectives;
 
@@ -82,29 +83,32 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                 totalInCustody += minds.Where(m => IsInCustody(m)).Count();
             }
 
-            var result = Loc.GetString("objectives-round-end-result", ("count", total), ("agent", agent));
+            var result = new StringBuilder();
+            result.AppendLine(Loc.GetString("objectives-round-end-result", ("count", total), ("agent", agent)));
             if (agent == Loc.GetString("traitor-round-end-agent-name"))
             {
-                result += "\n" + Loc.GetString("objectives-round-end-result-in-custody", ("count", total), ("custody", totalInCustody), ("agent", agent));
+                result.AppendLine(Loc.GetString("objectives-round-end-result-in-custody", ("count", total), ("custody", totalInCustody), ("agent", agent)));
             }
             // next add all the players with its own prepended text
             foreach (var (prepend, minds) in summary)
             {
                 if (prepend != string.Empty)
-                    result += prepend;
+                    result.Append(prepend);
 
                 // add space between the start text and player list
-                result += "\n";
+                result.AppendLine();
 
-                AddSummary(ref result, agent, minds);
+                AddSummary(result, agent, minds);
             }
 
-            ev.AddLine(result + "\n");
+            ev.AddLine(result.AppendLine().ToString());
         }
     }
 
-    private void AddSummary(ref string result, string agent, List<EntityUid> minds)
+    private void AddSummary(StringBuilder result, string agent, List<EntityUid> minds)
     {
+        var agentSummaries = new List<(string summary, float successRate, int completedObjectives)>();
+
         foreach (var mindId in minds)
         {
             if (!TryComp(mindId, out MindComponent? mind))
@@ -114,25 +118,26 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             if (title == null)
                 continue;
 
-            result += "\n";
-
             var custody = IsInCustody(mindId, mind) ? Loc.GetString("objectives-in-custody") : string.Empty;
 
             var objectives = mind.Objectives;
             if (objectives.Count == 0)
             {
-                result += Loc.GetString("objectives-no-objectives", ("custody", custody), ("title", title), ("agent", agent));
+                agentSummaries.Add((Loc.GetString("objectives-no-objectives", ("custody", custody), ("title", title), ("agent", agent)), 0f, 0));
                 continue;
             }
 
-            result += Loc.GetString("objectives-with-objectives", ("custody", custody), ("title", title), ("agent", agent));
+            var completedObjectives = 0;
+            var totalObjectives = 0;
+            var agentSummary = new StringBuilder();
+            agentSummary.AppendLine(Loc.GetString("objectives-with-objectives", ("custody", custody), ("title", title), ("agent", agent)));
 
             foreach (var objectiveGroup in objectives.GroupBy(o => Comp<ObjectiveComponent>(o).Issuer))
             {
                 //TO DO:
                 //check for the right group here. Getting the target issuer is easy: objectiveGroup.Key
                 //It should be compared to the type of the group's issuer.
-                result += "\n" + Loc.GetString($"objective-issuer-{objectiveGroup.Key}");
+                agentSummary.AppendLine(Loc.GetString($"objective-issuer-{objectiveGroup.Key}"));
 
                 foreach (var objective in objectiveGroup)
                 {
@@ -142,26 +147,39 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
                     var objectiveTitle = info.Value.Title;
                     var progress = info.Value.Progress;
+                    totalObjectives++;
+
+                    agentSummary.Append("- ");
                     if (progress > 0.99f)
                     {
-                        result += "\n- " + Loc.GetString(
+                        agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-success",
                             ("objective", objectiveTitle),
                             ("markupColor", "green")
-                        );
+                        ));
+                        completedObjectives++;
                     }
                     else
                     {
-                        result += "\n- " + Loc.GetString(
+                        agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-fail",
                             ("objective", objectiveTitle),
                             ("progress", (int) (progress * 100)),
                             ("markupColor", "red")
-                        );
+                        ));
                     }
                 }
             }
+
+            var successRate = totalObjectives > 0 ? (float) completedObjectives / totalObjectives : 0f;
+            agentSummaries.Add((agentSummary.ToString(), successRate, completedObjectives));
         }
+
+        var sortedAgents = agentSummaries.OrderByDescending(x => x.successRate)
+                                       .ThenByDescending(x => x.completedObjectives);
+
+        foreach (var (summary, _, _) in sortedAgents)
+            result.AppendLine(summary);
     }
 
     public EntityUid? GetRandomObjective(EntityUid mindId, MindComponent mind, string objectiveGroupProto)


### PR DESCRIPTION
## Mirror of  PR #26058: [Sort agents by success rate in end game summary](https://github.com/space-wizards/space-station-14/pull/26058) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `d674be697e83b590db5aaec9f4411dd57c131861`

PR opened by <img src="https://avatars.githubusercontent.com/u/254972?v=4" width="16"/><a href="https://github.com/Crotalus"> Crotalus</a> at 2024-03-12 22:44:16 UTC

---

PR changed 1 files with 34 additions and 16 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Sort the agents by success rate in the end game summary
> ## Why / Balance
> Fame and glory to the robust
> 
> **Changelog**
> :cl:
> - tweak: Sort agents by success rate in end game summary
> 
> 


</details>