### PR TITLE
Mirror: Change collision mask of canisters to allow passing through cargo flaps

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -74,7 +74,7 @@
             bounds: "-0.25,-0.25,0.25,0.25"
           density: 190
           mask:
-          - MachineMask
+          - SmallMobMask
           layer:
           - MachineLayer
     - type: AtmosDevice


### PR DESCRIPTION
## Mirror of  PR #26193: [Change collision mask of canisters to allow passing through cargo flaps](https://github.com/space-wizards/space-station-14/pull/26193) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `03b5c21b6e4d0efc70e0172690d9d2ec02d7a711`

PR opened by <img src="https://avatars.githubusercontent.com/u/107660393?v=4" width="16"/><a href="https://github.com/IamVelcroboy"> IamVelcroboy</a> at 2024-03-16 20:59:22 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Title
> 
> ## Why / Balance
> Frequently requested feature/QoL
> 
> ## Technical details
> n/a
> 
> ## Media
> n/a
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase
> 
> ## Breaking changes
> n/a
> 
> **Changelog**
> :cl: Velcroboy
> - tweak: Tweaked gas canisters to pass through cargo flaps.


</details>