### PR TITLE
Mirror: fix legally distinct visor man plush name.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1196,7 +1196,7 @@
 - type: entity
   parent: BasePlushie
   id: ToyAmongPequeno
-  name: among pequeno
+  name: among pequeño
   description: sus!
   components:
   - type: Sprite


### PR DESCRIPTION
## Mirror of  PR #26299: [fix legally distinct visor man plush name.](https://github.com/space-wizards/space-station-14/pull/26299) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `b06d40e8531250b2e7e391ea02e5c17e219a343a`

PR opened by <img src="https://avatars.githubusercontent.com/u/8107459?v=4" width="16"/><a href="https://github.com/PJB3005"> PJB3005</a> at 2024-03-21 01:33:59 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> am in vr. approved by real spaniard.
> 
> 


</details>