### PR TITLE
Mirror: fix: the captain can put his laser gun back in the box.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -578,6 +578,7 @@
     tags:
     - HighRiskItem
     - Sidearm
+    - WeaponAntiqueLaser
   - type: StaticPrice
     price: 750
   - type: StealTarget


### PR DESCRIPTION
## Mirror of  PR #26398: [fix: the captain can put his laser gun back in the box.](https://github.com/space-wizards/space-station-14/pull/26398) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `27a9b078239fb32be00e78fd980951f16f644dac`

PR opened by <img src="https://avatars.githubusercontent.com/u/107586145?v=4" width="16"/><a href="https://github.com/IProduceWidgets"> IProduceWidgets</a> at 2024-03-24 18:29:22 UTC

---

PR changed 1 files with 1 additions and 0 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> fixed #25519  the tagging for the captain's laser glass box.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl:
> - fix: The captain can now return his laser to the glass display box.


</details>