### PR TITLE
Mirror: Added verb action to Glue/Lube system

### DIFF
--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Item;
 using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 
@@ -21,6 +22,7 @@ public sealed class GlueSystem : SharedGlueSystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly OpenableSystem _openable = default!;
 
     public override void Initialize()
     {
@@ -28,6 +30,7 @@ public sealed class GlueSystem : SharedGlueSystem
 
         SubscribeLocalEvent<GlueComponent, AfterInteractEvent>(OnInteract, after: new[] { typeof(OpenableSystem) });
         SubscribeLocalEvent<GluedComponent, ComponentInit>(OnGluedInit);
+        SubscribeLocalEvent<GlueComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
         SubscribeLocalEvent<GluedComponent, GotEquippedHandEvent>(OnHandPickUp);
     }
 
@@ -41,35 +44,50 @@ public sealed class GlueSystem : SharedGlueSystem
             return;
 
         if (TryGlue(entity, target, args.User))
-        {
             args.Handled = true;
-            _audio.PlayPvs(entity.Comp.Squeeze, entity);
-            _popup.PopupEntity(Loc.GetString("glue-success", ("target", target)), args.User, args.User, PopupType.Medium);
-        }
-        else
-        {
-            _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), args.User, args.User, PopupType.Medium);
-        }
     }
 
-    private bool TryGlue(Entity<GlueComponent> glue, EntityUid target, EntityUid actor)
+    private void OnUtilityVerb(Entity<GlueComponent> entity, ref GetVerbsEvent<UtilityVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess || args.Target is not { Valid: true } target ||
+        _openable.IsClosed(entity))
+            return;
+
+        var user = args.User;
+
+        var verb = new UtilityVerb()
+        {
+            Act = () => TryGlue(entity, target, user),
+            IconEntity = GetNetEntity(entity),
+            Text = Loc.GetString("glue-verb-text"),
+            Message = Loc.GetString("glue-verb-message")
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private bool TryGlue(Entity<GlueComponent> entity, EntityUid target, EntityUid actor)
     {
         // if item is glued then don't apply glue again so it can be removed for reasonable time
         if (HasComp<GluedComponent>(target) || !HasComp<ItemComponent>(target))
         {
+            _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
             return false;
         }
 
-        if (HasComp<ItemComponent>(target) && _solutionContainer.TryGetSolution(glue.Owner, glue.Comp.Solution, out _, out var solution))
+        if (HasComp<ItemComponent>(target) && _solutionContainer.TryGetSolution(entity.Owner, entity.Comp.Solution, out _, out var solution))
         {
-            var quantity = solution.RemoveReagent(glue.Comp.Reagent, glue.Comp.ConsumptionUnit);
+            var quantity = solution.RemoveReagent(entity.Comp.Reagent, entity.Comp.ConsumptionUnit);
             if (quantity > 0)
             {
-                EnsureComp<GluedComponent>(target).Duration = quantity.Double() * glue.Comp.DurationPerUnit;
-                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} glued {ToPrettyString(target):subject} with {ToPrettyString(glue.Owner):tool}");
+                EnsureComp<GluedComponent>(target).Duration = quantity.Double() * entity.Comp.DurationPerUnit;
+                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} glued {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
+                _audio.PlayPvs(entity.Comp.Squeeze, entity.Owner);
+                _popup.PopupEntity(Loc.GetString("glue-success", ("target", target)), actor, actor, PopupType.Medium);
                 return true;
             }
         }
+        _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
         return false;
     }
 

--- a/Content.Server/Lube/LubeSystem.cs
+++ b/Content.Server/Lube/LubeSystem.cs
@@ -2,11 +2,13 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Database;
+using Content.Shared.Glue;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Lube;
 using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Random;
@@ -20,12 +22,14 @@ public sealed class LubeSystem : EntitySystem
     [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly OpenableSystem _openable = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<LubeComponent, AfterInteractEvent>(OnInteract, after: new[] { typeof(OpenableSystem) });
+        SubscribeLocalEvent<LubeComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
     }
 
     private void OnInteract(Entity<LubeComponent> entity, ref AfterInteractEvent args)
@@ -37,36 +41,51 @@ public sealed class LubeSystem : EntitySystem
             return;
 
         if (TryLube(entity, target, args.User))
-        {
             args.Handled = true;
-            _audio.PlayPvs(entity.Comp.Squeeze, entity);
-            _popup.PopupEntity(Loc.GetString("lube-success", ("target", Identity.Entity(target, EntityManager))), args.User, args.User, PopupType.Medium);
-        }
-        else
-        {
-            _popup.PopupEntity(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), args.User, args.User, PopupType.Medium);
-        }
     }
 
-    private bool TryLube(Entity<LubeComponent> lube, EntityUid target, EntityUid actor)
+    private void OnUtilityVerb(Entity<LubeComponent> entity, ref GetVerbsEvent<UtilityVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess || args.Target is not { Valid: true } target ||
+        _openable.IsClosed(entity))
+            return;
+
+        var user = args.User;
+
+        var verb = new UtilityVerb()
+        {
+            Act = () => TryLube(entity, target, user),
+            IconEntity = GetNetEntity(entity),
+            Text = Loc.GetString("lube-verb-text"),
+            Message = Loc.GetString("lube-verb-message")
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private bool TryLube(Entity<LubeComponent> entity, EntityUid target, EntityUid actor)
     {
         if (HasComp<LubedComponent>(target) || !HasComp<ItemComponent>(target))
         {
+            _popup.PopupEntity(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
             return false;
         }
 
-        if (HasComp<ItemComponent>(target) && _solutionContainer.TryGetSolution(lube.Owner, lube.Comp.Solution, out _, out var solution))
+        if (HasComp<ItemComponent>(target) && _solutionContainer.TryGetSolution(entity.Owner, entity.Comp.Solution, out _, out var solution))
         {
-            var quantity = solution.RemoveReagent(lube.Comp.Reagent, lube.Comp.Consumption);
+            var quantity = solution.RemoveReagent(entity.Comp.Reagent, entity.Comp.Consumption);
             if (quantity > 0)
             {
                 var lubed = EnsureComp<LubedComponent>(target);
-                lubed.SlipsLeft = _random.Next(lube.Comp.MinSlips * quantity.Int(), lube.Comp.MaxSlips * quantity.Int());
-                lubed.SlipStrength = lube.Comp.SlipStrength;
-                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} lubed {ToPrettyString(target):subject} with {ToPrettyString(lube.Owner):tool}");
+                lubed.SlipsLeft = _random.Next(entity.Comp.MinSlips * quantity.Int(), entity.Comp.MaxSlips * quantity.Int());
+                lubed.SlipStrength = entity.Comp.SlipStrength;
+                _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} lubed {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
+                _audio.PlayPvs(entity.Comp.Squeeze, entity.Owner);
+                _popup.PopupEntity(Loc.GetString("lube-success", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
                 return true;
             }
         }
+        _popup.PopupEntity(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
         return false;
     }
 }

--- a/Resources/Locale/en-US/glue/glue.ftl
+++ b/Resources/Locale/en-US/glue/glue.ftl
@@ -1,3 +1,6 @@
 glue-success = {THE($target)} has been covered in glue!
 glued-name-prefix = Glued {$target}
 glue-failure = Can't cover {THE($target)} in glue!
+glue-verb-text = Apply Glue
+glue-verb-message = Glue an object
+

--- a/Resources/Locale/en-US/lube/lube.ftl
+++ b/Resources/Locale/en-US/lube/lube.ftl
@@ -2,3 +2,5 @@ lube-success = {THE($target)} has been covered in lube!
 lubed-name-prefix = Lubed {$target}
 lube-failure = Can't cover {THE($target)} in lube!
 lube-slip = {THE($target)} slips out of your hands!
+lube-verb-text = Apply Lube
+lube-verb-message = Lube an object


### PR DESCRIPTION
## Mirror of  PR #26002: [Added verb action to Glue/Lube system](https://github.com/space-wizards/space-station-14/pull/26002) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `70c718f61cd952f49f6908107edfbeeb3b7e41e0`

PR opened by <img src="https://avatars.githubusercontent.com/u/83650252?v=4" width="16"/><a href="https://github.com/SlamBamActionman"> SlamBamActionman</a> at 2024-03-11 15:15:49 UTC

---

PR changed 4 files with 67 additions and 25 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> Added right-click Glue/Lube verbs (used by Space glue / lube tubes). This allows them to be used on containers and glasses.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> Attempting to glue/lube a container like a bag makes the insert verb take priority. Same for trying to glue/lube something like a glass, which empties the reagent into the container. That keeps those objects from being glued/lubed, but with a right-click verb it is now possible.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> Added a verb in each system using the Forensic Scanner verb implementation as a base. Had to move where the sound/pop-up message appears to avoid duplicating too much code. 
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> ![image](https://github.com/space-wizards/space-station-14/assets/83650252/7560e99b-5167-497a-9f7c-e9db391e06eb)![image](https://github.com/space-wizards/space-station-14/assets/83650252/749c950e-c091-4e35-9813-6fa95eb7fd54)
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - tweak: Space glue/lube tubes can now be used through the right-click menu.
> 


</details>