### PR TITLE
Mirror: Fix EFCore obsoletion warnings in Content.Server.Database

### DIFF
--- a/Content.Server.Database/SnakeCaseNaming.cs
+++ b/Content.Server.Database/SnakeCaseNaming.cs
@@ -301,14 +301,14 @@ namespace Content.Server.Database
         private static void RewriteColumnName(IConventionPropertyBuilder propertyBuilder)
         {
             var property = propertyBuilder.Metadata;
-            var entityType = property.DeclaringEntityType;
+            var entityType = (IConventionEntityType)property.DeclaringType;
 
             if (entityType.ClrType == typeof(Microsoft.EntityFrameworkCore.Migrations.HistoryRow))
                 return;
 
             property.Builder.HasNoAnnotation(RelationalAnnotationNames.ColumnName);
 
-            var baseColumnName = StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } tableIdentifier
+            var baseColumnName = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table) is { } tableIdentifier
                 ? property.GetDefaultColumnName(tableIdentifier)
                 : property.GetDefaultColumnName();
 


### PR DESCRIPTION
## Mirror of  PR #26285: [Fix EFCore obsoletion warnings in Content.Server.Database](https://github.com/space-wizards/space-station-14/pull/26285) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `fc76996dc55b19b313b621b2fb9025b9198e4b7d`

PR opened by <img src="https://avatars.githubusercontent.com/u/8107459?v=4" width="16"/><a href="https://github.com/PJB3005"> PJB3005</a> at 2024-03-20 11:47:51 UTC

---

PR changed 1 files with 2 additions and 2 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> 


</details>