### PR TITLE
Set RollForward Behavior to Patch

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "disable"
+    "rollForward": "patch"
   }
 }


### PR DESCRIPTION
This is apparently a more desirable behavior for global.json, as it allows servers running any version of Dotnet 8.0.1xx to automatically switch to a newer version than the base. This update was apparently required for DS14, NS14, and Syndicate Station to work properly, since Linux servers can't actually run 8.0.100, and the earliest they can use is 8.0.105(which is still a viable version). 