### PR TITLE
Mirror: Small species melee weapon change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1359,12 +1359,13 @@
     baseSprintSpeed: 5
   - type: MeleeWeapon
     soundHit:
-      path: /Audio/Weapons/pierce.ogg
+      collection: AlienClaw
     angle: 30
-    animation: WeaponArcPunch
+    animation: WeaponArcClaw
     damage:
       types:
-        Piercing: 9
+        Slash: 5
+        Piercing: 4
   - type: Temperature
     heatDamageThreshold: 360
     coldDamageThreshold: 285

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -51,7 +51,7 @@
   - type: MeleeWeapon
     animation: WeaponArcBite
     soundHit:
-      collection: AlienClaw
+      path: /Audio/Effects/bite.ogg
     damage:
       types:
         Piercing: 5

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -41,7 +41,7 @@
     damageModifierSet: Scale
   - type: MeleeWeapon
     soundHit:
-      path: /Audio/Weapons/pierce.ogg
+      collection: AlienClaw
     angle: 30
     animation: WeaponArcClaw
     damage:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -41,7 +41,7 @@
     bloodReagent: AmmoniaBlood
   - type: MeleeWeapon
     soundHit:
-      path: /Audio/Weapons/pierce.ogg
+      collection: AlienClaw
     angle: 30
     animation: WeaponArcClaw
     damage:


### PR DESCRIPTION
## Mirror of  PR #26183: [Small species melee weapon change](https://github.com/space-wizards/space-station-14/pull/26183) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `0a8def1ea2dc4b7aee297098b3b50a7367f3c4d1`

PR opened by <img src="https://avatars.githubusercontent.com/u/45323883?v=4" width="16"/><a href="https://github.com/Dutch-VanDerLinde"> Dutch-VanDerLinde</a> at 2024-03-16 17:39:26 UTC

---

PR changed 4 files with 7 additions and 6 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> - kobolds have the claw arc instead of the punch arc and do 5 slash 4 piercing instead of 9 piercing
> - arachnids make the carp bite sound similar to tarantulas and space spiders
> - lizards now make the slashing sound on hit instead of pierce, since they claw not pierce
> 
> ## Why / Balance
> kobolds did the old lizard pierce animation when they clawed, made more sense
> 
> if space bears claw and make the slashing sound then lizards should too
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 


</details>