### PR TITLE
Mirror: Fixes store purchase events and adds support to raise a directed event

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -250,10 +250,12 @@ public sealed partial class StoreSystem
                 HandleRefundComp(uid, component, upgradeActionId.Value);
         }
 
-        //broadcast event
         if (listing.ProductEvent != null)
         {
-            RaiseLocalEvent(listing.ProductEvent);
+            if (!listing.RaiseProductEventOnUser)
+                RaiseLocalEvent(listing.ProductEvent);
+            else
+                RaiseLocalEvent(buyer, listing.ProductEvent);
         }
 
         //log dat shit.

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -98,6 +98,9 @@ public partial class ListingData : IEquatable<ListingData>, ICloneable
     [DataField("productEvent")]
     public object? ProductEvent;
 
+    [DataField]
+    public bool RaiseProductEventOnUser;
+
     /// <summary>
     /// used internally for tracking how many times an item was purchased.
     /// </summary>
@@ -120,7 +123,7 @@ public partial class ListingData : IEquatable<ListingData>, ICloneable
             Description != listing.Description ||
             ProductEntity != listing.ProductEntity ||
             ProductAction != listing.ProductAction ||
-            ProductEvent != listing.ProductEvent ||
+            ProductEvent?.GetType() != listing.ProductEvent?.GetType() ||
             RestockTime != listing.RestockTime)
             return false;
 


### PR DESCRIPTION
## Mirror of  PR #26389: [Fixes store purchase events and adds support to raise a directed event](https://github.com/space-wizards/space-station-14/pull/26389) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `4dced51f0d8d008714a14675b48c8fa2b7fa0ace`

PR opened by <img src="https://avatars.githubusercontent.com/u/54602815?v=4" width="16"/><a href="https://github.com/keronshb"> keronshb</a> at 2024-03-24 14:16:44 UTC

---

PR changed 2 files with 8 additions and 3 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> When testing around some things with the magic PR I found that the purchase event wasn't being compared correctly. Also I added support to raise the purchase event directed at the buyer instead of just a broadcast event.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> The equals method will now check for purchase event type instead of comparing the references. To make this stronger we should talk about creating a base store purchase event class.
> 
> For directing the event I added a bool to raise on user and we check if that's true.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


</details>