### PR TITLE
Mirror: SlowContactsSystem to SpeedModifierContactsSystem mini rework

### DIFF
--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -45,9 +45,9 @@ namespace Content.Server.Chemistry.TileReactions
                 var step = entityManager.EnsureComponent<StepTriggerComponent>(puddleUid);
                 entityManager.EntitySysManager.GetEntitySystem<StepTriggerSystem>().SetRequiredTriggerSpeed(puddleUid, _requiredSlipSpeed, step);
 
-                var slow = entityManager.EnsureComponent<SlowContactsComponent>(puddleUid);
+                var slow = entityManager.EnsureComponent<SpeedModifierContactsComponent>(puddleUid);
                 var speedModifier = 1 - reagent.Viscosity;
-                entityManager.EntitySysManager.GetEntitySystem<SlowContactsSystem>().ChangeModifiers(puddleUid, speedModifier, slow);
+                entityManager.EntitySysManager.GetEntitySystem<SpeedModifierContactsSystem>().ChangeModifiers(puddleUid, speedModifier, slow);
 
                 return reactVolume;
             }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [Dependency] private readonly SharedPopupSystem _popups = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly StepTriggerSystem _stepTrigger = default!;
-    [Dependency] private readonly SlowContactsSystem _slowContacts = default!;
+    [Dependency] private readonly SpeedModifierContactsSystem _speedModContacts = default!;
     [Dependency] private readonly TileFrictionController _tile = default!;
 
     [ValidatePrototypeId<ReagentPrototype>]
@@ -435,13 +435,13 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         if (maxViscosity > 0)
         {
-            var comp = EnsureComp<SlowContactsComponent>(uid);
+            var comp = EnsureComp<SpeedModifierContactsComponent>(uid);
             var speed = 1 - maxViscosity;
-            _slowContacts.ChangeModifiers(uid, speed, comp);
+            _speedModContacts.ChangeModifiers(uid, speed, comp);
         }
         else
         {
-            RemComp<SlowContactsComponent>(uid);
+            RemComp<SpeedModifierContactsComponent>(uid);
         }
     }
 

--- a/Content.Shared/Movement/Components/SpeedModifiedByContactComponent.cs
+++ b/Content.Shared/Movement/Components/SpeedModifiedByContactComponent.cs
@@ -7,6 +7,6 @@ namespace Content.Shared.Movement.Components;
 /// Exists just to listen to a single event. What a life.
 /// </summary>
 [NetworkedComponent, RegisterComponent] // must be networked to properly predict adding & removal
-public sealed partial class SlowedByContactComponent : Component
+public sealed partial class SpeedModifiedByContactComponent : Component
 {
 }

--- a/Content.Shared/Movement/Components/SpeedModifierContactsComponent.cs
+++ b/Content.Shared/Movement/Components/SpeedModifierContactsComponent.cs
@@ -6,8 +6,8 @@ namespace Content.Shared.Movement.Components;
 
 [NetworkedComponent, RegisterComponent]
 [AutoGenerateComponentState]
-[Access(typeof(SlowContactsSystem))]
-public sealed partial class SlowContactsComponent : Component
+[Access(typeof(SpeedModifierContactsSystem))]
+public sealed partial class SpeedModifierContactsComponent : Component
 {
     [DataField("walkSpeedModifier"), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]

--- a/Content.Shared/Movement/Systems/FrictionContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/FrictionContactsSystem.cs
@@ -10,7 +10,7 @@ public sealed class FrictionContactsSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speedModifierSystem = default!;
 
-    // Comment copied from "original" SlowContactsSystem.cs
+    // Comment copied from "original" SlowContactsSystem.cs (now SpeedModifierContactsSystem.cs)
     // TODO full-game-save 
     // Either these need to be processed before a map is saved, or slowed/slowing entities need to update on init.
     private HashSet<EntityUid> _toUpdate = new();

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -82,7 +82,7 @@
     - type: AtmosExposed
       growthTickChance: 0.3
       spreadChance: 0.4
-    - type: SlowContacts
+    - type: SpeedModifierContacts
       walkSpeedModifier: 0.2
       sprintSpeedModifier: 0.2
       ignoreWhitelist:
@@ -123,7 +123,7 @@
     - type: Kudzu
       spriteVariants: 5
       spreadChance: 0.01
-    - type: SlowContacts
+    - type: SpeedModifierContacts
       walkSpeedModifier: 0.8
       sprintSpeedModifier: 0.8
       ignoreWhitelist:
@@ -237,7 +237,7 @@
          Heat: 3
       growthTickChance: 0.3
     - type: AtmosExposed
-    - type: SlowContacts
+    - type: SpeedModifierContacts
       walkSpeedModifier: 0.3
       sprintSpeedModifier: 0.3
       ignoreWhitelist:

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -72,7 +72,7 @@
         Flammable: [Touch]
         Extinguish: [Touch]
     - type: SpiderWebObject
-    - type: SlowContacts
+    - type: SpeedModifierContacts
       walkSpeedModifier: 0.5
       sprintSpeedModifier: 0.5
       ignoreWhitelist:

--- a/Resources/Prototypes/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/Entities/Tiles/water.yml
@@ -32,7 +32,7 @@
         Quantity: 100
   - type: DrainableSolution
     solution: pool
-  - type: SlowContacts
+  - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
   - type: Physics


### PR DESCRIPTION
## Mirror of  PR #26110: [SlowContactsSystem to SpeedModifierContactsSystem mini rework](https://github.com/space-wizards/space-station-14/pull/26110) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `c35ff87e146f0cda7c10782f4ab80b784b51e5fe`

PR opened by <img src="https://avatars.githubusercontent.com/u/96445749?v=4" width="16"/><a href="https://github.com/TheShuEd"> TheShuEd</a> at 2024-03-14 09:45:33 UTC

---

PR changed 9 files with 42 additions and 34 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> system and components are renamed. It can now be used including to accelerate entities
> 
> ## Why / Balance
> more reusability for the system
> 
> ## Technical details
> Now the system calculates the arithmetic mean of all the entities that affects your speed.


</details>