### PR TITLE
Port Frictionless Space

### DIFF
--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Movement.Components
         // Weightless
         public const float DefaultMinimumFrictionSpeed = 0.005f;
         public const float DefaultWeightlessFriction = 1f;
-        public const float DefaultWeightlessFrictionNoInput = 0.2f;
+        public const float DefaultWeightlessFrictionNoInput = 0f; // Parkstation-FrictionlessSpace
         public const float DefaultWeightlessModifier = 0.7f;
         public const float DefaultWeightlessAcceleration = 1f;
 

--- a/Content.Shared/Physics/FrictionRemoverSystem.cs
+++ b/Content.Shared/Physics/FrictionRemoverSystem.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 
-namespace Content.Shared.SimpleStation14.Physics;
+namespace Content.Shared.Physics;
 
 public sealed class FrictionRemoverSystem : EntitySystem
 {
@@ -19,7 +19,7 @@ public sealed class FrictionRemoverSystem : EntitySystem
 
     private void RemoveDampening(EntityUid uid, PhysicsComponent component, PhysicsSleepEvent args)
     {
-        _physics.SetAngularDamping(component, 0, false);
-        _physics.SetLinearDamping(component, 0);
+        _physics.SetAngularDamping(uid, component, 0f, false);
+        _physics.SetLinearDamping(uid, component, 0f);
     }
 }

--- a/Content.Shared/SimpleStation14/Physics/FrictionRemoverSystem.cs
+++ b/Content.Shared/SimpleStation14/Physics/FrictionRemoverSystem.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.SimpleStation14.Physics;
+
+public sealed class FrictionRemoverSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PhysicsComponent, PhysicsSleepEvent>(RemoveDampening);
+    }
+
+
+    private void RemoveDampening(EntityUid uid, PhysicsComponent component, PhysicsSleepEvent args)
+    {
+        _physics.SetAngularDamping(component, 0, false);
+        _physics.SetLinearDamping(component, 0);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -51,9 +51,7 @@
       Female: UnisexMoth
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
-    weightlessAcceleration: 1.5 # Move around more easily in space.
-    weightlessFriction: 1
-    weightlessModifier: 1
+    weightlessAcceleration: 2.5 # Move around more easily in space. # Parkstation-FrictionlessSpace
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -51,7 +51,7 @@
       Female: UnisexMoth
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
-    weightlessAcceleration: 2.5 # Move around more easily in space. # Parkstation-FrictionlessSpace
+    weightlessAcceleration: 2.5 # Move around more easily in space.
   - type: Flammable
     damage:
       types:


### PR DESCRIPTION
# Description

This ports https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/pull/46.
This PR is something I consider a key feature adjacent to Space Wind Rework and its accompanying updates, and is an essential part of the space station experience.
In practice, this weirdly enough makes being launched into space a bit easier to survive, since instead of needing to throw potentially hundreds of items, you can simply throw enough items to get started flying in the direction of the station and will eventually float back to the station. 

---

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/assets/77995199/5570ef35-16e2-493a-ac35-738f27751346

https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/assets/77995199/51fba943-8dce-4265-a9cc-7181155eb8de

https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/assets/77995199/cd6c0511-2639-4e14-8160-426ba7f2ba73

---
</p>
</details> 

# Changelog

:cl: DEATHB4DEFEAT
- tweak: Space has suddenly become less dense (objects don't slow down in space)
- remove: Moths are unable to move in space
- tweak: Moths have way better control in zero gravity environments
