### PR TITLE
Mirror: Maybe fix rsi truncheon error

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -100,7 +100,7 @@
   - type: Item
     size: Normal
   - type: Clothing
-    sprite: Objects\Weapons\Melee\truncheon.rsi
+    sprite: Objects/Weapons/Melee/truncheon.rsi
     quickEquip: false
     slots:
     - Belt


### PR DESCRIPTION
## Mirror of  PR #26374: [Maybe fix rsi truncheon error](https://github.com/space-wizards/space-station-14/pull/26374) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `cb97abb2defe5f333443997ccb82365e01ba1b6f`

PR opened by <img src="https://avatars.githubusercontent.com/u/81056464?v=4" width="16"/><a href="https://github.com/wrexbe"> wrexbe</a> at 2024-03-24 01:19:57 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> I was on ss14, and some kind of truncheon error was spamming in the console, and I am guessing it's this, because it looked sus.


</details>