### PR TITLE
Mirror: Holoprojectors crafted at lathes no longer come with a cell.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -27,6 +27,16 @@
 
 - type: entity
   parent: Holoprojector
+  id: HoloprojectorEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  parent: Holoprojector
   id: HoloprojectorBorg
   suffix: borg
   components:
@@ -62,6 +72,16 @@
       - HolofanProjector
 
 - type: entity
+  parent: HolofanProjector
+  id: HolofanProjectorEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
   parent: Holoprojector
   id: HoloprojectorField
   name: force field projector
@@ -78,6 +98,16 @@
         - HolofanProjector
     - type: StaticPrice
       price: 130
+
+- type: entity
+  parent: HoloprojectorField
+  id: HoloprojectorFieldEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
 
 - type: entity
   parent: Holoprojector

--- a/Resources/Prototypes/Recipes/Lathes/janitorial.yml
+++ b/Resources/Prototypes/Recipes/Lathes/janitorial.yml
@@ -66,7 +66,7 @@
 
 - type: latheRecipe
   id: Holoprojector
-  result: Holoprojector
+  result: HoloprojectorEmpty
   completetime: 3
   materials:
     Plastic: 250

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -189,14 +189,13 @@
 
 - type: latheRecipe
   id: HolofanProjector
-  result: HolofanProjector
+  result: HolofanProjectorEmpty
   category: Tools
   completetime: 8
-  materials: # Inherited materials and time from PowerCellMedium recipe
-    Steel: 600
-    Glass: 350
-    Plastic: 150
-    Gold: 10
+  materials:
+    Steel: 300
+    Glass: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: RPED
@@ -239,7 +238,7 @@
 
 - type: latheRecipe
   id: HoloprojectorField
-  result: HoloprojectorField
+  result: HoloprojectorFieldEmpty
   category: Tools
   completetime: 3
   materials:


### PR DESCRIPTION
## Mirror of  PR #26405: [Holoprojectors crafted at lathes no longer come with a cell.](https://github.com/space-wizards/space-station-14/pull/26405) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `0bc886c00996e28fc31ea764a65ef51e4b1294f3`

PR opened by <img src="https://avatars.githubusercontent.com/u/22885888?v=4" width="16"/><a href="https://github.com/Callmore"> Callmore</a> at 2024-03-24 19:11:50 UTC

---

PR changed 3 files with 37 additions and 8 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Adds versions of the holoprojectors (janitoral, fan, and field) that start without a battery and changes the lathe recipe to use these instead. This is consistant with flashlights, which when made do not start with a cell.
> 
> Also it's a bit silly to have cargo printing a bunch of these to sell.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> Cargo can no longer print a bunch of holosign projectors to just sell for... apparently huge profit (i dunno i've seen it happen a few times and i don't super get it). Also it's cheaper to print the projector than to print a medium cell so.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> Adds a variation of the holoprojector, holofan projector and holofield projector that do not have a cell.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> https://github.com/space-wizards/space-station-14/assets/22885888/44982b18-0fa2-45a6-9e15-2fa533000b0c
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> 
> :cl:
> - tweak: Holoprojectors no longer come with a cell when made at a lathe.
> 


</details>