### PR TITLE
Mirror 26421: Nerf Ninja's Research Stealing

### DIFF
--- a/Content.Server/Research/Systems/ResearchStealerSystem.cs
+++ b/Content.Server/Research/Systems/ResearchStealerSystem.cs
@@ -1,11 +1,13 @@
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Systems;
+using Robust.Shared.Random;
 
 namespace Content.Server.Research.Systems;
 
 public sealed class ResearchStealerSystem : SharedResearchStealerSystem
 {
     [Dependency] private readonly SharedResearchSystem _research = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -24,16 +26,26 @@ public sealed class ResearchStealerSystem : SharedResearchStealerSystem
         if (!TryComp<TechnologyDatabaseComponent>(target, out var database))
             return;
 
-        var ev = new ResearchStolenEvent(uid, target, database.UnlockedTechnologies);
+        var ev = new ResearchStolenEvent(uid, target, new());
+        var count = _random.Next(comp.MinToSteal, comp.MaxToSteal + 1);
+        for (var i = 0; i < count; i++)
+        {
+            if (database.UnlockedTechnologies.Count == 0)
+                break;
+
+            var toRemove = _random.Pick(database.UnlockedTechnologies);
+            if (_research.TryRemoveTechnology((target, database), toRemove))
+                ev.Techs.Add(toRemove);
+        }
         RaiseLocalEvent(uid, ref ev);
-        // oops, no more advanced lasers!
-        _research.ClearTechs(target, database);
+
+        args.Handled = true;
     }
 }
 
 /// <summary>
-/// Event raised on the user when research is stolen from a R&D server.
+/// Event raised on the user when research is stolen from a RND server.
 /// Techs contains every technology id researched.
 /// </summary>
 [ByRefEvent]
-public record struct ResearchStolenEvent(EntityUid Used, EntityUid Target, List<String> Techs);
+public record struct ResearchStolenEvent(EntityUid Used, EntityUid Target, List<string> Techs);

--- a/Content.Shared/Research/Components/ResearchStealerComponent.cs
+++ b/Content.Shared/Research/Components/ResearchStealerComponent.cs
@@ -14,4 +14,16 @@ public sealed partial class ResearchStealerComponent : Component
     /// </summary>
     [DataField("delay"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan Delay = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// The minimum number of technologies that will be stolen
+    /// </summary>
+    [DataField]
+    public int MinToSteal = 4;
+
+    /// <summary>
+    /// The maximum number of technologies that will be stolen
+    /// </summary>
+    [DataField]
+    public int MaxToSteal = 8;
 }

--- a/Resources/Prototypes/Objectives/ninja.yml
+++ b/Resources/Prototypes/Objectives/ninja.yml
@@ -39,8 +39,8 @@
       sprite: Structures/Machines/server.rsi
       state: server
   - type: NumberObjective
-    min: 5
-    max: 10
+    min: 9
+    max: 13
     title: objective-condition-steal-research-title
   - type: StealResearchCondition
 


### PR DESCRIPTION
## Mirror of  PR #26421: [Nerf ninja research stealing](https://github.com/space-wizards/space-station-14/pull/26421) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `3b9c5d43ec97a0693ced0118fcfcb8467aa5595e`

PR opened by <img src="https://avatars.githubusercontent.com/u/98561806?v=4" width="16"/><a href="https://github.com/EmoGarbage404"> EmoGarbage404</a> at 2024-03-25 01:44:21 UTC - merged at 2024-03-26 00:52:27 UTC

---

PR changed 4 files with 75 additions and 8 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
> <!-- The text between the arrows are comments - they will not be visible on your PR. -->
> 
> ## About the PR
> <!-- What did you change in this PR? -->
> Changes ninja gloves to steal a flat rate of techs instead of wiping all of them.
> Additionally adjusts the objective to require 1 to 2 steals to reach the target amount.
> 
> ## Why / Balance
> <!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
> Ninja's stealing research was previously an extremely trivial and annoying objective. For them, you can pretty easily break into the server room and wait out the 20 second doafter. It's not super hard and you're not exactly shooting off warning signs. At this very low cost, science loses literally an hour+ of progress.
> 
> This nerf changes it to only remove 4-8 random technologies, or only about 20k to 40k points worth. This is still pretty crippling but not awful. On top of that, they need to do it twice to hit the target amounts of 9 to 12 techs stolen. This provides counterplay by actually giving science a chance to see that all their research has vanished before the ninja is already gone. It also makes it significantly harder for ninja to obliterate everything science has done.
> 
> ## Media
> <!-- 
> PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
> Small fixes/refactors are exempt.
> Any media may be used in SS14 progress reports, with clear credit given.
> 
> If you're unsure whether your PR will require media, ask a maintainer.
> 
> Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
> -->
> 
> - [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
> 
> ## Breaking changes
> <!--
> List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
> -->
> 
> **Changelog**
> <!--
> Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
> -->
> 
> :cl:
> - tweak: Ninjas no longer wipe all technologies when using their gloves on a research server.
> 


</details>