### PR TITLE
Mirror: Fix presetidcard extended access throwing

### DIFF
--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -50,8 +50,10 @@ public sealed class PresetIdCardSystem : EntitySystem
 
         var station = _stationSystem.GetOwningStation(uid);
         var extended = false;
-        if (station != null)
-            extended = Comp<StationJobsComponent>(station.Value).ExtendedAccess;
+
+        // Station not guaranteed to have jobs (e.g. nukie outpost).
+        if (TryComp(station, out StationJobsComponent? stationJobs))
+            extended = stationJobs.ExtendedAccess;
 
         SetupIdAccess(uid, id, extended);
         SetupIdName(uid, id);


### PR DESCRIPTION
## Mirror of  PR #26195: [Fix presetidcard extended access throwing](https://github.com/space-wizards/space-station-14/pull/26195) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `677fd3c6db4550431d8801203c03aa2ab5075c29`

PR opened by <img src="https://avatars.githubusercontent.com/u/31366439?v=4" width="16"/><a href="https://github.com/metalgearsloth"> metalgearsloth</a> at 2024-03-17 00:47:51 UTC

---

PR changed 1 files with 4 additions and 2 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Resolves https://github.com/space-wizards/space-station-14/issues/25798
> 
> :cl:
> - fix: Fix ID cards sometimes not loading properly.


</details>