### PR TITLE
Mirror: Code cleanup: Purge obsoleted SharedPhysicsSystem methods

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -409,7 +409,7 @@ public sealed partial class AdminVerbSystem
                     var fixtures = Comp<FixturesComponent>(args.Target);
                     xform.Anchored = false; // Just in case.
                     _physics.SetBodyType(args.Target, BodyType.Dynamic, manager: fixtures, body: physics);
-                    _physics.SetBodyStatus(physics, BodyStatus.InAir);
+                    _physics.SetBodyStatus(args.Target, physics, BodyStatus.InAir);
                     _physics.WakeBody(args.Target, manager: fixtures, body: physics);
 
                     foreach (var fixture in fixtures.Fixtures.Values)
@@ -424,8 +424,8 @@ public sealed partial class AdminVerbSystem
 
                     _physics.SetLinearVelocity(args.Target, _random.NextVector2(1.5f, 1.5f), manager: fixtures, body: physics);
                     _physics.SetAngularVelocity(args.Target, MathF.PI * 12, manager: fixtures, body: physics);
-                    _physics.SetLinearDamping(physics, 0f);
-                    _physics.SetAngularDamping(physics, 0f);
+                    _physics.SetLinearDamping(args.Target, physics, 0f);
+                    _physics.SetAngularDamping(args.Target, physics, 0f);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-pinball-description")
@@ -444,7 +444,7 @@ public sealed partial class AdminVerbSystem
                     xform.Anchored = false; // Just in case.
 
                     _physics.SetBodyType(args.Target, BodyType.Dynamic, body: physics);
-                    _physics.SetBodyStatus(physics, BodyStatus.InAir);
+                    _physics.SetBodyStatus(args.Target, physics, BodyStatus.InAir);
                     _physics.WakeBody(args.Target, manager: fixtures, body: physics);
 
                     foreach (var fixture in fixtures.Fixtures.Values)
@@ -454,8 +454,8 @@ public sealed partial class AdminVerbSystem
 
                     _physics.SetLinearVelocity(args.Target, _random.NextVector2(8.0f, 8.0f), manager: fixtures, body: physics);
                     _physics.SetAngularVelocity(args.Target, MathF.PI * 12, manager: fixtures, body: physics);
-                    _physics.SetLinearDamping(physics, 0f);
-                    _physics.SetAngularDamping(physics, 0f);
+                    _physics.SetLinearDamping(args.Target, physics, 0f);
+                    _physics.SetAngularDamping(args.Target, physics, 0f);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-yeet-description")

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (HasComp<MobStateComponent>(uid) &&
                     TryComp<PhysicsComponent>(uid, out var body))
                 {
-                    _physics.SetBodyStatus(body, BodyStatus.OnGround);
+                    _physics.SetBodyStatus(uid, body, BodyStatus.OnGround);
                 }
 
                 if (TryComp<FixturesComponent>(uid, out var fixtures))
@@ -77,7 +77,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!TryComp<FixturesComponent>(uid, out var fixtures))
                 return;
 
-            _physics.SetBodyStatus(body, BodyStatus.InAir);
+            _physics.SetBodyStatus(uid, body, BodyStatus.InAir);
 
             foreach (var (id, fixture) in fixtures.Fixtures)
             {
@@ -96,9 +96,9 @@ namespace Content.Server.Atmos.EntitySystems
             // TODO ATMOS finish this
 
             // Don't play the space wind sound on tiles that are on fire...
-            if(tile.PressureDifference > 15 && !tile.Hotspot.Valid)
+            if (tile.PressureDifference > 15 && !tile.Hotspot.Valid)
             {
-                if(_spaceWindSoundCooldown == 0 && !string.IsNullOrEmpty(SpaceWindSound))
+                if (_spaceWindSoundCooldown == 0 && !string.IsNullOrEmpty(SpaceWindSound))
                 {
                     var coordinates = _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.GridIndices);
                     _audio.PlayPvs(SpaceWindSound, coordinates, AudioParams.Default.WithVariation(0.125f).WithVolume(MathHelper.Clamp(tile.PressureDifference / 10, 10, 100)));

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -66,8 +66,8 @@ namespace Content.Server.Chemistry.EntitySystems
             // Set Move
             if (EntityManager.TryGetComponent(vapor, out PhysicsComponent? physics))
             {
-                _physics.SetLinearDamping(physics, 0f);
-                _physics.SetAngularDamping(physics, 0f);
+                _physics.SetLinearDamping(vapor, physics, 0f);
+                _physics.SetAngularDamping(vapor, physics, 0f);
 
                 _throwing.TryThrow(vapor, dir, speed, user: user);
 

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -53,9 +53,9 @@ public sealed class ImmovableRodSystem : EntitySystem
     {
         if (EntityManager.TryGetComponent(uid, out PhysicsComponent? phys))
         {
-            _physics.SetLinearDamping(phys, 0f);
-            _physics.SetFriction(phys, 0f);
-            _physics.SetBodyStatus(phys, BodyStatus.InAir);
+            _physics.SetLinearDamping(uid, phys, 0f);
+            _physics.SetFriction(uid, phys, 0f);
+            _physics.SetBodyStatus(uid, phys, BodyStatus.InAir);
 
             if (!component.RandomizeVelocity)
                 return;

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
@@ -28,7 +28,7 @@ public sealed partial class ParticleAcceleratorSystem
         if (TryComp<PhysicsComponent>(emitted, out var particlePhys))
         {
             var angle = _transformSystem.GetWorldRotation(uid, xformQuery);
-            _physicsSystem.SetBodyStatus(particlePhys, BodyStatus.InAir);
+            _physicsSystem.SetBodyStatus(emitted, particlePhys, BodyStatus.InAir);
 
             var velocity = angle.ToWorldVec() * 20f;
             if (TryComp<PhysicsComponent>(uid, out var phys))

--- a/Content.Server/Physics/Controllers/ChasingWalkSystem.cs
+++ b/Content.Server/Physics/Controllers/ChasingWalkSystem.cs
@@ -97,6 +97,6 @@ public sealed class ChasingWalkSystem : VirtualController
         var speed = delta.Length() > 0 ? delta.Normalized() * component.Speed : Vector2.Zero;
 
         _physics.SetLinearVelocity(uid, speed);
-        _physics.SetBodyStatus(physics, BodyStatus.InAir); //If this is not done, from the explosion up close, the tesla will "Fall" to the ground, and almost stop moving.
+        _physics.SetBodyStatus(uid, physics, BodyStatus.InAir); //If this is not done, from the explosion up close, the tesla will "Fall" to the ground, and almost stop moving.
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -371,8 +371,8 @@ public sealed partial class ShuttleSystem
         Enable(uid, component: body);
         _physics.SetLinearVelocity(uid, new Vector2(0f, 20f), body: body);
         _physics.SetAngularVelocity(uid, 0f, body: body);
-        _physics.SetLinearDamping(body, 0f);
-        _physics.SetAngularDamping(body, 0f);
+        _physics.SetLinearDamping(uid, body, 0f);
+        _physics.SetAngularDamping(uid, body, 0f);
 
         _dockSystem.SetDockBolts(uid, true);
         _console.RefreshShuttleConsoles(uid);
@@ -426,8 +426,8 @@ public sealed partial class ShuttleSystem
 
         _physics.SetLinearVelocity(uid, Vector2.Zero, body: body);
         _physics.SetAngularVelocity(uid, 0f, body: body);
-        _physics.SetLinearDamping(body, entity.Comp2.LinearDamping);
-        _physics.SetAngularDamping(body, entity.Comp2.AngularDamping);
+        _physics.SetLinearDamping(uid, body, entity.Comp2.LinearDamping);
+        _physics.SetAngularDamping(uid, body, entity.Comp2.AngularDamping);
 
         var target = entity.Comp1.TargetCoordinates;
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -129,10 +129,10 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         _physics.SetBodyType(uid, BodyType.Dynamic, manager: manager, body: component);
-        _physics.SetBodyStatus(component, BodyStatus.InAir);
+        _physics.SetBodyStatus(uid, component, BodyStatus.InAir);
         _physics.SetFixedRotation(uid, false, manager: manager, body: component);
-        _physics.SetLinearDamping(component, shuttle.LinearDamping);
-        _physics.SetAngularDamping(component, shuttle.AngularDamping);
+        _physics.SetLinearDamping(uid, component, shuttle.LinearDamping);
+        _physics.SetAngularDamping(uid, component, shuttle.AngularDamping);
     }
 
     public void Disable(EntityUid uid, FixturesComponent? manager = null, PhysicsComponent? component = null)
@@ -141,7 +141,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         _physics.SetBodyType(uid, BodyType.Static, manager: manager, body: component);
-        _physics.SetBodyStatus(component, BodyStatus.OnGround);
+        _physics.SetBodyStatus(uid, component, BodyStatus.OnGround);
         _physics.SetFixedRotation(uid, true, manager: manager, body: component);
     }
 

--- a/Content.Server/StationEvents/Events/MeteorSwarmRule.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmRule.cs
@@ -68,9 +68,9 @@ namespace Content.Server.StationEvents.Events
                 var spawnPosition = new MapCoordinates(center + offset, mapId);
                 var meteor = Spawn("MeteorLarge", spawnPosition);
                 var physics = EntityManager.GetComponent<PhysicsComponent>(meteor);
-                _physics.SetBodyStatus(physics, BodyStatus.InAir);
-                _physics.SetLinearDamping(physics, 0f);
-                _physics.SetAngularDamping(physics, 0f);
+                _physics.SetBodyStatus(meteor, physics, BodyStatus.InAir);
+                _physics.SetLinearDamping(meteor, physics, 0f);
+                _physics.SetAngularDamping(meteor, physics, 0f);
                 _physics.ApplyLinearImpulse(meteor, -offset.Normalized() * component.MeteorVelocity * physics.Mass, body: physics);
                 _physics.ApplyAngularImpulse(
                     meteor,

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -366,7 +366,7 @@ public abstract partial class SharedBuckleSystem
 
         if (TryComp<PhysicsComponent>(buckleUid, out var physics))
         {
-            _physics.ResetDynamics(physics);
+            _physics.ResetDynamics(buckleUid, physics);
         }
 
         if (!buckleComp.PullStrap && TryComp<SharedPullableComponent>(strapUid, out var toPullable))

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -92,7 +92,7 @@ public abstract class SharedJetpackSystem : EntitySystem
         _mover.SetRelay(user, jetpackUid);
 
         if (TryComp<PhysicsComponent>(user, out var physics))
-            _physics.SetBodyStatus(physics, BodyStatus.InAir);
+            _physics.SetBodyStatus(user, physics, BodyStatus.InAir);
 
         userComp.Jetpack = jetpackUid;
     }
@@ -103,7 +103,7 @@ public abstract class SharedJetpackSystem : EntitySystem
             return;
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
-            _physics.SetBodyStatus(physics, BodyStatus.OnGround);
+            _physics.SetBodyStatus(uid, physics, BodyStatus.OnGround);
 
         RemComp<RelayInputMoverComponent>(uid);
     }

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -160,7 +160,7 @@ public sealed class ThrowingSystem : EntitySystem
         }
         else
         {
-            _physics.SetBodyStatus(physics, BodyStatus.InAir);
+            _physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
         }
 
         if (user == null)
@@ -176,10 +176,10 @@ public sealed class ThrowingSystem : EntitySystem
         {
             var msg = new ThrowPushbackAttemptEvent();
             RaiseLocalEvent(uid, msg);
-            const float MassLimit = 5f;
+            const float massLimit = 5f;
 
             if (!msg.Cancelled)
-                _physics.ApplyLinearImpulse(user.Value, -impulseVector / physics.Mass * pushbackRatio * MathF.Min(MassLimit, physics.Mass), body: userPhysics);
+                _physics.ApplyLinearImpulse(user.Value, -impulseVector / physics.Mass * pushbackRatio * MathF.Min(massLimit, physics.Mass), body: userPhysics);
         }
     }
 }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -93,7 +93,7 @@ namespace Content.Shared.Throwing
         {
             if (TryComp<PhysicsComponent>(uid, out var physics))
             {
-                _physics.SetBodyStatus(physics, BodyStatus.OnGround);
+                _physics.SetBodyStatus(uid, physics, BodyStatus.OnGround);
 
                 if (physics.Awake)
                     _broadphase.RegenerateContacts(uid, physics);

--- a/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
@@ -74,7 +74,7 @@ public sealed class MeleeThrowOnHitSystem : EntitySystem
         comp.PreviousStatus = body.BodyStatus;
         comp.ThrownEndTime = _timing.CurTime + TimeSpan.FromSeconds(comp.Lifetime);
         comp.MinLifetimeTime = _timing.CurTime + TimeSpan.FromSeconds(comp.MinLifetime);
-        _physics.SetBodyStatus(body, BodyStatus.InAir);
+        _physics.SetBodyStatus(ent, body, BodyStatus.InAir);
         _physics.SetLinearVelocity(ent, Vector2.Zero, body: body);
         _physics.ApplyLinearImpulse(ent, comp.Velocity * body.Mass, body: body);
         Dirty(ent, ent.Comp);
@@ -83,7 +83,7 @@ public sealed class MeleeThrowOnHitSystem : EntitySystem
     private void OnThrownShutdown(Entity<MeleeThrownComponent> ent, ref ComponentShutdown args)
     {
         if (TryComp<PhysicsComponent>(ent, out var body))
-            _physics.SetBodyStatus(body,ent.Comp.PreviousStatus);
+            _physics.SetBodyStatus(ent, body, ent.Comp.PreviousStatus);
         var ev = new MeleeThrowOnHitEndEvent();
         RaiseLocalEvent(ent, ref ev);
     }

--- a/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
@@ -207,12 +207,12 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
         TransformSystem.Unanchor(target, targetXform);
         component.Tethered = target;
         var tethered = EnsureComp<TetheredComponent>(target);
-        _physics.SetBodyStatus(targetPhysics, BodyStatus.InAir, false);
+        _physics.SetBodyStatus(target, targetPhysics, BodyStatus.InAir, false);
         _physics.SetSleepingAllowed(target, targetPhysics, false);
         tethered.Tetherer = gunUid;
         tethered.OriginalAngularDamping = targetPhysics.AngularDamping;
-        _physics.SetAngularDamping(targetPhysics, 0f);
-        _physics.SetLinearDamping(targetPhysics, 0f);
+        _physics.SetAngularDamping(target, targetPhysics, 0f);
+        _physics.SetLinearDamping(target, targetPhysics, 0f);
         _physics.SetAngularVelocity(target, SpinVelocity, body: targetPhysics);
         _physics.WakeBody(target, body: targetPhysics);
         var thrown = EnsureComp<ThrownItemComponent>(component.Tethered.Value);
@@ -264,9 +264,9 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
                 _thrown.StopThrow(component.Tethered.Value, thrown);
             }
 
-            _physics.SetBodyStatus(targetPhysics, BodyStatus.OnGround);
+            _physics.SetBodyStatus(component.Tethered.Value, targetPhysics, BodyStatus.OnGround);
             _physics.SetSleepingAllowed(component.Tethered.Value, targetPhysics, true);
-            _physics.SetAngularDamping(targetPhysics, Comp<TetheredComponent>(component.Tethered.Value).OriginalAngularDamping);
+            _physics.SetAngularDamping(component.Tethered.Value, targetPhysics, Comp<TetheredComponent>(component.Tethered.Value).OriginalAngularDamping);
         }
 
         if (!transfer)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -388,7 +388,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid gunUid, EntityUid? user = null, float speed = 20f)
     {
         var physics = EnsureComp<PhysicsComponent>(uid);
-        Physics.SetBodyStatus(physics, BodyStatus.InAir);
+        Physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
 
         var targetMapVelocity = gunVelocity + direction.Normalized() * speed;
         var currentMapVelocity = Physics.GetMapLinearVelocity(uid, physics);


### PR DESCRIPTION
## Mirror of  PR #26287: [Code cleanup: Purge obsoleted SharedPhysicsSystem methods](https://github.com/space-wizards/space-station-14/pull/26287) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `964c6d54caae45b205a326143f56d6458a1bbc8a`

PR opened by <img src="https://avatars.githubusercontent.com/u/85356?v=4" width="16"/><a href="https://github.com/Tayrtahn"> Tayrtahn</a> at 2024-03-20 13:37:25 UTC

---

PR changed 16 files with 43 additions and 43 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> Requires https://github.com/space-wizards/RobustToolbox/pull/4979
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Cleans up some obsolete method calls.
> 
> ## Why / Balance / Technical
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Cleaning up obsolete Dirty calls in RT required changing the signatures of some public methods in SharedPhysicsSystem. This updates the calls to those methods here in Content to use the new signatures passing in UIDs.
> 
> 


</details>