### PR TITLE
Mirror: fix eggsplosion

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
@@ -15,7 +15,8 @@
       completed:
       - !type:DamageEntity
         damage:
-          Blunt: 10
+          types:
+            Blunt: 10
       steps:
       # egg explodes some time after the water in it boils and increases pressure, guessing ~110C
       - minTemperature: 383


### PR DESCRIPTION
## Mirror of  PR #26146: [fix eggsplosion](https://github.com/space-wizards/space-station-14/pull/26146) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `d87be642ee9ec81064eff22389705755ab557b54`

PR opened by <img src="https://avatars.githubusercontent.com/u/39013340?v=4" width="16"/><a href="https://github.com/deltanedas"> deltanedas</a> at 2024-03-15 15:46:48 UTC

---

PR changed 1 files with 2 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> how does this shit not make yaml linter fail so many bugs have been caused by it
> 
> ## Media
> 
> ![15:49:11](https://github.com/space-wizards/space-station-14/assets/39013340/7a642926-4197-435c-a886-871808b59d7a)
> 


</details>