### PR TITLE
Fix Pride and Courier Vendors Not Being Able To Say Thank You, and Crashing the Game Out of Protest

### DIFF
--- a/Resources/Locale/en-US/deltav/advertisements/vending/courierdrobe.ftl
+++ b/Resources/Locale/en-US/deltav/advertisements/vending/courierdrobe.ftl
@@ -3,3 +3,5 @@ advertisement-courierdrobe-2 = A great investment for your survival!
 advertisement-courierdrobe-3 = Wear your brown with pride!
 advertisement-courierdrobe-4 = These shorts are comfy and easy to wear, get yours now!
 advertisement-courierdrobe-5 = Outrun every danger with our stylish clothes!
+thankyou-courierdrobe-1 = Now get out there and deliver that mail!
+thankyou-courierdrobe-1 = Those parcels aren't going to deliver themselves!

--- a/Resources/Locale/en-US/deltav/advertisements/vending/pride.ftl
+++ b/Resources/Locale/en-US/deltav/advertisements/vending/pride.ftl
@@ -1,3 +1,5 @@
 advertisement-pride-1 = Be gay do crime!
 advertisement-pride-2 = Full of colors!
 advertisement-pride-3 = You are valid!
+thankyou-pride-1 = Go, do some crime!
+thankyou-pride-1 = Have a colorful day!

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Advertisements/courierdrobe.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Advertisements/courierdrobe.yml
@@ -6,3 +6,6 @@
     - advertisement-courierdrobe-3
     - advertisement-courierdrobe-4
     - advertisement-courierdrobe-5
+  thankyous:
+    - thankyou-courierdrobe-1
+    - thankyou-courierdrobe-2

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Advertisements/pride.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Advertisements/pride.yml
@@ -4,3 +4,6 @@
   - advertisement-pride-1
   - advertisement-pride-2
   - advertisement-pride-3
+  thankyous:
+  - thankyou-pride-1
+  - thankyou-pride-2


### PR DESCRIPTION
# Description

This fixes a crash related to the CourierDrobe and PrideVend not having thank you messages. Instead of deleting the ability to say a thank you message, I have elected to add thank you messages to both vendors.

# Media

![image](https://github.com/Simple-Station/Einstein-Engines/assets/16548818/3b06ebfe-9c09-42a7-979a-605a7a0f3869)