### PR TITLE
Remove glibc from shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,6 @@ let
     SDL2
     libGL
     openal
-    glibc
     freetype
     fluidsynth
     soundfont-fluid


### PR DESCRIPTION
Change just for the nix devenv,

Currently it pulls glibc from 23.11, which breaks the devenv if the rest of your system is on a different version, such as unstable.