### PR TITLE
Mirror: Restrict door remotes to only being able to manipulate doors relevant to their type

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -80,10 +80,8 @@ namespace Content.Server.Remotes
                 return;
             }
 
-            // Holding the door remote grants you access to the relevant doors IN ADDITION to what ever access you had.
-            // This access is enforced in _doorSystem.HasAccess when it calls _accessReaderSystem.IsAllowed
             if (TryComp<AccessReaderComponent>(args.Target, out var accessComponent)
-                && !_doorSystem.HasAccess(args.Target.Value, args.User, doorComp, accessComponent))
+                && !_doorSystem.HasAccess(args.Target.Value, args.Used, doorComp, accessComponent))
             {
                 _doorSystem.Deny(args.Target.Value, doorComp, args.User);
                 ShowPopupToUser("door-remote-denied", args.User);
@@ -93,10 +91,7 @@ namespace Content.Server.Remotes
             switch (component.Mode)
             {
                 case OperatingMode.OpenClose:
-                    // Note we provide args.User here to TryToggleDoor as the "user"
-                    // This means that the door will look at all access items carryed by the player for access, including
-                    // this remote, but also including anything else they are carrying such as a PDA or ID card.
-                    if (_doorSystem.TryToggleDoor(args.Target.Value, doorComp, args.User))
+                    if (_doorSystem.TryToggleDoor(args.Target.Value, doorComp, args.Used))
                         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)}: {doorComp.State}");
                     break;
                 case OperatingMode.ToggleBolts:
@@ -104,7 +99,7 @@ namespace Content.Server.Remotes
                     {
                         if (!boltsComp.BoltWireCut)
                         {
-                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, args.User);
+                            _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, args.Used);
                             _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
                         }
                     }


### PR DESCRIPTION
## Mirror of  PR #26371: [Restrict door remotes to only being able to manipulate doors relevant to their type](https://github.com/space-wizards/space-station-14/pull/26371) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `93e3aed26e30375058aa44482236410ff31484f0`

PR opened by <img src="https://avatars.githubusercontent.com/u/32041239?v=4" width="16"/><a href="https://github.com/nikthechampiongr"> nikthechampiongr</a> at 2024-03-24 00:28:39 UTC

---

PR changed 1 files with 3 additions and 8 deletions.

The PR had the following labels:


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> This makes it so door remotes can no longer manipulate doors just because their user has access to them. 
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Being able to bolt doors and put them on emergency access from a distance is extremely powerful. You should not be able to do it just because you have the access in your id card, it should be limited to the capabilities of the door remote.
> 
> It also makes no sense.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> Relevant calls to check for access, and try open/bolt doors had their arguments changed to pass in the door remote instead of the user so now only the door remote's accesses are checked.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - tweak: Door remotes can now only control doors specific to their type and do not use the access of their user.


</details>