### PR TITLE
Mirror: Sort all tags in aplhabetical order

### DIFF
--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1,3 +1,5 @@
+# PUT YOUR TAGS IN ALPHABETICAL ORDER
+
 - type: Tag
   id: AirAlarm
 
@@ -17,10 +19,10 @@
   id: AppraisalTool
 
 - type: Tag
-  id: ArtifactFragment
+  id: Arrow
 
 - type: Tag
-  id: Arrow
+  id: ArtifactFragment
 
 - type: Tag
   id: ATVKeys
@@ -206,9 +208,6 @@
   id: BoxHug
 
 - type: Tag
-  id: Burnt
-
-- type: Tag
   id: BrassInstrument
 
 - type: Tag
@@ -233,6 +232,9 @@
   id: BulletFoam
 
 - type: Tag
+  id: Burnt
+
+- type: Tag
   id: BypassDropChecks
 
 - type: Tag
@@ -242,13 +244,22 @@
   id: CableCoil
 
 - type: Tag
+  id: CannonBall
+
+- type: Tag
+  id: CannonRestrict
+
+- type: Tag
+  id: CannotSuicide
+
+- type: Tag
+  id: CanPilot
+
+- type: Tag
   id: CapacitorStockPart
 
 - type: Tag
-  id: Carrot
-
-- type: Tag
-  id: CarrotFries
+  id: CaptainSabre
 
 - type: Tag
   id: Carpet
@@ -269,31 +280,25 @@
   id: CarpetOrange
 
 - type: Tag
-  id: CarpetPurple
+  id: CarpetPink
 
 - type: Tag
-  id: CarpetPink
+  id: CarpetPurple
 
 - type: Tag
   id: CarpetRed
 
 - type: Tag
+  id: CarpetSBlue
+
+- type: Tag
   id: CarpetWhite
 
 - type: Tag
-  id: CanPilot
+  id: Carrot
 
 - type: Tag
-  id: CannonBall
-
-- type: Tag
-  id: CannonRestrict
-
-- type: Tag
-  id: CannotSuicide
-
-- type: Tag
-  id: CaptainSabre
+  id: CarrotFries
 
 - type: Tag
   id: Carp
@@ -380,11 +385,23 @@
 - type: Tag
   id: CluwneHorn
 
-- type: Tag #Ohioans die happy
-  id: Corn
+- type: Tag
+  id: Cola
 
 - type: Tag
   id: Coldsauce
+
+- type: Tag
+  id: CombatKnife
+
+- type: Tag
+  id: ComputerTelevisionCircuitboard
+
+- type: Tag
+  id: ConveyorAssembly
+
+- type: Tag #Ohioans die happy
+  id: Corn
 
 - type: Tag
   id: Cow
@@ -426,13 +443,10 @@
   id: Cryobeaker
 
 - type: Tag
-  id: CrystalCyan
-
-- type: Tag
   id: CrystalBlue
 
 - type: Tag
-  id: CrystalPink
+  id: CrystalCyan
 
 - type: Tag
   id: CrystalGreen
@@ -441,19 +455,10 @@
   id: CrystalOrange
 
 - type: Tag
+  id: CrystalPink
+
+- type: Tag
   id: CrystalRed
-
-- type: Tag
-  id: ConveyorAssembly
-
-- type: Tag
-  id: Cola
-
-- type: Tag
-  id: CombatKnife
-
-- type: Tag
-  id: ComputerTelevisionCircuitboard
 
 - type: Tag
   id: CubanCarp
@@ -483,25 +488,25 @@
   id: Document
 
 - type: Tag
-  id: DoorBumpOpener
-
-- type: Tag
-  id: DoorElectronics
-
-- type: Tag
   id: DonkPocket
 
 - type: Tag
   id: Donut
 
 - type: Tag
+  id: DoorBumpOpener
+
+- type: Tag
+  id: DoorElectronics
+
+- type: Tag
+  id: DrinkBottle
+
+- type: Tag
   id: DrinkCan
 
 - type: Tag
   id: DrinkSpaceGlue
-
-- type: Tag
-  id: DrinkBottle
 
 - type: Tag
   id: Duck
@@ -537,9 +542,6 @@
   id: FireAxe
 
 - type: Tag
-  id: Flesh
-
-- type: Tag
   id: FirelockElectronics
 
 - type: Tag
@@ -547,6 +549,9 @@
 
 - type: Tag
   id: Flashlight
+
+- type: Tag
+  id: Flesh
 
 - type: Tag
   id: Flower
@@ -633,10 +638,10 @@
   id: HamtrLLeg
 
 - type: Tag
-  id: HamtrRLeg
+  id: HamtrRArm
 
 - type: Tag
-  id: HamtrRArm
+  id: HamtrRLeg
 
 - type: Tag
   id: Handcuffs
@@ -696,10 +701,10 @@
   id: HonkerLLeg
 
 - type: Tag
-  id: HonkerRLeg
+  id: HonkerRArm
 
 - type: Tag
-  id: HonkerRArm
+  id: HonkerRLeg
 
 - type: Tag
   id: Hotsauce
@@ -726,10 +731,10 @@
   id: JawsOfLife
 
 - type: Tag
-  id: Katana
+  id: Kangaroo
 
 - type: Tag
-  id: Kangaroo
+  id: Katana
 
 - type: Tag
   id: Ketchup
@@ -757,18 +762,6 @@
 
 - type: Tag
   id: MacroBomb
-
-- type: Tag
-  id: MicroBomb
-
-- type: Tag
-  id: MimeBelt
-
-- type: Tag
-  id: MimeHappyHonk
-
-- type: Tag
-  id: Mineshaft
 
 # Magazines ordered by slot then caliber
 
@@ -823,6 +816,8 @@
 - type: Tag
   id: MagazineGrenade
 
+# Magazines end
+
 - type: Tag
   id: MailingUnitElectronics
 
@@ -842,16 +837,31 @@
   id: Metal
 
 - type: Tag
+  id: MicroBomb
+
+- type: Tag
+  id: MimeBelt
+
+- type: Tag
+  id: MimeHappyHonk
+
+- type: Tag
   id: MindShield
 
 - type: Tag
   id: MindTransferTarget
 
 - type: Tag
+  id: Mineshaft
+
+- type: Tag
   id: ModularReceiver
 
 - type: Tag
   id: MonkeyCube
+
+- type: Tag
+  id: MonkeyWearable
 
 - type: Tag
   id: Mop
@@ -890,10 +900,10 @@
   id: Paper
 
 - type: Tag
-  id: Payload # for grenade/bomb crafting
+  id: Pancake
 
 - type: Tag
-  id: Pancake
+  id: Payload # for grenade/bomb crafting
 
 - type: Tag
   id: Pen
@@ -906,9 +916,6 @@
 
 - type: Tag
   id: PetWearable
-
-- type: Tag
-  id: MonkeyWearable
 
 - type: Tag
   id: Pickaxe
@@ -956,10 +963,10 @@
   id: PlushieSharkBlue
 
 - type: Tag
-  id: PlushieSharkPink
+  id: PlushieSharkGrey
 
 - type: Tag
-  id: PlushieSharkGrey
+  id: PlushieSharkPink
 
 - type: Tag
   id: Potato
@@ -968,13 +975,13 @@
   id: PotatoBattery
 
 - type: Tag
+  id: PowerCage
+
+- type: Tag
   id: PowerCell
 
 - type: Tag
   id: PowerCellSmall
-
-- type: Tag
-  id: PowerCage
 
 - type: Tag
   id: Powerdrill
@@ -1023,10 +1030,10 @@
   id: RipleyLLeg
 
 - type: Tag
-  id: RipleyRLeg
+  id: RipleyRArm
 
 - type: Tag
-  id: RipleyRArm
+  id: RipleyRLeg
 
 - type: Tag
   id: RodMetal1
@@ -1083,10 +1090,10 @@
   id: SmallMech
 
 - type: Tag
-  id: SnapPop
+  id: Smokable
 
 - type: Tag
-  id: Smokable
+  id: SnapPop
 
 - type: Tag
   id: SnowyLabs
@@ -1099,13 +1106,6 @@
 
 - type: Tag
   id: Soup
-
-- type: Tag
-  id: SpookyFog
-
-- type: Tag
-  id: Spray
-
 - type: Tag
   id: Spear
 
@@ -1125,13 +1125,19 @@
   id: SpiderCraft
 
 - type: Tag
+  id: SpookyFog
+
+- type: Tag
+  id: Spray
+
+- type: Tag
   id: SpreaderIgnore
 
 - type: Tag
-  id: StringInstrument
+  id: StationMapElectronics
 
 - type: Tag
-  id: StationMapElectronics
+  id: StringInstrument
 
 - type: Tag
   id: SubdermalImplant
@@ -1155,13 +1161,13 @@
   id: Spellbook
 
 - type: Tag
-  id: Taser
-
-- type: Tag
   id: TabletopBoard
 
 - type: Tag
   id: TabletopPiece
+
+- type: Tag
+  id: Taser
 
 - type: Tag
   id: TimerBrigElectronics
@@ -1233,13 +1239,13 @@
   id: Window
 
 - type: Tag
-  id: WizardWand # that evil vvizard vvand
+  id: Wirecutter
 
 - type: Tag
   id: WizardStaff
 
 - type: Tag
-  id: Wirecutter
+  id: WizardWand # that evil vvizard vvand
 
 - type: Tag
   id: Wooden # just like our atmos
@@ -1258,5 +1264,3 @@
 
 - type: Tag
   id: WriteIgnoreStamps
-
-# PUT YOUR TAGS IN ALPHABETICAL ORDER


### PR DESCRIPTION
## Mirror of  PR #26114: [Sort all tags in aplhabetical order](https://github.com/space-wizards/space-station-14/pull/26114) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `0fdb551c3d54824b8191a94befdd97ae88cc0102`

PR opened by <img src="https://avatars.githubusercontent.com/u/124214523?v=4" width="16"/><a href="https://github.com/lzk228"> lzk228</a> at 2024-03-14 16:22:29 UTC

---

PR changed 1 files with 99 additions and 98 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> title


</details>