### PR TITLE
Mirror: Sleep on Stasis Beds

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -7,6 +7,11 @@
   - type: StasisBed
     baseMultiplier: 10
   - type: AntiRotOnBuckle
+  - type: HealOnBuckle
+    damage:
+      types:
+        Poison: -0.001
+        Blunt: -0.001
   - type: Sprite
     sprite: Structures/Machines/stasis_bed.rsi
     noRot: true


### PR DESCRIPTION
## Mirror of  PR #26129: [Sleep on Stasis Beds](https://github.com/space-wizards/space-station-14/pull/26129) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `5912b062503841ad8adc6a4a959f97670063f1fb`

PR opened by <img src="https://avatars.githubusercontent.com/u/58439124?v=4" width="16"/><a href="https://github.com/Plykiya"> Plykiya</a> at 2024-03-15 05:47:26 UTC

---

PR changed 1 files with 5 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Made stasis beds heal you at the same rate as normal beds and allows you to sleep on it.
> Edit: I have made the healing 100x worse than normal beds.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> I kinda just wanted to sleep on a stasis bed and was sad I couldn't. I'm open to any arguments for changing the numbers...
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> .yml component that adds a sleep action
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> no changelog cause this feels like it shoulda already been a thing...


</details>