### PR TITLE
Mirror: Fix mailing units turning into disposal units while recharging.

### DIFF
--- a/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
+++ b/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
@@ -22,6 +22,9 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
     private const string AnimationKey = "disposal_unit_animation";
 
+    private const string DefaultFlushState = "disposal-flush";
+    private const string DefaultChargeState = "disposal-charging";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -101,12 +104,18 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         sprite.LayerSetVisible(DisposalUnitVisualLayers.Base, state == VisualState.Anchored);
         sprite.LayerSetVisible(DisposalUnitVisualLayers.BaseFlush, state is VisualState.Flushing or VisualState.Charging);
 
+        var chargingState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseCharging, out var chargingLayer)
+            ? sprite.LayerGetState(chargingLayer)
+            : new RSI.StateId(DefaultChargeState);
+
         // This is a transient state so not too worried about replaying in range.
         if (state == VisualState.Flushing)
         {
             if (!_animationSystem.HasRunningAnimation(uid, AnimationKey))
             {
-                var flushState = new RSI.StateId("disposal-flush");
+                var flushState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseFlush, out var flushLayer)
+                    ? sprite.LayerGetState(flushLayer)
+                    : new RSI.StateId(DefaultFlushState);
 
                 // Setup the flush animation to play
                 var anim = new Animation
@@ -124,7 +133,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
                                 // Return to base state (though, depending on how the unit is
                                 // configured we might get an appearance change event telling
                                 // us to go to charging state)
-                                new AnimationTrackSpriteFlick.KeyFrame("disposal-charging", (float) unit.FlushDelay.TotalSeconds)
+                                new AnimationTrackSpriteFlick.KeyFrame(chargingState, (float) unit.FlushDelay.TotalSeconds)
                             }
                         },
                     }
@@ -147,7 +156,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         }
         else if (state == VisualState.Charging)
         {
-            sprite.LayerSetState(DisposalUnitVisualLayers.BaseFlush, new RSI.StateId("disposal-charging"));
+            sprite.LayerSetState(DisposalUnitVisualLayers.BaseFlush, chargingState);
         }
         else
         {

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -16,6 +16,8 @@
       map: [ "enum.DisposalUnitVisualLayers.Unanchored" ]
     - state: disposal
       map: [ "enum.DisposalUnitVisualLayers.Base" ]
+    - state: disposal-charging
+      map: [ "enum.DisposalUnitVisualLayers.BaseCharging" ]
     - state: disposal-flush
       map: [ "enum.DisposalUnitVisualLayers.BaseFlush" ]
     - state: dispover-charge


### PR DESCRIPTION
## Mirror of  PR #26383: [Fix mailing units turning into disposal units while recharging.](https://github.com/space-wizards/space-station-14/pull/26383) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `94e4755a8de6885c97fac1cfb767144e8e07981a`

PR opened by <img src="https://avatars.githubusercontent.com/u/32041239?v=4" width="16"/><a href="https://github.com/nikthechampiongr"> nikthechampiongr</a> at 2024-03-24 11:57:45 UTC

---

PR changed 2 files with 14 additions and 3 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> fixes #18275
> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> This fixes mailing units appearing as disposal units when flushed.
> 
> ## Technical details
> <!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
> The states were hardcoded.
> 
> Now they are not.
> 
> Bug seems to have been introduced in #17803 as a part of a larger refactor on disposal units. To my understanding, this was made in error with the logic that no other objects would ever have a different animation when flushing and charging but I am not sure. 
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> <!--
> Make sure to take this Changelog template out of the comment block in order for it to show up.
> :cl:
> - add: Added fun!
> - remove: Removed fun!
> - tweak: Changed fun!
> - fix: Fixed fun!
> -->
> :cl: 
> - fix: Mailing units no longer spontaneously turn into disposal units when flushed.


</details>