### PR TITLE
Mirror: Give cap door remote his access

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Devices/door_remote.rsi
   - type: Item
     storedRotation: -90
-  - type: Access
+  - type: Access #No access, useless
   - type: DoorRemote
   - type: StealTarget
     stealGroup: DoorRemote
@@ -28,7 +28,7 @@
       color: "#9f9f00"
   - type: Access
     groups:
-    - Command
+    - AllAccess #Cap must be able to control the station
 
 - type: entity
   parent: DoorRemoteDefault


### PR DESCRIPTION
## Mirror of  PR #26378: [Give cap door remote his access](https://github.com/space-wizards/space-station-14/pull/26378) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `ea818ea1b6d910fb1b86ee06648fc0da5a100a27`

PR opened by <img src="https://avatars.githubusercontent.com/u/152836416?v=4" width="16"/><a href="https://github.com/Baptr0b0t"> Baptr0b0t</a> at 2024-03-24 05:03:38 UTC

---

PR changed 1 files with 2 additions and 2 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Add access to the command door remote.
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Because of #26371 
> The command remote control becomes useless and cannot access most doors
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> YML configuration, change access group of command door remote 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl: 
> - fix: Fix access of command door remote.


</details>