### PR TITLE
Mirror: Unify `Content`'s `EntitySystem` logging

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -31,12 +31,10 @@ namespace Content.Server.Chemistry.EntitySystems
 
         private const float ReactTime = 0.125f;
 
-        private ISawmill _sawmill = default!;
-
         public override void Initialize()
         {
             base.Initialize();
-            _sawmill = Logger.GetSawmill("vapor");
+
             SubscribeLocalEvent<VaporComponent, StartCollideEvent>(HandleCollide);
         }
 
@@ -128,7 +126,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
                     if (reaction > reagentQuantity.Quantity)
                     {
-                        _sawmill.Error($"Tried to tile react more than we have for reagent {reagentQuantity}. Found {reaction} and we only have {reagentQuantity.Quantity}");
+                        Log.Error($"Tried to tile react more than we have for reagent {reagentQuantity}. Found {reaction} and we only have {reagentQuantity.Quantity}");
                         reaction = reagentQuantity.Quantity;
                     }
 

--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
@@ -12,8 +12,6 @@ namespace Content.Server.DeviceNetwork.Systems;
 [UsedImplicitly]
 public sealed class DeviceListSystem : SharedDeviceListSystem
 {
-    private ISawmill _sawmill = default!;
-
     [Dependency] private readonly NetworkConfiguratorSystem _configurator = default!;
 
     public override void Initialize()
@@ -23,7 +21,6 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
         SubscribeLocalEvent<DeviceListComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
         SubscribeLocalEvent<DeviceListComponent, BeforePacketSentEvent>(OnBeforePacketSent);
         SubscribeLocalEvent<BeforeSaveEvent>(OnMapSave);
-        _sawmill = Logger.GetSawmill("devicelist");
     }
 
     private void OnShutdown(EntityUid uid, DeviceListComponent component, ComponentShutdown args)
@@ -154,7 +151,7 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
                 // TODO full game saves.
                 // when full saves are supported, this should instead add data to the BeforeSaveEvent informing the
                 // saving system that this map (or null-space entity) also needs to be included in the save.
-                _sawmill.Error(
+                Log.Error(
                     $"Saving a device list ({ToPrettyString(uid)}) that has a reference to an entity on another map ({ToPrettyString(ent)}). Removing entity from list.");
             }
 

--- a/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicScannerSystem.cs
@@ -28,13 +28,9 @@ namespace Content.Server.Forensics
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
         [Dependency] private readonly MetaDataSystem _metaData = default!;
 
-        private ISawmill _sawmill = default!;
-
         public override void Initialize()
         {
             base.Initialize();
-
-            _sawmill = Logger.GetSawmill("forensics.scanner");
 
             SubscribeLocalEvent<ForensicScannerComponent, AfterInteractEvent>(OnAfterInteract);
             SubscribeLocalEvent<ForensicScannerComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
@@ -57,7 +53,7 @@ namespace Content.Server.Forensics
                 component.PrintReadyAt);
 
             if (!_uiSystem.TrySetUiState(uid, ForensicScannerUiKey.Key, state))
-                _sawmill.Warning($"{ToPrettyString(uid)} was unable to set UI state.");
+                Log.Warning($"{ToPrettyString(uid)} was unable to set UI state.");
         }
 
         private void OnDoAfter(EntityUid uid, ForensicScannerComponent component, DoAfterEvent args)
@@ -180,7 +176,7 @@ namespace Content.Server.Forensics
         {
             if (!args.Session.AttachedEntity.HasValue)
             {
-                _sawmill.Warning($"{ToPrettyString(uid)} got OnPrint without Session.AttachedEntity");
+                Log.Warning($"{ToPrettyString(uid)} got OnPrint without Session.AttachedEntity");
                 return;
             }
 
@@ -200,7 +196,7 @@ namespace Content.Server.Forensics
 
             if (!HasComp<PaperComponent>(printed))
             {
-                _sawmill.Error("Printed paper did not have PaperComponent.");
+                Log.Error("Printed paper did not have PaperComponent.");
                 return;
             }
 

--- a/Content.Server/Mapping/MappingSystem.cs
+++ b/Content.Server/Mapping/MappingSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -32,7 +32,6 @@ public sealed class MappingSystem : EntitySystem
     /// <returns></returns>
     private Dictionary<MapId, (TimeSpan next, string fileName)> _currentlyAutosaving = new();
 
-    private ISawmill _sawmill = default!;
     private bool _autosaveEnabled;
 
     public override void Initialize()
@@ -44,7 +43,6 @@ public sealed class MappingSystem : EntitySystem
             "autosave <map> <path if enabling>",
             ToggleAutosaveCommand);
 
-        _sawmill = Logger.GetSawmill("autosave");
         Subs.CVar(_cfg, CCVars.AutosaveEnabled, SetAutosaveEnabled, true);
     }
 
@@ -69,7 +67,7 @@ public sealed class MappingSystem : EntitySystem
 
             if (!_mapManager.MapExists(map) || _mapManager.IsMapInitialized(map))
             {
-                _sawmill.Warning($"Can't autosave map {map}; it doesn't exist, or is initialized. Removing from autosave.");
+                Log.Warning($"Can't autosave map {map}; it doesn't exist, or is initialized. Removing from autosave.");
                 _currentlyAutosaving.Remove(map);
                 return;
             }
@@ -79,7 +77,7 @@ public sealed class MappingSystem : EntitySystem
 
             var path = Path.Combine(saveDir, $"{DateTime.Now.ToString("yyyy-M-dd_HH.mm.ss")}-AUTO.yml");
             _currentlyAutosaving[map] = (CalculateNextTime(), name);
-            _sawmill.Info($"Autosaving map {name} ({map}) to {path}. Next save in {ReadableTimeLeft(map)} seconds.");
+            Log.Info($"Autosaving map {name} ({map}) to {path}. Next save in {ReadableTimeLeft(map)} seconds.");
             _map.SaveMap(map, path);
         }
     }
@@ -105,17 +103,17 @@ public sealed class MappingSystem : EntitySystem
         {
             if (!_mapManager.MapExists(map) || _mapManager.IsMapInitialized(map))
             {
-                _sawmill.Warning("Tried to enable autosaving on non-existant or already initialized map!");
+                Log.Warning("Tried to enable autosaving on non-existant or already initialized map!");
                 _currentlyAutosaving.Remove(map);
                 return;
             }
 
-            _sawmill.Info($"Started autosaving map {path} ({map}). Next save in {ReadableTimeLeft(map)} seconds.");
+            Log.Info($"Started autosaving map {path} ({map}). Next save in {ReadableTimeLeft(map)} seconds.");
         }
         else
         {
             _currentlyAutosaving.Remove(map);
-            _sawmill.Info($"Stopped autosaving on map {map}");
+            Log.Info($"Stopped autosaving on map {map}");
         }
     }
 

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -39,14 +39,10 @@ public sealed partial class MechSystem : SharedMechSystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
-    private ISawmill _sawmill = default!;
-
     /// <inheritdoc/>
     public override void Initialize()
     {
         base.Initialize();
-
-        _sawmill = Logger.GetSawmill("mech");
 
         SubscribeLocalEvent<MechComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<MechComponent, EntInsertedIntoContainerMessage>(OnInsertBattery);
@@ -343,7 +339,7 @@ public sealed partial class MechSystem : SharedMechSystem
         _battery.SetCharge(battery!.Value, batteryComp.CurrentCharge + delta.Float(), batteryComp);
         if (batteryComp.CurrentCharge != component.Energy) //if there's a discrepency, we have to resync them
         {
-            _sawmill.Debug($"Battery charge was not equal to mech charge. Battery {batteryComp.CurrentCharge}. Mech {component.Energy}");
+            Log.Debug($"Battery charge was not equal to mech charge. Battery {batteryComp.CurrentCharge}. Mech {component.Energy}");
             component.Energy = batteryComp.CurrentCharge;
             Dirty(component);
         }

--- a/Content.Server/Movement/Systems/LagCompensationSystem.cs
+++ b/Content.Server/Movement/Systems/LagCompensationSystem.cs
@@ -18,12 +18,10 @@ public sealed class LagCompensationSystem : EntitySystem
     // Max ping I've had is 350ms from aus to spain.
     public static readonly TimeSpan BufferTime = TimeSpan.FromMilliseconds(750);
 
-    private ISawmill _sawmill = Logger.GetSawmill("lagcomp");
-
     public override void Initialize()
     {
         base.Initialize();
-        _sawmill.Level = LogLevel.Info;
+        Log.Level = LogLevel.Info;
         SubscribeLocalEvent<LagCompensationComponent, MoveEvent>(OnLagMove);
     }
 
@@ -87,13 +85,13 @@ public sealed class LagCompensationSystem : EntitySystem
 
         if (coordinates == default)
         {
-            _sawmill.Debug($"No long comp coords found, using {xform.Coordinates}");
+            Log.Debug($"No long comp coords found, using {xform.Coordinates}");
             coordinates = xform.Coordinates;
             angle = xform.LocalRotation;
         }
         else
         {
-            _sawmill.Debug($"Actual coords is {xform.Coordinates} and got {coordinates}");
+            Log.Debug($"Actual coords is {xform.Coordinates} and got {coordinates}");
         }
 
         return (coordinates, angle);

--- a/Content.Server/NPC/Systems/NpcFactionSystem.cs
+++ b/Content.Server/NPC/Systems/NpcFactionSystem.cs
@@ -15,8 +15,6 @@ public sealed partial class NpcFactionSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
-    private ISawmill _sawmill = default!;
-
     /// <summary>
     /// To avoid prototype mutability we store an intermediary data class that gets used instead.
     /// </summary>
@@ -25,7 +23,7 @@ public sealed partial class NpcFactionSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        _sawmill = Logger.GetSawmill("faction");
+
         SubscribeLocalEvent<NpcFactionMemberComponent, ComponentStartup>(OnFactionStartup);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnProtoReload);
 
@@ -70,7 +68,7 @@ public sealed partial class NpcFactionSystem : EntitySystem
     {
         if (!_protoManager.HasIndex<NpcFactionPrototype>(faction))
         {
-            _sawmill.Error($"Unable to find faction {faction}");
+            Log.Error($"Unable to find faction {faction}");
             return;
         }
 
@@ -91,7 +89,7 @@ public sealed partial class NpcFactionSystem : EntitySystem
     {
         if (!_protoManager.HasIndex<NpcFactionPrototype>(faction))
         {
-            _sawmill.Error($"Unable to find faction {faction}");
+            Log.Error($"Unable to find faction {faction}");
             return;
         }
 
@@ -214,13 +212,13 @@ public sealed partial class NpcFactionSystem : EntitySystem
     {
         if (!_factions.TryGetValue(source, out var sourceFaction))
         {
-            _sawmill.Error($"Unable to find faction {source}");
+            Log.Error($"Unable to find faction {source}");
             return;
         }
 
         if (!_factions.ContainsKey(target))
         {
-            _sawmill.Error($"Unable to find faction {target}");
+            Log.Error($"Unable to find faction {target}");
             return;
         }
 
@@ -256,13 +254,13 @@ public sealed partial class NpcFactionSystem : EntitySystem
     {
         if (!_factions.TryGetValue(source, out var sourceFaction))
         {
-            _sawmill.Error($"Unable to find faction {source}");
+            Log.Error($"Unable to find faction {source}");
             return;
         }
 
         if (!_factions.ContainsKey(target))
         {
-            _sawmill.Error($"Unable to find faction {target}");
+            Log.Error($"Unable to find faction {target}");
             return;
         }
 

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -63,8 +63,6 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
-    private ISawmill _sawmill = default!;
-
     private const float ShuttleSpawnBuffer = 1f;
 
     private bool _emergencyShuttleEnabled;
@@ -74,7 +72,6 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
     public override void Initialize()
     {
-        _sawmill = Logger.GetSawmill("shuttle.emergency");
         _emergencyShuttleEnabled = _configManager.GetCVar(CCVars.EmergencyShuttleEnabled);
         // Don't immediately invoke as roundstart will just handle it.
         Subs.CVar(_configManager, CCVars.EmergencyShuttleEnabled, SetEmergencyShuttleEnabled);
@@ -384,7 +381,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     {
         if (component.MapEntity != null || component.Entity != null)
         {
-            _sawmill.Warning("Attempted to re-add an existing centcomm map.");
+            Log.Warning("Attempted to re-add an existing centcomm map.");
             return;
         }
 
@@ -409,7 +406,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
         if (string.IsNullOrEmpty(component.Map.ToString()))
         {
-            _sawmill.Warning("No CentComm map found, skipping setup.");
+            Log.Warning("No CentComm map found, skipping setup.");
             return;
         }
 
@@ -484,7 +481,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
         if (shuttle == null)
         {
-            _sawmill.Error($"Unable to spawn emergency shuttle {shuttlePath} for {ToPrettyString(uid)}");
+            Log.Error($"Unable to spawn emergency shuttle {shuttlePath} for {ToPrettyString(uid)}");
             return;
         }
 

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.GameTicking;
 using Content.Server.StationEvents.Components;
 using Content.Shared.CCVar;
@@ -19,16 +19,12 @@ public sealed class EventManagerSystem : EntitySystem
     [Dependency] public readonly GameTicker GameTicker = default!;
     [Dependency] private readonly GlimmerSystem _glimmerSystem = default!; //Nyano - Summary: pulls in the glimmer system.
 
-    private ISawmill _sawmill = default!;
-
     public bool EventsEnabled { get; private set; }
     private void SetEnabled(bool value) => EventsEnabled = value;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _sawmill = Logger.GetSawmill("events");
 
         Subs.CVar(_configurationManager, CCVars.EventsEnabled, SetEnabled, true);
     }
@@ -43,13 +39,13 @@ public sealed class EventManagerSystem : EntitySystem
         if (randomEvent == null)
         {
             var errStr = Loc.GetString("station-event-system-run-random-event-no-valid-events");
-            _sawmill.Error(errStr);
+            Log.Error(errStr);
             return errStr;
         }
 
         var ent = GameTicker.AddGameRule(randomEvent);
         var str = Loc.GetString("station-event-system-run-event",("eventName", ToPrettyString(ent)));
-        _sawmill.Info(str);
+        Log.Info(str);
         return str;
     }
 
@@ -59,7 +55,7 @@ public sealed class EventManagerSystem : EntitySystem
     public string? PickRandomEvent()
     {
         var availableEvents = AvailableEvents();
-        _sawmill.Info($"Picking from {availableEvents.Count} total available events");
+        Log.Info($"Picking from {availableEvents.Count} total available events");
         return FindEvent(availableEvents);
     }
 
@@ -71,7 +67,7 @@ public sealed class EventManagerSystem : EntitySystem
     {
         if (availableEvents.Count == 0)
         {
-            _sawmill.Warning("No events were available to run!");
+            Log.Warning("No events were available to run!");
             return null;
         }
 
@@ -94,7 +90,7 @@ public sealed class EventManagerSystem : EntitySystem
             }
         }
 
-        _sawmill.Error("Event was not found after weighted pick process!");
+        Log.Error("Event was not found after weighted pick process!");
         return null;
     }
 
@@ -118,7 +114,7 @@ public sealed class EventManagerSystem : EntitySystem
         {
             if (CanRun(proto, stationEvent, playerCount, currentTime))
             {
-                _sawmill.Debug($"Adding event {proto.ID} to possibilities");
+                Log.Debug($"Adding event {proto.ID} to possibilities");
                 result.Add(proto, stationEvent);
             }
         }

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -41,13 +41,10 @@ namespace Content.Server.VendingMachines
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly AdvertiseSystem _advertise = default!;
 
-        private ISawmill _sawmill = default!;
-
         public override void Initialize()
         {
             base.Initialize();
 
-            _sawmill = Logger.GetSawmill("vending");
             SubscribeLocalEvent<VendingMachineComponent, MapInitEvent>(OnComponentMapInit);
             SubscribeLocalEvent<VendingMachineComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<VendingMachineComponent, BreakageEventArgs>(OnBreak);
@@ -86,7 +83,7 @@ namespace Content.Server.VendingMachines
             {
                 if (!PrototypeManager.TryIndex<EntityPrototype>(entry.ID, out var proto))
                 {
-                    _sawmill.Error($"Unable to find entity prototype {entry.ID} on {ToPrettyString(uid)} vending.");
+                    Log.Error($"Unable to find entity prototype {entry.ID} on {ToPrettyString(uid)} vending.");
                     continue;
                 }
 
@@ -193,7 +190,7 @@ namespace Content.Server.VendingMachines
 
             if (!TryComp<VendingMachineRestockComponent>(args.Args.Used, out var restockComponent))
             {
-                _sawmill.Error($"{ToPrettyString(args.Args.User)} tried to restock {ToPrettyString(uid)} with {ToPrettyString(args.Args.Used.Value)} which did not have a VendingMachineRestockComponent.");
+                Log.Error($"{ToPrettyString(args.Args.User)} tried to restock {ToPrettyString(uid)} with {ToPrettyString(args.Args.Used.Value)} which did not have a VendingMachineRestockComponent.");
                 return;
             }
 

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -35,8 +35,6 @@ public abstract class SharedAnomalySystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-    private ISawmill _sawmill = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -45,8 +43,6 @@ public abstract class SharedAnomalySystem : EntitySystem
         SubscribeLocalEvent<AnomalyComponent, AttackedEvent>(OnAttacked);
         SubscribeLocalEvent<AnomalyComponent, MeleeThrowOnHitStartEvent>(OnAnomalyThrowStart);
         SubscribeLocalEvent<AnomalyComponent, MeleeThrowOnHitEndEvent>(OnAnomalyThrowEnd);
-
-        _sawmill = Logger.GetSawmill("anomaly");
     }
 
     private void OnInteractHand(EntityUid uid, AnomalyComponent component, InteractHandEvent args)
@@ -98,7 +94,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         component.NextPulseTime = Timing.CurTime + GetPulseLength(component) * variation;
 
         if (_net.IsServer)
-            _sawmill.Info($"Performing anomaly pulse. Entity: {ToPrettyString(uid)}");
+            Log.Info($"Performing anomaly pulse. Entity: {ToPrettyString(uid)}");
 
         // if we are above the growth threshold, then grow before the pulse
         if (component.Stability > component.GrowthThreshold)
@@ -135,7 +131,7 @@ public abstract class SharedAnomalySystem : EntitySystem
 
         AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(uid)} began to go supercritical.");
         if (_net.IsServer)
-            _sawmill.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(uid)}");
+            Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(uid)}");
 
         var super = AddComp<AnomalySupercriticalComponent>(uid);
         super.EndTime = Timing.CurTime + super.SupercriticalDuration;
@@ -161,7 +157,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         Audio.PlayPvs(component.SupercriticalSound, uid);
 
         if (_net.IsServer)
-            _sawmill.Info($"Raising supercritical event. Entity: {ToPrettyString(uid)}");
+            Log.Info($"Raising supercritical event. Entity: {ToPrettyString(uid)}");
 
         var ev = new AnomalySupercriticalEvent(uid);
         RaiseLocalEvent(uid, ref ev, true);
@@ -179,8 +175,9 @@ public abstract class SharedAnomalySystem : EntitySystem
     {
         // Logging before resolve, in case the anomaly has deleted itself.
         if (_net.IsServer)
-            _sawmill.Info($"Ending anomaly. Entity: {ToPrettyString(uid)}");
-        AdminLog.Add(LogType.Anomaly, LogImpact.Extreme, $"Anomaly {ToPrettyString(uid)} went supercritical.");
+            Log.Info($"Ending anomaly. Entity: {ToPrettyString(uid)}");
+        AdminLog.Add(LogType.Anomaly, supercritical ? LogImpact.High : LogImpact.Low,
+                     $"Anomaly {ToPrettyString(uid)} {(supercritical ? "went supercritical" : "decayed")}.");
 
         if (!Resolve(uid, ref component))
             return;

--- a/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
+++ b/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
@@ -13,7 +13,6 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    private ISawmill _sawmill = default!;
 
     public const string InvokedPort = "link_port";
 
@@ -25,7 +24,6 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
         SubscribeLocalEvent<DeviceLinkSinkComponent, ComponentStartup>(OnSinkStartup);
         SubscribeLocalEvent<DeviceLinkSourceComponent, ComponentRemove>(OnSourceRemoved);
         SubscribeLocalEvent<DeviceLinkSinkComponent, ComponentRemove>(OnSinkRemoved);
-        _sawmill = Logger.GetSawmill("devicelink");
     }
 
     #region Link Validation
@@ -386,12 +384,12 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
 
         if (sourceComponent == null)
         {
-            _sawmill.Error($"Attempted to remove link between {ToPrettyString(sourceUid)} and {ToPrettyString(sinkUid)}, but the source component was missing.");
+            Log.Error($"Attempted to remove link between {ToPrettyString(sourceUid)} and {ToPrettyString(sinkUid)}, but the source component was missing.");
             sinkComponent!.LinkedSources.Remove(sourceUid);
         }
         else
         {
-            _sawmill.Error($"Attempted to remove link between {ToPrettyString(sourceUid)} and {ToPrettyString(sinkUid)}, but the sink component was missing.");
+            Log.Error($"Attempted to remove link between {ToPrettyString(sourceUid)} and {ToPrettyString(sinkUid)}, but the sink component was missing.");
             sourceComponent.LinkedPorts.Remove(sourceUid);
         }
     }

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -18,13 +18,9 @@ public sealed class ThirstSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedJetpackSystem _jetpack = default!;
 
-    private ISawmill _sawmill = default!;
-
     public override void Initialize()
     {
         base.Initialize();
-
-        _sawmill = Logger.GetSawmill("thirst");
 
         SubscribeLocalEvent<ThirstComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<ThirstComponent, MapInitEvent>(OnMapInit);
@@ -156,7 +152,7 @@ public sealed class ThirstSystem : EntitySystem
                 return;
 
             default:
-                _sawmill.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
+                Log.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
                 throw new ArgumentOutOfRangeException($"No thirst threshold found for {component.CurrentThirstThreshold}");
         }
     }


### PR DESCRIPTION
## Mirror of  PR #26216: [Unify `Content`'s `EntitySystem` logging](https://github.com/space-wizards/space-station-14/pull/26216) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `eeaea6c25b496106eb741e93738f2ab8503949ba`

PR opened by <img src="https://avatars.githubusercontent.com/u/27449516?v=4" width="16"/><a href="https://github.com/LordCarve"> LordCarve</a> at 2024-03-17 20:05:08 UTC

---

PR changed 13 files with 43 additions and 82 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Log things via `Log` with generated sawmill name rather than an explicitly set one for all Content `EntitySystem`s, except the ones with `Rule`s. In all cases the explicit `_sawmill` was redundant.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> - Bringing consistency to logs (all logs originating from `EntitySystem` should be recognizible in the logs `system.something`).
> - Logs' sawmills match system class name to assist with debugging.
> - Less likelihood of someone building a new `EntitySystem` to copy-paste the unnecessary `_sawmill` and instaed use the appropriate inherited `Log` instead.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> This addresses **_just_** `Content`'s `EntitySystem`s.
> 
> `GameRuleSystem` **and all classes inheriting from it are excluded.** I want to include both the calling system name and the rule name in the sawmill name - this however requires engine changes. I thus opted to cut out that part and made this a `Content`-only PR.
> 
> Also, even with the rule changes, the `GameRule`s themselves will be excluded pending antag refactor, because currently they are a _hot-hot_ mess and I'm sure it's preferable by everyone for me to wait for it to cool down before introducing merge conflicts unnecessarily.
> 
> Log Sawmill changes:
> **System class | current master sawmill | this PR's sawmill**
> `VaporSystem.cs`: `vapor` -> `system.vapor`
> `DeviceListSystem.cs`: `devicelist` -> `system.device_list`
> `ForensicScannerSystem.cs`: `forensic.scanner` -> `system.forensic_scanner`
> `MappingSystem.cs`: `autosave` -> `system.mapping`
> `MechSystem.cs`: `mech` -> `system.mech`
> `LagCompensationSystem.cs`: `lagcomp` -> `system.lag_compensation`
> `NpcFactionSystem.cs`: `faction` -> `system.npc_faction`
> `EmergencyShuttleSystem.cs`: `shuttle.emergency` -> `system.emergency_shuttle`
> `EventManagerSystem.cs`: `events` -> `system.event_manager`
> `VendingMachineSystem.cs`: `vending` -> `system.vending_machine`
> `SharedAnomalySystem.cs`: `anomaly` -> `system.anomaly`
> `SharedDeviceLinkSystem.cs`: `devicelink` -> `system.device_link`
> `ThirstSystem.cs`: `thirst` -> `system.thirst`
> 
> Manually tested most (all that I had doubts about) and confirmed that `LagCompensationSystem`'s `Log.Level` is getting correctly set like this.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> Log sawmill name changes. Any analyzers/other software that processes logs needs to be adjusted to new sawmills. Full list of changes in PR - section Technical details.


</details>