### PR TITLE
Mirror: Pizza is not a fruit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -29,7 +29,7 @@
   - type: Tag
     tags:
     - Pizza
-    - Fruit # Tomato? idk
+    - ReptilianFood
 
 - type: entity
   parent: FoodInjectableBase # Not sliceable
@@ -58,7 +58,7 @@
   - type: Tag
     tags:
     - Pizza
-    - Fruit
+    - ReptilianFood
 
 # Pizza
 


### PR DESCRIPTION
## Mirror of  PR #26293: [Pizza is not a fruit](https://github.com/space-wizards/space-station-14/pull/26293) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `1200d406cada06abdbd068a962716ca8c021f506`

PR opened by <img src="https://avatars.githubusercontent.com/u/85356?v=4" width="16"/><a href="https://github.com/Tayrtahn"> Tayrtahn</a> at 2024-03-20 16:41:16 UTC

---

PR changed 1 files with 2 additions and 2 deletions.

The PR had the following labels:
- No C#
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Pizza no longer qualifies as fruit.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Pizza being considered a fruit has been causing integration test failures because the FoodPizzaLarge cargo order contains 16 random pizzas, and a cargo bounty for fruits was recently added (#26160).
> 
> The base pizza has the Fruit tag, so any types of pizza that don't override the Tag component also count as fruit. The ones that do override the tags don't add Fruit back in (but typically add Meat), so they're not considered fruit. Because the cargo order gives a random set of pizzas, _sometimes_ there are enough considered fruit that it triggers the test failure.
> 
> The fruit tag was added to pizzas by #20328, to enable lizards to eat pizzas (because tomatoes). I appreciate that lizards need food to eat, but this tag usage feels weird. Maybe there should be a "ContainsFruit" tag?
> Edit: Added ReptilianFood tag.
> 
> (And yes, go ahead and make jokes about the US ruling that pizza can be considered a vegetable, and the whole "tomatoes are fruit" thing)
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Removed the Fruit tag from FoodPizzaBase and FoodPizzaSliceBase. Added ReptilianFood tag to both instead.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - tweak: Pizza is no longer considered a fruit.


</details>