### PR TITLE
Mirror: nerf rad artifacts

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -257,7 +257,8 @@
   effectHint: artifact-effect-hint-release
   components:
   - type: RadiationSource
-    intensity: 2
+    intensity: 1
+    slope: 0.3
 
 - type: artifactEffect
   id: EffectKnock
@@ -556,7 +557,8 @@
   effectHint: artifact-effect-hint-release
   components:
   - type: RadiationSource
-    intensity: 6
+    intensity: 2
+    slope: 0.3
 
 - type: artifactEffect
   id: EffectMaterialSpawn


### PR DESCRIPTION
## Mirror of  PR #26422: [nerf rad artifacts](https://github.com/space-wizards/space-station-14/pull/26422) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `b2c5ae9023a6f659754f55b030ba52cdb1c2f80a`

PR opened by <img src="https://avatars.githubusercontent.com/u/98561806?v=4" width="16"/><a href="https://github.com/EmoGarbage404"> EmoGarbage404</a> at 2024-03-25 01:56:30 UTC

---

PR changed 1 files with 4 additions and 2 deletions.

The PR had the following labels:
- No C#


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> nerfs rad artifacts significantly.
> 
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> 
> for 10 million years, science mains across the globe have been weeping and lamenting the rad artifact. They're irradiated bodies shuddering as they decry the unfairness in the world that would produce such pain and suffering unto the world.
> 
> but surely there could be no fix? no respite nor relief? who in this open source repo could possibly fix something as complex as a single number? The idea shakes many to the very core. How could they handle it???
> 
> they may only hope that one golden son shall come and save them and bring peace unto the land of science.
> 
> /uj
> the old values were literally on-par with singulo this makes them weaker so science doesn't irradiate a city block and perma kill a quarter of the station.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> no cl no fun
> 


</details>