### PR TITLE
Mirror: Hide empty marking categories in the markings picker

### DIFF
--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -124,17 +124,16 @@ public sealed partial class MarkingPicker : Control
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
 
-        SetupCategoryButtons();
         CMarkingCategoryButton.OnItemSelected +=  OnCategoryChange;
         CMarkingsUnused.OnItemSelected += item =>
             _selectedUnusedMarking = CMarkingsUnused[item.ItemIndex];
 
-        CMarkingAdd.OnPressed += args =>
+        CMarkingAdd.OnPressed += _ =>
             MarkingAdd();
 
         CMarkingsUsed.OnItemSelected += OnUsedMarkingSelected;
 
-        CMarkingRemove.OnPressed += args =>
+        CMarkingRemove.OnPressed += _ =>
             MarkingRemove();
 
         CMarkingRankUp.OnPressed += _ => SwapMarkingUp();
@@ -146,16 +145,34 @@ public sealed partial class MarkingPicker : Control
     private void SetupCategoryButtons()
     {
         CMarkingCategoryButton.Clear();
+
+        var validCategories = new List<MarkingCategories>();
         for (var i = 0; i < _markingCategories.Count; i++)
         {
-            if (_ignoreCategories.Contains(_markingCategories[i]))
+            var category = _markingCategories[i];
+            var markings = GetMarkings(category);
+            if (_ignoreCategories.Contains(category) ||
+                markings.Count == 0)
             {
                 continue;
             }
 
-            CMarkingCategoryButton.AddItem(Loc.GetString($"markings-category-{_markingCategories[i].ToString()}"), i);
+            validCategories.Add(category);
+            CMarkingCategoryButton.AddItem(Loc.GetString($"markings-category-{category.ToString()}"), i);
         }
-        CMarkingCategoryButton.SelectId(_markingCategories.IndexOf(_selectedMarkingCategory));
+
+        if (validCategories.Contains(_selectedMarkingCategory))
+        {
+            CMarkingCategoryButton.SelectId(_markingCategories.IndexOf(_selectedMarkingCategory));
+        }
+        else if (validCategories.Count > 0)
+        {
+            _selectedMarkingCategory = validCategories[0];
+        }
+        else
+        {
+            _selectedMarkingCategory = MarkingCategories.Chest;
+        }
     }
 
     private string GetMarkingName(MarkingPrototype marking) => Loc.GetString($"marking-{marking.ID}");
@@ -179,16 +196,21 @@ public sealed partial class MarkingPicker : Control
         return result;
     }
 
+    private IReadOnlyDictionary<string, MarkingPrototype> GetMarkings(MarkingCategories category)
+    {
+        return IgnoreSpecies
+            ? _markingManager.MarkingsByCategoryAndSex(category, _currentSex)
+            : _markingManager.MarkingsByCategoryAndSpeciesAndSex(category, _currentSpecies, _currentSex);
+    }
+
     public void Populate(string filter)
     {
+        SetupCategoryButtons();
+
         CMarkingsUnused.Clear();
         _selectedUnusedMarking = null;
 
-        var markings = IgnoreSpecies
-            ? _markingManager.MarkingsByCategoryAndSex(_selectedMarkingCategory, _currentSex)
-            : _markingManager.MarkingsByCategoryAndSpeciesAndSex(_selectedMarkingCategory, _currentSpecies, _currentSex);
-
-        var sortedMarkings = markings.Values.Where(m =>
+        var sortedMarkings = GetMarkings(_selectedMarkingCategory).Values.Where(m =>
             m.ID.ToLower().Contains(filter.ToLower()) ||
             GetMarkingName(m).ToLower().Contains(filter.ToLower())
         ).OrderBy(p => Loc.GetString(GetMarkingName(p)));


### PR DESCRIPTION
## Mirror of  PR #26377: [Hide empty marking categories in the markings picker](https://github.com/space-wizards/space-station-14/pull/26377) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `4790ccba19c1f63f21a2aa57fe4525587c119d9c`

PR opened by <img src="https://avatars.githubusercontent.com/u/10968691?v=4" width="16"/><a href="https://github.com/DrSmugleaf"> DrSmugleaf</a> at 2024-03-24 03:49:01 UTC

---

PR changed 1 files with 33 additions and 11 deletions.

The PR had the following labels:
- Changes: UI


---

<details open="true"><summary><h1>Original Body</h1></summary>

> ## About the PR
> Updates when something about the character is changed.
> This helps not gaslight me about which markings a species has available, and also slime person players are faced with the hard truth that they barely have any.
> 
> ## Media
> https://github.com/space-wizards/space-station-14/assets/10968691/439a4b39-a7c6-4ab1-839f-5436ba54b817
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> :cl:
> - tweak: Empty marking categories are now hidden in the markings picker.


</details>