### PR TITLE
Mirror: Round start Ion storms

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -463,7 +463,6 @@
   components:
   - type: StationEvent
     weight: 10
-    earliestStart: 20
     reoccurrenceDelay: 20
     duration: 1
   - type: IonStormRule


### PR DESCRIPTION
## Mirror of  PR #26165: [Round start Ion storms](https://github.com/space-wizards/space-station-14/pull/26165) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `23e6d537a44d8aaea781462ce600292811ac4998`

PR opened by <img src="https://avatars.githubusercontent.com/u/58439124?v=4" width="16"/><a href="https://github.com/Plykiya"> Plykiya</a> at 2024-03-16 01:37:52 UTC

---

PR changed 1 files with 0 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Changed the earliest start for ion storms to be at shift start
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Ion storms rarely happen, and it adds more variety for borgs if it does happen early on, also Discord discussion...
> https://discord.com/channels/310555209753690112/1218041638115348500
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Changed earliestStart from 20 minutes to 0 minutes in the yml
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - tweak: Ion storms now have a chance of happening from the start of shift.


</details>