### PR TITLE
Mirror: Fixed safe filling with WT550

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -283,7 +283,7 @@
     contents:
     - id: WeaponSubMachineGunWt550
       amount: 2
-    - id: MagazinePistolSubMachineGun
+    - id: MagazinePistolSubMachineGunTopMounted
       amount: 4
 
 - type: entity


### PR DESCRIPTION
## Mirror of  PR #26208: [Fixed safe filling with WT550](https://github.com/space-wizards/space-station-14/pull/26208) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `597107c4314f001e1026fd02db33749492c5a62c`

PR opened by <img src="https://avatars.githubusercontent.com/u/117393350?v=4" width="16"/><a href="https://github.com/HappyRoach"> HappyRoach</a> at 2024-03-17 14:10:47 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Fixed filling of WT550 safes 
> 
> ## Why / Balance
> 
> The WT550 requires a different type of magazine, which was clearly not noticed when creating safes. Therefore, what is now in safes is simply not suitable for the WT550.
> 
> ## Media
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> 
> **Changelog**
> :cl:
> - fix: The correct magazines now appear in the WT550 safe.
> 


</details>