### PR TITLE
Default to Separated UI Layout

### DIFF
--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -93,16 +93,16 @@ namespace Content.Client.Gameplay
             var screenTypeString = _configurationManager.GetCVar(CCVars.UILayout);
             if (!Enum.TryParse(screenTypeString, out ScreenType screenType))
             {
-                screenType = default;
+                screenType = ScreenType.Separated;
             }
 
             switch (screenType)
             {
-                case ScreenType.Default:
-                    _uiManager.LoadScreen<DefaultGameScreen>();
-                    break;
                 case ScreenType.Separated:
                     _uiManager.LoadScreen<SeparatedChatGameScreen>();
+                    break;
+                case ScreenType.Overlay:
+                    _uiManager.LoadScreen<OverlayChatGameScreen>();
                     break;
             }
 

--- a/Content.Client/UserInterface/Screens/OverlayChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/OverlayChatGameScreen.xaml
@@ -1,4 +1,4 @@
-﻿<screens:DefaultGameScreen
+﻿<screens:OverlayChatGameScreen
     xmlns="https://spacestation14.io"
     xmlns:screens="clr-namespace:Content.Client.UserInterface.Screens"
     xmlns:menuBar="clr-namespace:Content.Client.UserInterface.Systems.MenuBar.Widgets"
@@ -30,4 +30,4 @@
     <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
     <chat:ResizableChatBox Name="Chat" Access="Protected" />
     <alerts:AlertsUI Name="Alerts" Access="Protected" />
-</screens:DefaultGameScreen>
+</screens:OverlayChatGameScreen>

--- a/Content.Client/UserInterface/Screens/OverlayChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/OverlayChatGameScreen.xaml.cs
@@ -6,9 +6,9 @@ using Robust.Client.UserInterface.XAML;
 namespace Content.Client.UserInterface.Screens;
 
 [GenerateTypedNameReferences]
-public sealed partial class DefaultGameScreen : InGameScreen
+public sealed partial class OverlayChatGameScreen : InGameScreen
 {
-    public DefaultGameScreen()
+    public OverlayChatGameScreen()
     {
         RobustXamlLoader.Load(this);
 

--- a/Content.Client/UserInterface/Screens/ScreenType.cs
+++ b/Content.Client/UserInterface/Screens/ScreenType.cs
@@ -3,11 +3,11 @@ namespace Content.Client.UserInterface.Screens;
 public enum ScreenType
 {
     /// <summary>
-    ///     The modern SS14 user interface.
-    /// </summary>
-    Default,
-    /// <summary>
     ///     The classic SS13 user interface.
     /// </summary>
-    Separated
+    Separated,
+    /// <summary>
+    ///     The temporary SS14 user interface.
+    /// </summary>
+    Overlay,
 }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -322,11 +322,11 @@ public sealed class ChatUIController : UIController
             $"{size.X.ToString(CultureInfo.InvariantCulture)},{size.Y.ToString(CultureInfo.InvariantCulture)}";
         switch (UIManager.ActiveScreen)
         {
-            case OverlayChatGameScreen _:
-                _config.SetCVar(CCVars.OverlayScreenChatSize, stringSize);
-                break;
             case SeparatedChatGameScreen _:
                 _config.SetCVar(CCVars.SeparatedScreenChatSize, stringSize);
+                break;
+            case OverlayChatGameScreen _:
+                _config.SetCVar(CCVars.OverlayScreenChatSize, stringSize);
                 break;
             default:
                 // do nothing

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -264,15 +264,15 @@ public sealed class ChatUIController : UIController
 
         switch (UIManager.ActiveScreen)
         {
-            case DefaultGameScreen defaultScreen:
-                chatBox = defaultScreen.ChatBox;
-                chatSizeRaw = _config.GetCVar(CCVars.DefaultScreenChatSize);
-                SetChatSizing(chatSizeRaw, defaultScreen, setting);
-                break;
             case SeparatedChatGameScreen separatedScreen:
                 chatBox = separatedScreen.ChatBox;
                 chatSizeRaw = _config.GetCVar(CCVars.SeparatedScreenChatSize);
                 SetChatSizing(chatSizeRaw, separatedScreen, setting);
+                break;
+            case OverlayChatGameScreen overlayScreen:
+                chatBox = overlayScreen.ChatBox;
+                chatSizeRaw = _config.GetCVar(CCVars.OverlayScreenChatSize);
+                SetChatSizing(chatSizeRaw, overlayScreen, setting);
                 break;
             default:
                 // this could be better?
@@ -322,8 +322,8 @@ public sealed class ChatUIController : UIController
             $"{size.X.ToString(CultureInfo.InvariantCulture)},{size.Y.ToString(CultureInfo.InvariantCulture)}";
         switch (UIManager.ActiveScreen)
         {
-            case DefaultGameScreen _:
-                _config.SetCVar(CCVars.DefaultScreenChatSize, stringSize);
+            case OverlayChatGameScreen _:
+                _config.SetCVar(CCVars.OverlayScreenChatSize, stringSize);
                 break;
             case SeparatedChatGameScreen _:
                 _config.SetCVar(CCVars.SeparatedScreenChatSize, stringSize);

--- a/Content.Client/UserInterface/Systems/Vote/VoteUIController.cs
+++ b/Content.Client/UserInterface/Systems/Vote/VoteUIController.cs
@@ -23,11 +23,11 @@ public sealed class VoteUIController : UIController
     {
         switch (UIManager.ActiveScreen)
         {
-            case DefaultGameScreen game:
-                _votes.SetPopupContainer(game.VoteMenu);
-                break;
             case SeparatedChatGameScreen separated:
                 _votes.SetPopupContainer(separated.VoteMenu);
+                break;
+            case OverlayChatGameScreen overlay:
+                _votes.SetPopupContainer(overlay.VoteMenu);
                 break;
         }
     }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1598,8 +1598,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> UILayout =
             CVarDef.Create("ui.layout", "Separated", CVar.CLIENTONLY | CVar.ARCHIVE);
 
-        public static readonly CVarDef<string> DefaultScreenChatSize =
-            CVarDef.Create("ui.default_chat_size", "", CVar.CLIENTONLY | CVar.ARCHIVE);
+        public static readonly CVarDef<string> OverlayScreenChatSize =
+            CVarDef.Create("ui.overlay_chat_size", "", CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<string> SeparatedScreenChatSize =
             CVarDef.Create("ui.separated_chat_size", "0.6,0", CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1596,7 +1596,7 @@ namespace Content.Shared.CCVar
          */
 
         public static readonly CVarDef<string> UILayout =
-            CVarDef.Create("ui.layout", "Default", CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("ui.layout", "Separated", CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<string> DefaultScreenChatSize =
             CVarDef.Create("ui.default_chat_size", "", CVar.CLIENTONLY | CVar.ARCHIVE);


### PR DESCRIPTION
# Description

<sub>~~Change from Nyano~~</sub>
Uses space a lot better. The old layout still exists if people want it for whatever reason.
I also renamed "Default" to "Overlay", which should stay anyway if the default change is denied.

---

<details><summary><h1>Media</h1></summary>
<p>

## Separated

![image](https://github.com/Simple-Station/Einstein-Engines/assets/77995199/b97c4373-99ac-4ac5-80a5-149122238551)

## Overlay

![image](https://github.com/Simple-Station/Einstein-Engines/assets/77995199/3891756f-91f0-4336-b075-6c461ee1b8e6)

</p>
</details>

---

# Changelog

:cl:
- tweak: UI layout now defaults to separated, the old one is still available in settings
