### PR TITLE
Mirror: Small performance optimization. Don't do String.Trim() second time

### DIFF
--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -122,7 +122,7 @@ namespace Content.Server.Disposal.Tube
                     if (trimmed == "")
                         continue;
 
-                    router.Tags.Add(tag.Trim());
+                    router.Tags.Add(trimmed);
                 }
 
                 _audioSystem.PlayPvs(router.ClickSound, uid, AudioParams.Default.WithVolume(-2f));


### PR DESCRIPTION
## Mirror of  PR #26161: [Small performance optimization. Don't do String.Trim() second time](https://github.com/space-wizards/space-station-14/pull/26161) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `3425444c5383f73c830f6299885e44cb4bcab46a`

PR opened by <img src="https://avatars.githubusercontent.com/u/9883873?v=4" width="16"/><a href="https://github.com/CrafterKolyan"> CrafterKolyan</a> at 2024-03-15 21:45:04 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Super small performance optimization
> 
> ## Technical details
> Obvious change


</details>