### PR TITLE
Mirror: add decoy syndicate bomb to uplink

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -64,7 +64,10 @@ uplink-exploding-pen-name = Exploding pen
 uplink-exploding-pen-desc = A class IV explosive device contained within a standard pen. Comes with a 4 second fuse.
 
 uplink-exploding-syndicate-bomb-name = Syndicate Bomb
-uplink-exploding-syndicate-bomb-desc = A big, anchored bomb that can create a huge explosion if not defused in time. Useful as a distraction. Has an adjustable timer with a minimum setting of 120 seconds.
+uplink-exploding-syndicate-bomb-desc = A big, anchored bomb that can create a huge explosion if not defused in time. Useful as a distraction. Has an adjustable timer with a minimum setting of 180 seconds.
+
+uplink-exploding-syndicate-bomb-fake-name = Decoy Syndicate Bomb
+uplink-exploding-syndicate-bomb-fake-desc = A training bomb carefully made to look just like the real thing. In all ways similar to a syndicate bomb, but only creates a tiny explosion.
 
 uplink-cluster-grenade-name = Cluster Grenade
 uplink-cluster-grenade-desc = Three explosive grenades bundled together, the grenades get launched after the 3.5 second timer runs out.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -255,6 +255,16 @@
       - NukeOpsUplink
 
 - type: listing
+  id: UplinkSyndicateBombFake
+  name: uplink-exploding-syndicate-bomb-fake-name
+  description: uplink-exploding-syndicate-bomb-fake-desc
+  productEntity: SyndicateBombFake
+  cost:
+    Telecrystal: 4
+  categories:
+    - UplinkExplosives
+
+- type: listing
   id: UplinkClusterGrenade
   name: uplink-cluster-grenade-name
   description: uplink-cluster-grenade-desc

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -129,6 +129,18 @@
 
 - type: entity
   parent: SyndicateBomb
+  id: SyndicateBombFake
+  suffix: fake
+  components:
+    - type: Explosive
+      explosionType: Default
+      totalIntensity: 5.0
+      intensitySlope: 5
+      maxIntensity: 4
+      canCreateVacuum: false
+
+- type: entity
+  parent: SyndicateBomb
   id: DebugHardBomb
   name: debug bomb
   suffix: DEBUG


### PR DESCRIPTION
## Mirror of  PR #26034: [add decoy syndicate bomb to uplink](https://github.com/space-wizards/space-station-14/pull/26034) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `90be67e67956c7dd0348ddd0688d7d3ab614cb99`

PR opened by <img src="https://avatars.githubusercontent.com/u/57039557?v=4" width="16"/><a href="https://github.com/Ilya246"> Ilya246</a> at 2024-03-12 10:07:47 UTC

---

PR changed 3 files with 26 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> adds a decoy syndicate bomb to uplink for 4 TC
> in all ways similar to a real syndicate bomb, but only explodes as hard as a training bomb
> 
> price has been discussed on discord several times and seems good
> 
> *also fixes syndicate bomb description saying their timer is 120 seconds, when it's actually 180
> 
> ## Why / Balance
> a lesser distraction (no huge hole and dead people if it blows) for a lesser price, and allows syndicate bombs to be more effective for more TC if you buy one together with decoy bombs to draw attention
> why 4 TC? anything above that just doesn't seem like it'd be worth it; yes, a syndicate bomb will likely cause nearby people to vacate the place, but it will also draw at least one person to go defuse it and you will be very sus if you're spotted nearby and aren't defusing
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> ![image](https://github.com/space-wizards/space-station-14/assets/57039557/1b619411-cdd4-4f53-972c-7b9704bbd4b5)
> ![image](https://github.com/space-wizards/space-station-14/assets/57039557/373dd1b2-ba85-4c14-b219-a8e71e11142d)
> ![image](https://github.com/space-wizards/space-station-14/assets/57039557/c6488260-2f35-4a77-9f4b-c769c71899a1)
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - add: Syndicate decoy bombs may now be purchased from the uplink.
> - fix: Syndicate bomb description no longer lies about their minimum detonation time.
> 


</details>