### PR TITLE
Mirror: Convert "IgnoreWeatherComponent" into "BlockWeatherComponent"

### DIFF
--- a/Content.Shared/Weather/BlockWeatherComponent.cs
+++ b/Content.Shared/Weather/BlockWeatherComponent.cs
@@ -3,10 +3,10 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Weather;
 
 /// <summary>
-/// This entity will be ignored for considering weather on a tile
+/// This entity will block the weather if it's anchored to the floor.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class IgnoreWeatherComponent : Component
+public sealed partial class BlockWeatherComponent : Component
 {
 
 }

--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -19,13 +19,13 @@ public abstract class SharedWeatherSystem : EntitySystem
     [Dependency] private   readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
-    private EntityQuery<IgnoreWeatherComponent> _ignoreQuery;
+    private EntityQuery<BlockWeatherComponent> _blockQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
     public override void Initialize()
     {
         base.Initialize();
-        _ignoreQuery = GetEntityQuery<IgnoreWeatherComponent>();
+        _blockQuery = GetEntityQuery<BlockWeatherComponent>();
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         SubscribeLocalEvent<WeatherComponent, EntityUnpausedEvent>(OnWeatherUnpaused);
     }
@@ -57,13 +57,8 @@ public abstract class SharedWeatherSystem : EntitySystem
 
         while (anchoredEnts.MoveNext(out var ent))
         {
-            if (!_ignoreQuery.HasComponent(ent.Value) &&
-                _physicsQuery.TryGetComponent(ent, out var body) &&
-                body.Hard &&
-                body.CanCollide)
-            {
+            if (_blockQuery.HasComponent(ent.Value))
                 return false;
-            }
         }
 
         return true;

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -38,7 +38,6 @@
   description: Yep, it's a tree.
   abstract: true
   components:
-  - type: IgnoreWeather
   - type: SpriteFade
   - type: Clickable
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -147,6 +147,7 @@
       - Airlock
       # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
   - type: PryUnpowered
+  - type: BlockWeather
   placement:
     mode: SnapgridCenter
 

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -56,6 +56,7 @@
     key: walls
     mode: NoSprite
   - type: Occluder
+  - type: BlockWeather
 
 - type: entity
   parent: BaseMaterialDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -64,6 +64,7 @@
   - type: ContainerContainer
     containers:
       battery-container: !type:Container
+  - type: BlockWeather
 
 - type: entity
   id: BaseSecretDoorAssembly

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -97,6 +97,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+  - type: BlockWeather
 
 - type: entity
   id: ShuttersNormal

--- a/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
@@ -68,3 +68,4 @@
   - type: Construction
     graph: Bookshelf
     node: bookshelf
+  - type: BlockWeather

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -49,6 +49,7 @@
     price: 75
   - type: RadiationBlocker
     resistance: 2
+  - type: BlockWeather
 
 - type: entity
   parent: BaseWall

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -88,6 +88,7 @@
       sprite: Structures/Windows/cracks.rsi
   - type: StaticPrice
     price: 100
+  - type: BlockWeather
 
 - type: entity
   id: WindowDirectional


### PR DESCRIPTION
## Mirror of  PR #26135: [Convert "IgnoreWeatherComponent" into "BlockWeatherComponent"](https://github.com/space-wizards/space-station-14/pull/26135) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `4aa72af574cc7a3370085fb70831fbde1df29077`

PR opened by <img src="https://avatars.githubusercontent.com/u/96445749?v=4" width="16"/><a href="https://github.com/TheShuEd"> TheShuEd</a> at 2024-03-15 09:30:10 UTC

---

PR changed 10 files with 12 additions and 11 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> inverting the logic of the component. Now inversely, tagging an entity with this component will cause it to block weather if it is attached to the floor. Previously, this conversely excluded the entity from weather checking, and only applied to trees on planets.
> 
> It now blocks rain on walls, windows, airlocks. 
> 
> ## Why / Balance
> 95% of the structures in the game should not block weather. Railings, tables, chairs, fences all logically allow water to pass through. We're making a map under rainy skies, and it's annoying.
> ![image](https://github.com/space-wizards/space-station-14/assets/96445749/d383e2c1-17a3-4c83-8620-e558f3ba9b3c)
> ![image](https://github.com/space-wizards/space-station-14/assets/96445749/f872d0ca-aac2-43b0-a2c4-ba0ed29443f5)
> ![image](https://github.com/space-wizards/space-station-14/assets/96445749/4b225631-0ec6-45d7-911d-76aa35128b35)
> 
> this will also be useful for the visual part of expeditions or something with planets when weather is added there in the future


</details>