### PR TITLE
Mirror: Fixed some icon rsi warnings

### DIFF
--- a/Resources/Prototypes/Actions/diona.yml
+++ b/Resources/Prototypes/Actions/diona.yml
@@ -5,7 +5,9 @@
   noSpawn: true
   components:
   - type: InstantAction
-    icon: Mobs/Species/Diona/organs.rsi/brain.png
+    icon:
+      sprite: Mobs/Species/Diona/organs.rsi
+      state: brain
     event: !type:GibActionEvent {}
     checkCanInteract: false
 
@@ -16,6 +18,8 @@
   noSpawn: true
   components:
   - type: InstantAction
-    icon: Mobs/Species/Diona/parts.rsi/full.png
+    icon:
+      sprite: Mobs/Species/Diona/parts.rsi
+      state: full
     event: !type:ReformEvent {}
     useDelay: 600 # Once every 10 minutes. Keep them dead for a fair bit before reforming

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -40,7 +40,7 @@
   components:
   - type: InstantAction
     icon: { sprite: Objects/Tools/flashlight.rsi, state: flashlight }
-    iconOn: Objects/Tools/flashlight.rsi/flashlight-on.png
+    iconOn: { sprite: Objects/Tools/flashlight.rsi, state: flashlight-on }
     event: !type:ToggleActionEvent
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -73,7 +73,9 @@
   noSpawn: true
   components:
   - type: EntityTargetAction
-    icon: Clothing/Neck/Misc/stethoscope.rsi/icon.png
+    icon:
+      sprite: Clothing/Neck/Misc/stethoscope.rsi
+      state: icon
     event: !type:StethoscopeActionEvent
     checkCanInteract: false
     priority: -1

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -47,5 +47,7 @@
   - type: InstantAction
     priority: -1
     useDelay: 30
-    icon: Structures/Walls/solid.rsi/full.png
+    icon:
+      sprite: Structures/Walls/solid.rsi
+      state: full
     event: !type:InvisibleWallActionEvent


### PR DESCRIPTION
## Mirror of  PR #26414: [Fixed some icon rsi warnings](https://github.com/space-wizards/space-station-14/pull/26414) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `5562bcebcb114892616383a95f5d5a8884c09bbb`

PR opened by <img src="https://avatars.githubusercontent.com/u/81056464?v=4" width="16"/><a href="https://github.com/wrexbe"> wrexbe</a> at 2024-03-24 22:11:54 UTC

---

PR changed 4 files with 13 additions and 5 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Fixes some .png rsi reference warnings


</details>