### PR TITLE
Mirror: Fix store refunds

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -323,7 +323,7 @@ public sealed partial class StoreSystem
         if (!component.RefundAllowed || component.BoughtEntities.Count == 0)
             return;
 
-        for (var i = component.BoughtEntities.Count; i >= 0; i--)
+        for (var i = component.BoughtEntities.Count - 1; i >= 0; i--)
         {
             var purchase = component.BoughtEntities[i];
 
@@ -332,13 +332,15 @@ public sealed partial class StoreSystem
 
             component.BoughtEntities.RemoveAt(i);
 
-            if (_actions.TryGetActionData(purchase, out var actionComponent))
+            if (_actions.TryGetActionData(purchase, out var actionComponent, logError: false))
             {
                 _actionContainer.RemoveAction(purchase, actionComponent);
             }
 
             EntityManager.DeleteEntity(purchase);
         }
+
+        component.BoughtEntities.Clear();
 
         foreach (var (currency, value) in component.BalanceSpent)
         {


### PR DESCRIPTION
## Mirror of  PR #26173: [Fix store refunds](https://github.com/space-wizards/space-station-14/pull/26173) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f8d023f286bdf1b38bb69349e1c474792a950f51`

PR opened by <img src="https://avatars.githubusercontent.com/u/31366439?v=4" width="16"/><a href="https://github.com/metalgearsloth"> metalgearsloth</a> at 2024-03-16 11:25:11 UTC

---

PR changed 1 files with 4 additions and 2 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Index out of range + error log + cleaning up boughtentities.
> 
> :cl:
> - fix: Fix store refunds.


</details>