### PR TITLE
Mirror: Fix crash on load when no slot key assigned

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -42,11 +42,12 @@ public class ActionButtonContainer : GridContainer
         {
             var button = new ActionButton(_entity);
 
-            if (keys.TryGetValue(index, out var boundKey))
-            {
-                button.KeyBind = boundKey;
+            if (!keys.TryGetValue(index, out var boundKey))
+                return button;
 
-                var binding = _input.GetKeyBinding(boundKey);
+            button.KeyBind = boundKey;
+            if (_input.TryGetKeyBinding(boundKey, out var binding))
+            {
                 button.Label.Text = binding.GetKeyString();
             }
 


### PR DESCRIPTION
## Mirror of  PR #26354: [Fix crash on load when no slot key assigned](https://github.com/space-wizards/space-station-14/pull/26354) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `e69723153dc571e1461c99ac5c7d82a1992e011d`

PR opened by <img src="https://avatars.githubusercontent.com/u/81056464?v=4" width="16"/><a href="https://github.com/wrexbe"> wrexbe</a> at 2024-03-23 02:21:12 UTC

---

PR changed 1 files with 5 additions and 4 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> I fixed the game crashing if you don't have hotkeys assigned to the action bar slots when the game loads


</details>