### PR TITLE
Mirror: make traitor syndicate reinforcements get the traitor role

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -9,9 +9,9 @@
 #Syndie
 - type: entity
   parent: MobHuman
-  id: MobHumanSyndicateAgent
+  id: MobHumanSyndicateAgentBase
   name: syndicate agent
-  suffix: Human
+  suffix: Human, Base
   components:
     - type: Loadout
       prototypes: [SyndicateOperativeGearExtremelyBasic]
@@ -22,9 +22,20 @@
       - Syndicate
 
 - type: entity
-  parent: MobHumanSyndicateAgent
+  parent: MobHumanSyndicateAgentBase
+  id: MobHumanSyndicateAgent
+  name: syndicate agent
+  suffix: Human, Traitor
+  components:
+    # make the player a traitor once its taken
+    - type: AutoTraitor
+      giveUplink: false
+      giveObjectives: false
+
+- type: entity
+  parent: MobHumanSyndicateAgentBase
   id: MobHumanSyndicateAgentNukeops # Reinforcement exclusive to nukeops uplink
-  suffix: NukeOps
+  suffix: Human, NukeOps
   components:
     - type: NukeOperative
 


### PR DESCRIPTION
## Mirror of  PR #25400: [make traitor syndicate reinforcements get the traitor role](https://github.com/space-wizards/space-station-14/pull/25400) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `a7d95c3b13bfa64fe08a8f855515cdc1d258808a`

PR opened by <img src="https://avatars.githubusercontent.com/u/45323883?v=4" width="16"/><a href="https://github.com/Dutch-VanDerLinde"> Dutch-VanDerLinde</a> at 2024-02-20 00:35:08 UTC

---

PR changed 1 files with 15 additions and 4 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> traitor syndie reinforcements get the autotraitor component, like traitor syndie monkies
> 
> ## Why / Balance
> syndie monkies can see the codewords, so why cant the more expensive human reinforcement see the codewords aswell?
> this also makes it so they are listed as an antag with admin vision
> 
> 
> ## Technical details
> made syndicate base for human reinforcement
> ![image](https://github.com/space-wizards/space-station-14/assets/45323883/4959010a-b867-4563-aa74-7232931f298c)
> 
> gives traitor reinforcement the autotraitor component
> 
> ## Media
> https://github.com/space-wizards/space-station-14/assets/45323883/5ada01f9-d098-46e5-baea-487e2215ba58
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> no
> 
> **Changelog**
> no
> 


</details>