### PR TITLE
Finally Put the meta.json Shema to Use

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
     "omnisharp.analyzeOpenDocumentsOnly": true,
-    "dotnet.defaultSolution": "SpaceStation14.sln"
+    "dotnet.defaultSolution": "SpaceStation14.sln",
+    "json.schemas": [
+        {
+            "fileMatch": [ "**/meta.json" ],
+            "url": "https://raw.githubusercontent.com/Simple-Station/Einstein-Engines/master/.github/rsi-schema.json"
+        }
+    ]
 }


### PR DESCRIPTION
# Description

This file has been chilling unused (excluding that one workflow) for so long, and it's so useful.
Forks might want to edit the URL to theirs, but it's unlikely they'll ever want to change it.
