### PR TITLE
Mirror: Fix tranq rounds injecting when reflected

### DIFF
--- a/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
@@ -25,7 +25,4 @@ public sealed partial class SolutionInjectOnCollideComponent : Component
     /// </summary>
     [DataField("blockSlots"), ViewVariables(VVAccess.ReadWrite)]
     public SlotFlags BlockSlots = SlotFlags.MASK;
-
-    [DataField]
-    public string FixtureId = SharedProjectileSystem.ProjectileFixture;
 }

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
@@ -3,8 +3,7 @@ using Content.Server.Body.Systems;
 using Content.Server.Chemistry.Components;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Shared.Inventory;
-using JetBrains.Annotations;
-using Robust.Shared.Physics.Events;
+using Content.Shared.Projectiles;
 
 namespace Content.Server.Chemistry.EntitySystems;
 
@@ -17,17 +16,15 @@ public sealed class SolutionInjectOnCollideSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<SolutionInjectOnCollideComponent, StartCollideEvent>(HandleInjection);
+        SubscribeLocalEvent<SolutionInjectOnCollideComponent, ProjectileHitEvent>(HandleInjection);
     }
 
-    private void HandleInjection(Entity<SolutionInjectOnCollideComponent> ent, ref StartCollideEvent args)
+    private void HandleInjection(Entity<SolutionInjectOnCollideComponent> ent, ref ProjectileHitEvent args)
     {
         var component = ent.Comp;
-        var target = args.OtherEntity;
+        var target = args.Target;
 
-        if (!args.OtherBody.Hard ||
-            args.OurFixtureId != ent.Comp.FixtureId ||
-            !EntityManager.TryGetComponent<BloodstreamComponent>(target, out var bloodstream) ||
+        if (!TryComp<BloodstreamComponent>(target, out var bloodstream) ||
             !_solutionContainersSystem.TryGetInjectableSolution(ent.Owner, out var solution, out _))
         {
             return;


### PR DESCRIPTION
## Mirror of  PR #26141: [Fix tranq rounds injecting when reflected](https://github.com/space-wizards/space-station-14/pull/26141) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f0dfe3f6fb10e1b1f4e1a4b40c860fc0bac8427b`

PR opened by <img src="https://avatars.githubusercontent.com/u/85356?v=4" width="16"/><a href="https://github.com/Tayrtahn"> Tayrtahn</a> at 2024-03-15 13:11:00 UTC

---

PR changed 2 files with 5 additions and 11 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Tranquilizer rounds no longer inject their target when they are successfully reflected.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Fixes #26137
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Changed SolutionInjectOnCollideSystem to subscribe to ProjectileHitEvent instead of StartCollideEvent. This also simplifies the logic a little and removes a component field (FixtureId), since SolutionInjectOnCollideSystem no longer has to check for fixture match or fixture hardness (these are already checked by ProjectileSystem before raising ProjectileHitEvent).
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> https://github.com/space-wizards/space-station-14/assets/85356/beb47792-5408-4231-ba96-97be25a96e8c
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - fix: Reflected tranquilizer rounds no longer inject the character who reflected them.


</details>