### PR TITLE
Mirror: Update close-master-pr.yml

### DIFF
--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -1,4 +1,4 @@
-name: Close PR's on master
+name: Close PRs on master
 
 on:
   pull_request_target:


### PR DESCRIPTION
## Mirror of  PR #26416: [Update close-master-pr.yml](https://github.com/space-wizards/space-station-14/pull/26416) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `a30fb1fffa107bac79668866fdbf7fb7c6d3f8e0`

PR opened by <img src="https://avatars.githubusercontent.com/u/8107459?v=4" width="16"/><a href="https://github.com/PJB3005"> PJB3005</a> at 2024-03-24 22:47:21 UTC

---

PR changed 1 files with 1 additions and 1 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> Fix name of "Close PRs on master" workflow
> 


</details>