### PR TITLE
Sign Language!

### DIFF
--- a/Content.Shared/Language/LanguagePrototype.cs
+++ b/Content.Shared/Language/LanguagePrototype.cs
@@ -16,6 +16,12 @@ public sealed class LanguagePrototype : IPrototype
     [DataField(required: true)]
     public bool ObfuscateSyllables;
 
+    // <summary>
+    // If true, will mark the language as a SignLanguage and will be handled as such, this variable is nullable. (Please do not put SignLanguage = false or i will choke you, this does nothing!)
+    // </summary>
+    [DataField(required: false)]
+    public bool SignLanguage;
+
     /// <summary>
     ///     Lists all syllables that are used to obfuscate a message a listener cannot understand if obfuscateSyllables is true.
     ///     Otherwise uses all possible phrases the creature can make when trying to say anything.

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -33,6 +33,9 @@ chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
      [true] {$entityName} {$message}[/italic]
     }
 
+chat-manager-entity-signlanguage-message = [italic]{$entityName} signs "[BubbleContent]{$message}[/BubbleContent]"[/italic]
+chat-manager-entity-signlanguage-obfuscated = [italic]{$entityName} signs something.[/italic]
+
 chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {$message}
 chat-manager-send-ooc-wrap-message = OOC: {$playerName}: {$message}
 chat-manager-send-ooc-patron-wrap-message = OOC: [color={$patronColor}]{$playerName}[/color]: {$message}

--- a/Resources/Locale/en-US/language/languages.ftl
+++ b/Resources/Locale/en-US/language/languages.ftl
@@ -4,6 +4,9 @@ language-Universal-description = What are you?
 language-GalacticCommon-name = Galactic common
 language-GalacticCommon-description = The standard Galatic language, most commonly used for inter-species communications and legal work.
 
+language-SignLanguage-name = Sign Language
+language-SignLanguage-description = The standard Galatic sign language, used by those that are unable to speak or speak Galactic Common.
+
 language-Bubblish-name = Bubblish
 language-Bubblish-description = The language of Slimes. Being a mixture of bubbling noises and pops it's very difficult to speak for humans without the use of mechanical aids.
 

--- a/Resources/Prototypes/Language/languages.yml
+++ b/Resources/Prototypes/Language/languages.yml
@@ -31,6 +31,14 @@
   - nah
   - wah
 
+# The common galactic Sign Language!
+- type: language
+  id: SignLanguage
+  signLanguage: true
+  obfuscateSyllables: false
+  replacement:
+  - "*incomprehensible*"
+
 # Spoken by slimes.
 - type: language
   id: Bubblish


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Sign Language!

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Require: #43 
Gives a new way to speak, Sign Languages using the Language system by only adding a nullable variable.
Sign Language uses the default Emote system, meaning its will not get picked up by Radio or others devices or get blocked by accents.

When a Sign Language is on, "Say/Whisper" will talk in Sign Language, Emote will still act like normal emotes.

The Glorious Sign Language has arrived... and there can be more then one!

*Note: Theres only 5 Files Changed but because #43 is not merged its will show more changes, DO NOT MERGE UNTIL #43 IS MERGED*

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Merge PR #43 
- [x] Add SignLanguage Method.
- [x] ftl files

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/Simple-Station/Einstein-Engines/assets/45297731/9bb282fd-1566-45e2-ad9b-19a86b0549db)
![image](https://github.com/Simple-Station/Einstein-Engines/assets/45297731/9716ba18-d09b-47e4-b8aa-97b3d1cba7d1)
![image](https://github.com/Simple-Station/Einstein-Engines/assets/45297731/2224a22c-fda7-4d02-a42e-4e85b2081ef7)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Sign Languages!
