### PR TITLE
Update Nix Direnv .NET SDK

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ in import (builtins.fetchTarball {
 
 let
   dependencies = with pkgs; [
-    dotnetCorePackages.sdk_8_0
+    dotnetCorePackages.sdk_8_0_1xx
     glfw
     SDL2
     libGL


### PR DESCRIPTION
# Description

Nixpkgs updated `8.0.x` to `8.0.3xx` but we need `8.0.1xx`
