### PR TITLE
Mirror 26441: Fix atmos NaN error

### DIFF
--- a/Content.Server/Atmos/Components/AirtightComponent.cs
+++ b/Content.Server/Atmos/Components/AirtightComponent.cs
@@ -9,27 +9,53 @@ namespace Content.Server.Atmos.Components
     {
         public (EntityUid Grid, Vector2i Tile) LastPosition { get; set; }
 
+        /// <summary>
+        /// The directions in which this entity should block airflow, relative to its own reference frame.
+        /// </summary>
         [DataField("airBlockedDirection", customTypeSerializer: typeof(FlagSerializer<AtmosDirectionFlags>))]
         public int InitialAirBlockedDirection { get; set; } = (int) AtmosDirection.All;
 
+        /// <summary>
+        /// The directions in which the entity is currently blocking airflow, relative to the grid that the entity is on.
+        /// I.e., this is a variant of <see cref="InitialAirBlockedDirection"/> that takes into account the entity's
+        /// current rotation.
+        /// </summary>
         [ViewVariables]
         public int CurrentAirBlockedDirection;
 
-        [DataField("airBlocked")]
+        /// <summary>
+        /// Whether the airtight entity is currently blocking airflow.
+        /// </summary>
+        [DataField]
         public bool AirBlocked { get; set; } = true;
 
-        [DataField("fixVacuum")]
+        /// <summary>
+        /// If true, entities on this tile will attempt to draw air from surrounding tiles when they become unblocked
+        /// and currently have no air. This is generally only required when <see cref="NoAirWhenFullyAirBlocked"/> is
+        /// true, or if the entity is likely to occupy the same tile as another no-air airtight entity.
+        /// </summary>
+        [DataField]
         public bool FixVacuum { get; set; } = true;
+        // I think fixvacuum exists to ensure that repeatedly closing/opening air-blocking doors doesn't end up
+        // depressurizing a room. However it can also effectively be used as a means of generating gasses for free
+        // TODO ATMOS Mass conservation. Make it actually push/pull air from adjacent tiles instead of destroying & creating,
 
+
+        // TODO ATMOS Do we need these two fields?
         [DataField("rotateAirBlocked")]
         public bool RotateAirBlocked { get; set; } = true;
 
+        // TODO ATMOS remove this? What is this even for??
         [DataField("fixAirBlockedDirectionInitialize")]
         public bool FixAirBlockedDirectionInitialize { get; set; } = true;
 
-        [DataField("noAirWhenFullyAirBlocked")]
+        /// <summary>
+        /// If true, then the tile that this entity is on will have no air at all if all directions are blocked.
+        /// </summary>
+        [DataField]
         public bool NoAirWhenFullyAirBlocked { get; set; } = true;
 
+        /// <inheritdoc cref="CurrentAirBlockedDirection"/>
         [Access(Other = AccessPermissions.ReadWriteExecute)]
         public AtmosDirection AirBlockedDirection => (AtmosDirection)CurrentAirBlockedDirection;
     }

--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -85,8 +85,6 @@ namespace Content.Server.Atmos.EntitySystems
         private bool AirtightMove(Entity<AirtightComponent> ent, ref MoveEvent ev)
         {
             var (owner, airtight) = ent;
-            if (!airtight.RotateAirBlocked || airtight.InitialAirBlockedDirection == (int)AtmosDirection.Invalid)
-                return false;
 
             airtight.CurrentAirBlockedDirection = (int) Rotate((AtmosDirection)airtight.InitialAirBlockedDirection, ev.NewRotation);
             var pos = airtight.LastPosition;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -399,10 +399,7 @@ public sealed partial class AtmosphereSystem
         args.Handled = true;
     }
 
-    private void GridFixTileVacuum(
-        Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> ent,
-        TileAtmosphere tile,
-        float volume)
+    private void GridFixTileVacuum(TileAtmosphere tile)
     {
         DebugTools.AssertNotNull(tile.Air);
         DebugTools.Assert(tile.Air?.Immutable == false );
@@ -415,6 +412,9 @@ public sealed partial class AtmosphereSystem
             if (adj?.Air != null)
                 count++;
         }
+
+        if (count == 0)
+            return;
 
         var ratio = 1f / count;
         var totalTemperature = 0f;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -272,7 +272,7 @@ namespace Content.Server.Atmos.EntitySystems
             tile.Air = new GasMixture(volume){Temperature = Atmospherics.T20C};
 
             if (data.FixVacuum)
-                GridFixTileVacuum(ent, tile, volume);
+                GridFixTileVacuum(tile);
         }
 
         private void QueueRunTiles(

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -78,12 +78,13 @@ public partial class AtmosphereSystem
             if (!_airtightQuery.TryGetComponent(ent, out var airtight))
                 continue;
 
+            fixVacuum |= airtight.FixVacuum;
+
             if(!airtight.AirBlocked)
                 continue;
 
             blockedDirs |= airtight.AirBlockedDirection;
             noAirWhenBlocked |= airtight.NoAirWhenFullyAirBlocked;
-            fixVacuum |= airtight.FixVacuum;
 
             if (blockedDirs == AtmosDirection.All && noAirWhenBlocked && fixVacuum)
                 break;

--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -62,9 +62,9 @@ namespace Content.Server.Atmos
             get => _temperature;
             set
             {
-                DebugTools.Assert(!float.IsNaN(_temperature));
-                if (Immutable) return;
-                _temperature = MathF.Min(MathF.Max(value, Atmospherics.TCMB), Atmospherics.Tmax);
+                DebugTools.Assert(!float.IsNaN(value));
+                if (!Immutable)
+                    _temperature = MathF.Min(MathF.Max(value, Atmospherics.TCMB), Atmospherics.Tmax);
             }
         }
 
@@ -91,6 +91,7 @@ namespace Content.Server.Atmos
             if (volume < 0)
                 volume = 0;
 
+            DebugTools.Assert(!float.IsNaN(temp));
             _temperature = temp;
             Moles = moles;
             Volume = volume;

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -28,6 +28,9 @@ namespace Content.Server.Atmos
         [ViewVariables]
         public TileAtmosphere? PressureSpecificTarget { get; set; }
 
+        /// <summary>
+        /// This is either the pressure difference, or the quantity of moles transferred if monstermos is enabled.
+        /// </summary>
         [ViewVariables]
         public float PressureDifference { get; set; }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -104,7 +104,6 @@
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
   - type: Airtight
-    fixVacuum: true
     noAirWhenFullyAirBlocked: false
   - type: RadiationBlocker
     resistance: 3

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -80,7 +80,6 @@
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
   - type: Airtight
-    fixVacuum: true
   - type: Occluder
   - type: Damageable
     damageContainer: StructuralInorganic

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -57,7 +57,6 @@
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
   - type: Airtight
-    fixVacuum: true
     noAirWhenFullyAirBlocked: false
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -93,7 +93,6 @@
     - type: Physics
       canCollide: false
     - type: Airtight
-      fixVacuum: true
       airBlocked: false
       noAirWhenFullyAirBlocked: true
     - type: RadiationBlocker
@@ -158,7 +157,6 @@
       sprite: Structures/Doors/edge_door_hazard.rsi
       snapCardinals: false
     - type: Airtight
-      fixVacuum: true
       airBlocked: false
       noAirWhenFullyAirBlocked: false
       airBlockedDirection:

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -40,7 +40,6 @@
       path: /Audio/Effects/stonedoor_openclose.ogg
   - type: Appearance
   - type: Airtight
-    fixVacuum: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -38,7 +38,6 @@
   - type: Weldable
     time: 2
   - type: Airtight
-    fixVacuum: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -59,7 +59,6 @@
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
   - type: Airtight
-    fixVacuum: true
   - type: RadiationBlocker
     resistance: 2
   - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -130,7 +130,6 @@
   - type: Appearance
   - type: WiresVisuals
   - type: Airtight
-    fixVacuum: true
     noAirWhenFullyAirBlocked: false
     airBlockedDirection:
       - South

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -83,7 +83,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: Airtight
-    fixVacuum: true
 
 - type: entity
   id: PlasticFlapsAirtightOpaque
@@ -101,4 +100,3 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: Airtight
-    fixVacuum: true


### PR DESCRIPTION
## Mirror of  PR #26441: [Fix atmos NaN error](https://github.com/space-wizards/space-station-14/pull/26441) from <img src="https://avatars.githubusercontent.com/u/10567778?v=4" alt="space-wizards" width="22"/> [space-wizards](https://github.com/space-wizards)/[space-station-14](https://github.com/space-wizards/space-station-14)

###### `fdb4a61487db9fc67714c913832427063abdea42`

PR opened by <img src="https://avatars.githubusercontent.com/u/60421075?v=4" width="16"/><a href="https://github.com/ElectroJr"> ElectroJr</a> at 2024-03-26 04:27:08 UTC - merged at 2024-03-26 04:44:56 UTC

---

PR changed 16 files with 43 additions and 25 deletions.

The PR had the following labels:
- Status: Needs Review


---

<details open="true"><summary><h1>Original Body</h1></summary>

> - Fixes a bug I introduced in #22521 that caused the temperature to be set to `NaN`. I don't know for sure, but I assume this is causing the current atmos issues
> - Fixes `FixVacuum` not working after #22521
> - Removes some redundant yaml that was setting FixVacuum to its default value
> 
> :cl:
> - fix: Fixed an atmos bug, which was (probably) causing atmospherics on the station to behave incorrectly.


</details>