### PR TITLE
Mirror: Include bans in adminremarks command

### DIFF
--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -1368,6 +1368,8 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
                     .Include(note => note.Player)
                     .ToListAsync()).Select(MakeAdminNoteRecord));
             notesCol.AddRange(await GetMessagesImpl(db, player));
+            notesCol.AddRange(await GetServerBansAsNotesForUser(db, player));
+            notesCol.AddRange(await GetGroupedServerRoleBansAsNotesForUser(db, player));
             return notesCol;
         }
 


### PR DESCRIPTION
## Mirror of  PR #26240: [Include bans in adminremarks command](https://github.com/space-wizards/space-station-14/pull/26240) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f55c98ce6d1dfdc14a293f2559647372203938af`

PR opened by <img src="https://avatars.githubusercontent.com/u/8107459?v=4" width="16"/><a href="https://github.com/PJB3005"> PJB3005</a> at 2024-03-18 17:50:15 UTC

---

PR changed 1 files with 2 additions and 0 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Fixes #20645
> 
> :cl:
> - add: Bans are now shown in the "adminremarks" command.


</details>