### PR TITLE
Mirror: Immovable Rod visual variations

### DIFF
--- a/Content.Server/StationEvents/Components/ImmovableRodRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/ImmovableRodRuleComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.StationEvents.Events;
+using Content.Shared.Storage;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -7,6 +8,8 @@ namespace Content.Server.StationEvents.Components;
 [RegisterComponent, Access(typeof(ImmovableRodRule))]
 public sealed partial class ImmovableRodRuleComponent : Component
 {
-    [DataField("rodPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string RodPrototype = "ImmovableRodKeepTilesStill";
+    ///     List of possible rods and spawn probabilities.
+    /// </summary>
+    [DataField]
+    public List<EntitySpawnEntry> RodPrototypes = new();
 }

--- a/Content.Server/StationEvents/Events/ImmovableRodRule.cs
+++ b/Content.Server/StationEvents/Events/ImmovableRodRule.cs
@@ -3,9 +3,11 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.ImmovableRod;
 using Content.Server.StationEvents.Components;
 using Content.Server.Weapons.Ranged.Systems;
-using Robust.Shared.Spawners;
+using Content.Shared.Storage;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
+using System.Linq;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -19,7 +21,10 @@ public sealed class ImmovableRodRule : StationEventSystem<ImmovableRodRuleCompon
     {
         base.Started(uid, component, gameRule, args);
 
-        var proto = _prototypeManager.Index<EntityPrototype>(component.RodPrototype);
+        var protoName = EntitySpawnCollection.GetSpawns(component.RodPrototypes).First();
+
+        var proto = _prototypeManager.Index<EntityPrototype>(protoName);
+
         if (proto.TryGetComponent<ImmovableRodComponent>(out var rod) && proto.TryGetComponent<TimedDespawnComponent>(out var despawn))
         {
             TryFindRandomTile(out _, out _, out _, out var targetCoords);
@@ -27,12 +32,12 @@ public sealed class ImmovableRodRule : StationEventSystem<ImmovableRodRuleCompon
             var angle = RobustRandom.NextAngle();
             var direction = angle.ToVec();
             var spawnCoords = targetCoords.ToMap(EntityManager, _transform).Offset(-direction * speed * despawn.Lifetime / 2);
-            var ent = Spawn(component.RodPrototype, spawnCoords);
+            var ent = Spawn(protoName, spawnCoords);
             _gun.ShootProjectile(ent, direction, Vector2.Zero, uid, speed: speed);
         }
         else
         {
-            Sawmill.Error($"Invalid immovable rod prototype: {component.RodPrototype}");
+            Sawmill.Error($"Invalid immovable rod prototype: {protoName}");
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -60,3 +60,86 @@
   components:
   - type: ImmovableRod
     randomizeVelocity: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodMop
+  name: immovable mop
+  description: Hurled like a javelin, with the power of a thousand furious janitors.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Janitorial/mop.rsi
+    state: mop
+    rotation: 225
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodShark
+  name: immovable shark
+  description: SHARK TORNADO!
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/sharkplush.rsi
+    state: blue
+    rotation: 90
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodClown
+  name: immovable clown
+  description: Ejected from the neighbouring station one solar system over. HONK!
+  components:
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    state: clown
+    rotation: 180
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodBanana
+  name: immovable banana
+  description: At least you won't slip on it.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Hydroponics/banana.rsi
+    state: produce
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodHammer
+  name: immovable hammer
+  description: Bwoink.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/sledgehammer.rsi
+    state: icon
+    rotation: 225
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodThrongler
+  name: immovable throngler
+  description: If you catch it, you can keep it.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/Throngler2.rsi
+    state: icon
+    rotation: 225
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodGibstick
+  name: immovable gibstick
+  description: What did you expect?
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/debug.rsi
+    state: icon
+    rotation: 225
+    noRot: false

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -441,20 +441,45 @@
     sounds:
       collection: Paracusia
 
-#- type: entity # DeltaV - Why does this exist??
-#  id: ImmovableRodSpawn
-#  parent: BaseGameRule
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    startAnnouncement: station-event-immovable-rod-start-announcement
-#    startAudio:
-#      path: /Audio/Announcements/attention.ogg
-#    weight: 5
-#    duration: 1
-#    earliestStart: 45
-#    minimumPlayers: 20
-#  - type: ImmovableRodRule
+- type: entity
+  id: ImmovableRodSpawn
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-immovable-rod-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    weight: 5
+    duration: 1
+    earliestStart: 45
+    minimumPlayers: 20
+  - type: ImmovableRodRule
+    rodPrototypes:
+    - id: ImmovableRodKeepTilesStill
+      prob: 0.95
+      orGroup: rodProto
+    - id: ImmovableRodMop
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodShark
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodClown
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodBanana
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodHammer
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodThrongler
+      prob: 0.0072
+      orGroup: rodProto
+    - id: ImmovableRodGibstick
+      prob: 0.0072
+      orGroup: rodProto
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
## Mirror of  PR #25932: [Immovable Rod visual variations](https://github.com/space-wizards/space-station-14/pull/25932) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `8f652eaa7560a47a750173d716426dcd1ad7c01b`

PR opened by <img src="https://avatars.githubusercontent.com/u/83650252?v=4" width="16"/><a href="https://github.com/SlamBamActionman"> SlamBamActionman</a> at 2024-03-08 15:02:40 UTC

---

PR changed 4 files with 122 additions and 6 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> 
> This PR adds 7 rare visual variations to the Immovable Rod, making it possible for other wacky items to replace the basic metal rod.
> 
> The current items have been added:
> - Mop
> - Hammer
> - Shark (Plushie)
> - Banana
> - Clown
> - Throngler
> - Gibstick
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> Gives the immovable rod some more flavor and fits the announcement warning text, which is non-specific as of what item hits the station. The variations will not change the effect of the immovable rod.
> 
> To keep the variations rare and interesting when they happen, the rod has only a 1 in 10 chance to be replaced by a variation. All variations have an equal chance to be chosen. 
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> Uses a similar pick system to the Wilhelm scream easter egg, though with prototypes instead of sound files. 
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> ![image](https://github.com/space-wizards/space-station-14/assets/83650252/eb78734b-9513-4c47-9c36-2cff5790e6bb)
> 
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> no cl lots of fun
> 


</details>