### PR TITLE
Mirror: Fix SCRAM implant not working while cuffed. Incidentally fix freedom implant working while dead/crit

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -95,6 +95,7 @@ namespace Content.Client.Actions
             component.Container = EnsureEntity<T>(state.Container, uid);
             component.EntityIcon = EnsureEntity<T>(state.EntityIcon, uid);
             component.CheckCanInteract = state.CheckCanInteract;
+            component.CheckConsciousness = state.CheckConsciousness;
             component.ClientExclusive = state.ClientExclusive;
             component.Priority = state.Priority;
             component.AttachedEntity = EnsureEntity<T>(state.AttachedEntity, uid);

--- a/Content.Server/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Server/Bed/Sleep/SleepingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Slippery;
@@ -45,6 +46,7 @@ namespace Content.Server.Bed.Sleep
             SubscribeLocalEvent<SleepingComponent, InteractHandEvent>(OnInteractHand);
             SubscribeLocalEvent<SleepingComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<SleepingComponent, SlipAttemptEvent>(OnSlip);
+            SubscribeLocalEvent<SleepingComponent, ConsciousAttemptEvent>(OnConsciousAttempt);
             SubscribeLocalEvent<ForcedSleepingComponent, ComponentInit>(OnInit);
         }
 
@@ -172,6 +174,12 @@ namespace Content.Server.Bed.Sleep
         {
             args.Cancel();
         }
+
+        private void OnConsciousAttempt(EntityUid uid, SleepingComponent component, ConsciousAttemptEvent args)
+        {
+            args.Cancel();
+        }
+
 
         private void OnInit(EntityUid uid, ForcedSleepingComponent component, ComponentInit args)
         {

--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Body.Events;
 using Content.Shared.DragDrop;
 using Content.Shared.Emoting;
@@ -5,6 +6,8 @@ using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Speech;
@@ -67,6 +70,9 @@ namespace Content.Shared.ActionBlocker
         /// <returns></returns>
         public bool CanInteract(EntityUid user, EntityUid? target)
         {
+            if (!CanConsciouslyPerformAction(user))
+                return false;
+
             var ev = new InteractionAttemptEvent(user, target);
             RaiseLocalEvent(user, ev);
 
@@ -93,6 +99,21 @@ namespace Content.Shared.ActionBlocker
         public bool CanUseHeldEntity(EntityUid user)
         {
             var ev = new UseAttemptEvent(user);
+            RaiseLocalEvent(user, ev);
+
+            return !ev.Cancelled;
+        }
+
+
+        /// <summary>
+        /// Whether a user conscious to perform an action.
+        /// </summary>
+        /// <remarks>
+        /// This should be used when you want a much more permissive check than <see cref="CanInteract"/>
+        /// </remarks>
+        public bool CanConsciouslyPerformAction(EntityUid user)
+        {
+            var ev = new ConsciousAttemptEvent(user);
             RaiseLocalEvent(user, ev);
 
             return !ev.Cancelled;

--- a/Content.Shared/Actions/BaseActionComponent.cs
+++ b/Content.Shared/Actions/BaseActionComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Audio;
+﻿using Content.Shared.Mobs;
+using Robust.Shared.Audio;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -119,6 +120,12 @@ public abstract partial class BaseActionComponent : Component
     [DataField("checkCanInteract")] public bool CheckCanInteract = true;
 
     /// <summary>
+    /// Whether to check if the user is conscious or not. Can be used instead of <see cref="CheckCanInteract"/>
+    /// for a more permissive check.
+    /// </summary>
+    [DataField] public bool CheckConsciousness = true;
+
+    /// <summary>
     ///     If true, this will cause the action to only execute locally without ever notifying the server.
     /// </summary>
     [DataField("clientExclusive")] public bool ClientExclusive = false;
@@ -177,6 +184,7 @@ public abstract class BaseActionComponentState : ComponentState
     public NetEntity? Container;
     public NetEntity? EntityIcon;
     public bool CheckCanInteract;
+    public bool CheckConsciousness;
     public bool ClientExclusive;
     public int Priority;
     public NetEntity? AttachedEntity;
@@ -204,6 +212,7 @@ public abstract class BaseActionComponentState : ComponentState
         MaxCharges = component.MaxCharges;
         RenewCharges = component.RenewCharges;
         CheckCanInteract = component.CheckCanInteract;
+        CheckConsciousness = component.CheckConsciousness;
         ClientExclusive = component.ClientExclusive;
         Priority = component.Priority;
         AutoPopulate = component.AutoPopulate;

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mind;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
@@ -369,6 +370,9 @@ public abstract class SharedActionsSystem : EntitySystem
             ResetCharges(actionEnt);
 
         BaseActionEvent? performEvent = null;
+
+        if (action.CheckConsciousness && !_actionBlockerSystem.CanConsciouslyPerformAction(user))
+            return;
 
         // Validate request by checking action blockers and the like:
         switch (action)

--- a/Content.Shared/Interaction/Events/InteractionAttemptEvent.cs
+++ b/Content.Shared/Interaction/Events/InteractionAttemptEvent.cs
@@ -16,6 +16,14 @@
     }
 
     /// <summary>
+    /// Raised to determine whether an entity is conscious to perform an action.
+    /// </summary>
+    public sealed class ConsciousAttemptEvent(EntityUid Uid) : CancellableEntityEventArgs
+    {
+        public EntityUid Uid { get; } = Uid;
+    }
+
+    /// <summary>
     ///     Event raised directed at the target entity of an interaction to see if the user is allowed to perform some
     ///     generic interaction.
     /// </summary>

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -28,7 +28,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, ChangeDirectionAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UseAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, AttackAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, InteractionAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, ConsciousAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, ThrowAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, SpeakAttemptEvent>(OnSpeakAttempt);
         SubscribeLocalEvent<MobStateComponent, IsEquippingAttemptEvent>(OnEquipAttempt);

--- a/Resources/Prototypes/Actions/crit.yml
+++ b/Resources/Prototypes/Actions/crit.yml
@@ -1,4 +1,4 @@
-﻿# Actions added to mobs in crit.
+# Actions added to mobs in crit.
 - type: entity
   id: ActionCritSuccumb
   name: Succumb
@@ -8,6 +8,7 @@
   - type: InstantAction
     itemIconStyle: NoItem
     checkCanInteract: false
+    checkConsciousness: false
     icon:
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
@@ -22,6 +23,7 @@
   - type: InstantAction
     itemIconStyle: NoItem
     checkCanInteract: false
+    checkConsciousness: false
     icon:
       sprite: Interface/Actions/actions_crit.rsi
       state: fakedeath
@@ -37,6 +39,7 @@
   - type: InstantAction
     itemIconStyle: NoItem
     checkCanInteract: false
+    checkConsciousness: false
     icon:
       sprite: Interface/Actions/actions_crit.rsi
       state: lastwords

--- a/Resources/Prototypes/Actions/diona.yml
+++ b/Resources/Prototypes/Actions/diona.yml
@@ -8,6 +8,7 @@
     icon: Mobs/Species/Diona/organs.rsi/brain.png
     event: !type:GibActionEvent {}
     checkCanInteract: false
+    checkConsciousness: false
 
 - type: entity
   id: DionaReformAction

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -29,6 +29,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     icon: Interface/Actions/zombie-turn.png
     event: !type:ZombifySelfActionEvent
 
@@ -66,6 +67,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     itemIconStyle: BigAction
     priority: -20
     icon:
@@ -82,6 +84,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     itemIconStyle: BigAction
     priority: -20
     icon:
@@ -143,6 +146,7 @@
   noSpawn: true
   components:
   - type: InstantAction
+    checkCanInteract: false
     charges: 2
     useDelay: 5
     itemIconStyle: BigAction
@@ -186,6 +190,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     icon: Interface/Actions/harmOff.png
     iconOn: Interface/Actions/harm.png
     event: !type:ToggleCombatActionEvent
@@ -256,6 +261,7 @@
   - type: InstantAction
     clientExclusive: true
     checkCanInteract: false
+    checkConsciousness: false
     temporary: true
     icon: { sprite: Objects/Tools/multitool.rsi, state: icon }
     event: !type:ClearAllOverlaysEvent
@@ -279,6 +285,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
     event: !type:SleepActionEvent
 
@@ -291,6 +298,7 @@
   - type: InstantAction
     icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
     checkCanInteract: false
+    checkConsciousness: false
     event: !type:WakeActionEvent
 
 - type: entity
@@ -328,6 +336,7 @@
     event: !type:ToggleEyesActionEvent
     useDelay: 1 # so u cant give yourself and observers eyestrain by rapidly spamming the action
     checkCanInteract: false
+    checkConsciousness: false
 
 - type: entity
   id: ActionToggleWagging

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -253,3 +253,4 @@
     event: !type:GuardianToggleActionEvent
     useDelay: 2
     checkCanInteract: false
+    checkConsciousness: false

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -138,6 +138,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
+    checkConsciousness: false
     icon: Interface/Actions/pai-midi.png
     event: !type:OpenUiActionEvent
       key: enum.InstrumentUiKey.Key
@@ -150,6 +151,7 @@
   components:
     - type: InstantAction
       checkCanInteract: false
+      checkConsciousness: false
       icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
       event: !type:OpenUiActionEvent
         key: enum.StationMapUiKey.Key

--- a/Resources/mapping_actions.yml
+++ b/Resources/mapping_actions.yml
@@ -3,6 +3,7 @@
       entity: ReinforcedWindow
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -17,6 +18,7 @@
       entity: WallSolid
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -31,6 +33,7 @@
       entity: WallReinforced
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -45,6 +48,7 @@
       entity: Window
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -59,6 +63,7 @@
       entity: Firelock
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -73,6 +78,7 @@
       entity: Grille
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -86,6 +92,7 @@
     icon: Interface/VerbIcons/delete.svg.192dpi.png
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -104,6 +111,7 @@
       entity: GasPipeStraight
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -118,6 +126,7 @@
       entity: GasPipeBend
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -132,6 +141,7 @@
       entity: GasPipeTJunction
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -146,6 +156,7 @@
       entity: GasPipeFourway
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -160,6 +171,7 @@
       entity: GasVentScrubber
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -174,6 +186,7 @@
       entity: GasVentPump
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -188,6 +201,7 @@
       entity: AirAlarm
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -202,6 +216,7 @@
       entity: FireAlarm
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -216,6 +231,7 @@
       entity: APCBasic
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -230,6 +246,7 @@
       entity: CableApcExtension
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -244,6 +261,7 @@
       entity: CableMV
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -258,6 +276,7 @@
       entity: CableHV
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -272,6 +291,7 @@
       entity: SubstationBasic
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -286,6 +306,7 @@
       entity: Poweredlight
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -300,6 +321,7 @@
       entity: EmergencyLight
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -314,6 +336,7 @@
       entity: SMESBasic
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -328,6 +351,7 @@
       entity: TableWood
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -342,6 +366,7 @@
       entity: Table
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -356,6 +381,7 @@
       entity: ChairWood
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -370,6 +396,7 @@
       entity: Chair
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -384,6 +411,7 @@
       entity: ChairOfficeLight
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -398,6 +426,7 @@
       entity: StoolBar
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -412,6 +441,7 @@
       entity: Stool
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -426,6 +456,7 @@
       entity: Rack
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -440,6 +471,7 @@
       entity: ChairOfficeDark
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -454,6 +486,7 @@
       entity: LampGold
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -468,6 +501,7 @@
       entity: DisposalPipe
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -482,6 +516,7 @@
       entity: DisposalBend
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -496,6 +531,7 @@
       entity: DisposalJunction
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -510,6 +546,7 @@
       entity: DisposalJunctionFlipped
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -524,6 +561,7 @@
       entity: DisposalRouter
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -538,6 +576,7 @@
       entity: DisposalRouterFlipped
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -552,6 +591,7 @@
       entity: DisposalUnit
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -566,6 +606,7 @@
       entity: DisposalTrunk
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -580,6 +621,7 @@
       entity: SignDisposalSpace
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -594,6 +636,7 @@
       entity: Windoor
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -608,6 +651,7 @@
       entity: WindowDirectional
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -622,6 +666,7 @@
       entity: WindowReinforcedDirectional
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -636,6 +681,7 @@
       entity: PlasmaWindowDirectional
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -650,6 +696,7 @@
       entity: Railing
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -664,6 +711,7 @@
       entity: RailingCorner
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -678,6 +726,7 @@
       entity: RailingCornerSmall
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -693,6 +742,7 @@
     name: RailingRound
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -706,6 +756,7 @@
       entity: AirlockMaintLocked
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -720,6 +771,7 @@
       entity: AirlockGlass
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -734,6 +786,7 @@
       entity: AirlockServiceLocked
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -748,6 +801,7 @@
       entity: AirlockSecurityLocked
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -762,6 +816,7 @@
       entity: AirlockCommand
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -776,6 +831,7 @@
       entity: AirlockScience
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -790,6 +846,7 @@
       entity: AirlockMedical
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -804,6 +861,7 @@
       entity: AirlockEngineering
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -818,6 +876,7 @@
       entity: AirlockCargo
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -837,6 +896,7 @@
       state: bot_left
     iconColor: '#EFB34196'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -857,6 +917,7 @@
       state: delivery
     iconColor: '#EFB34196'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -877,6 +938,7 @@
       state: warn_full
     iconColor: '#EFB34196'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -897,6 +959,7 @@
       state: halftile_overlay
     iconColor: '#EFB34196'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -917,6 +980,7 @@
       state: halftile_overlay
     iconColor: '#334E6DC8'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -937,6 +1001,7 @@
       state: halftile_overlay
     iconColor: '#52B4E996'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -957,6 +1022,7 @@
       state: halftile_overlay
     iconColor: '#9FED5896'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -977,6 +1043,7 @@
       state: halftile_overlay
     iconColor: '#DE3A3A96'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -997,6 +1064,7 @@
       state: halftile_overlay
     iconColor: '#D381C996'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -1017,6 +1085,7 @@
       state: halftile_overlay
     iconColor: '#A4610696'
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -1031,6 +1100,7 @@
     icon: /Textures/Tiles/steel.png
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -1044,6 +1114,7 @@
     icon: /Textures/Tiles/plating.png
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True
@@ -1059,6 +1130,7 @@
     icon: /Textures/Tiles/cropped_parallax.png
     keywords: []
     checkCanInteract: False
+    checkConsciousness: False
     clientExclusive: True
     autoPopulate: False
     temporary: True


### PR DESCRIPTION
## Mirror of  PR #25978: [Fix SCRAM implant not working while cuffed. Incidentally fix freedom implant working while dead/crit](https://github.com/space-wizards/space-station-14/pull/25978) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `22e9d6562f21bdd4f0962d6e3b6fcdd81bb4c253`

PR opened by <img src="https://avatars.githubusercontent.com/u/32041239?v=4" width="16"/><a href="https://github.com/nikthechampiongr"> nikthechampiongr</a> at 2024-03-10 19:33:05 UTC

---

PR changed 13 files with 142 additions and 3 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> fixes #25662 
> 
> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> This pr makes it so you can use the SCRAM implant while cuffed. Also fixes the freedom implant working while you are in crit, or even dead.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> The implant is made so you can escape horrible situations. It should as such work while in crit.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> ActionBlockers now has a specific check to see if someone is conscious. It is also used in the Interaction check now. Actions can now use that check if the bool is set. The bool is now set for the freedom and SCRAM!  implant actions. Additionally the SCRAM! action now ignores whether the user can interact in order to be able to use it while cuffed.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> fix: You can now use the SCRAM! implant while cuffed.
> fix: The freedom implant can no longer be used while in crit, or dead.


</details>