### PR TITLE
Mirror: Store keybind priority

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -403,7 +403,7 @@ namespace Content.Client.Options.UI.Tabs
                 Mod1 = mods[0],
                 Mod2 = mods[1],
                 Mod3 = mods[2],
-                Priority = 0,
+                Priority = _currentlyRebinding.Binding?.Priority ?? 0,
                 Type = bindType,
                 CanFocus = key == Keyboard.Key.MouseLeft
                            || key == Keyboard.Key.MouseRight

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -167,6 +167,7 @@ binds:
   type: State
   key: MouseLeft
   canFocus: true
+  priority: 10
 - function: RotateStoredItem
   type: State
   key: MouseRight


### PR DESCRIPTION
## Mirror of  PR #26356: [Store keybind priority](https://github.com/space-wizards/space-station-14/pull/26356) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `f7a1ffd0aab25d70ac185753d596469fc1e87480`

PR opened by <img src="https://avatars.githubusercontent.com/u/81056464?v=4" width="16"/><a href="https://github.com/wrexbe"> wrexbe</a> at 2024-03-23 02:49:07 UTC

---

PR changed 2 files with 2 additions and 1 deletions.

The PR had the following labels:
- Changes: UI


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Changed it so the priority isn't lost when you set a binding in the UI.
> Also added a priority to MoveStoredItem so it doesn't conflict with Use.
> Fixes https://github.com/space-wizards/space-station-14/issues/26142
> Does not fix old keybinds files, so they will need to reset it, and rebind it.
> 
> A better solution might be to change it so the keybinds are always in the order they appear in the default keybinds folder, to prevent the ordering from changing unpredictably based on what the user overrides.


</details>