### PR TITLE
Mirror: Prevent dead players from turning bar stools

### DIFF
--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -101,7 +101,7 @@ namespace Content.IntegrationTests.Tests.Buckle
                     Assert.That(buckle.Buckled);
 
                     Assert.That(actionBlocker.CanMove(human), Is.False);
-                    Assert.That(actionBlocker.CanChangeDirection(human), Is.False);
+                    Assert.That(actionBlocker.CanChangeDirection(human));
                     Assert.That(standingState.Down(human), Is.False);
                     Assert.That(
                         (xformSystem.GetWorldPosition(human) - xformSystem.GetWorldPosition(chair)).LengthSquared,

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -7,7 +7,6 @@ using Content.Shared.Database;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
@@ -39,7 +38,6 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, StandAttemptEvent>(OnBuckleStandAttempt);
         SubscribeLocalEvent<BuckleComponent, ThrowPushbackAttemptEvent>(OnBuckleThrowPushbackAttempt);
         SubscribeLocalEvent<BuckleComponent, UpdateCanMoveEvent>(OnBuckleUpdateCanMove);
-        SubscribeLocalEvent<BuckleComponent, ChangeDirectionAttemptEvent>(OnBuckleChangeDirectionAttempt);
     }
 
     private void OnBuckleComponentStartup(EntityUid uid, BuckleComponent component, ComponentStartup args)
@@ -139,12 +137,6 @@ public abstract partial class SharedBuckleSystem
             return;
 
         if (component.Buckled) // buckle shitcode
-            args.Cancel();
-    }
-
-    private void OnBuckleChangeDirectionAttempt(EntityUid uid, BuckleComponent component, ChangeDirectionAttemptEvent args)
-    {
-        if (component.Buckled)
             args.Cancel();
     }
 

--- a/Content.Shared/Interaction/RotateToFaceSystem.cs
+++ b/Content.Shared/Interaction/RotateToFaceSystem.cs
@@ -80,14 +80,8 @@ namespace Content.Shared.Interaction
 
         public bool TryFaceAngle(EntityUid user, Angle diffAngle, TransformComponent? xform = null)
         {
-            if (_actionBlockerSystem.CanChangeDirection(user))
-            {
-                if (!Resolve(user, ref xform))
-                    return false;
-
-                _transform.SetWorldRotation(xform, diffAngle);
-                return true;
-            }
+            if (!_actionBlockerSystem.CanChangeDirection(user))
+                return false;
 
             if (EntityManager.TryGetComponent(user, out BuckleComponent? buckle) && buckle.Buckled)
             {
@@ -105,9 +99,16 @@ namespace Content.Shared.Interaction
                         return true;
                     }
                 }
+
+                return false;
             }
 
-            return false;
+            // user is not buckled in; apply to their transform
+            if (!Resolve(user, ref xform))
+                return false;
+
+            _transform.SetWorldRotation(xform, diffAngle);
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Mirror of  PR #24308: [Prevent dead players from turning bar stools](https://github.com/space-wizards/space-station-14/pull/24308) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `15a7520df17a6fa95cbd8ce8914edab5b0d7ed50`

PR opened by <img src="https://avatars.githubusercontent.com/u/4543739?v=4" width="16"/><a href="https://github.com/Nopey"> Nopey</a> at 2024-01-19 22:47:45 UTC

---

PR changed 3 files with 11 additions and 18 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> Bugfix.
> 
> ## Why / Balance
> Previously, players could always turn a bar stool (or office chair, etc..) they were buckled into; even while stone cold dead.
> 
> ## Technical details
> RotateToFaceSystem now only lets players rotate barstools (& similar) when the actionBlockerSystem reports that they CanChangeDirection; this also means players who are frozen by admins (see AdminFrozenSystem) can no longer spin barstools.
> 
> SharedBuckleSystem no longer tries to prevent buckled players from being able to change direction, instead relying on RotateToFaceSystem to ensure that players on beds and such don't rotate.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame
> 
> Video showcasing prior broken behavior: 
> 
> https://github.com/space-wizards/space-station-14/assets/4543739/74be203a-0961-4850-842a-768d927f6691
> 
> 
> 
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> :cl:
> - fix: Dead players can no longer spin on a bar stool.
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> 


</details>