### PR TITLE
Mirror: less fish in maints

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -110,6 +110,9 @@
           prob: 0.10
         - id: Soap
           prob: 0.44
+        - id: null
+          prob: 0.67
+          orGroup: carp
         - id: PlushieCarp
           prob: 0.2
         - id: PlushieSlime
@@ -203,6 +206,9 @@
           prob: 0.10
         - id: Soap
           prob: 0.44
+        - id: null
+          prob: 0.67
+          orGroup: carp
         - id: PlushieCarp
           prob: 0.2
         - id: PlushieSlime


### PR DESCRIPTION
## Mirror of  PR #26156: [less fish in maints](https://github.com/space-wizards/space-station-14/pull/26156) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `6aa77700c1e4ae9d5e287c7c4f6e3484e1eb28b4`

PR opened by <img src="https://avatars.githubusercontent.com/u/39013340?v=4" width="16"/><a href="https://github.com/deltanedas"> deltanedas</a> at 2024-03-15 19:45:58 UTC

---

PR changed 1 files with 6 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> 
> fixes #26155 probably


</details>