### PR TITLE
Cherry-Pick Carrypets From Delta-V

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -13,6 +13,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: bat
       sprite: Mobs/Animals/bat.rsi
+  - type: Carriable #DeltaV
   - type: Speech
     speechSounds: Squeak
     speechVerb: SmallMob
@@ -180,6 +181,8 @@
     noMovementLayers:
       movement:
         state: chicken-0
+  - type: Carriable #Delta-V
+    freeHandsRequired: 1
   - type: Fixtures
     fixtures:
       fix1:
@@ -571,6 +574,8 @@
         - MobMask
         layer:
         - MobLayer
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -819,6 +824,8 @@
     noMovementLayers:
       movement:
         state: crab
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -880,6 +887,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goat
       sprite: Mobs/Animals/goat.rsi
+  - type: Carriable #DeltaV
   - type: Fixtures
     fixtures:
       fix1:
@@ -972,6 +980,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goose
       sprite: Mobs/Animals/goose.rsi
+  - type: Carriable #DeltaV
   - type: Fixtures
     fixtures:
       fix1:
@@ -1218,6 +1227,7 @@
       sprite: "Effects/creampie.rsi"
       state: "creampie_human"
       visible: false
+  - type: Carriable #DeltaV
   - type: Hands
   - type: GenericVisualizer
     visuals:
@@ -1736,6 +1746,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: lizard
       sprite: Mobs/Animals/lizard.rsi
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1790,6 +1801,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: slug
       sprite: Mobs/Animals/slug.rsi
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1 
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1842,6 +1855,7 @@
     noMovementLayers:
       movement:
         state: frog
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1893,6 +1907,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: parrot
       sprite: Mobs/Animals/parrot.rsi
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1
   - type: Fixtures
     fixtures:
       fix1:
@@ -1948,6 +1964,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: penguin
       sprite: Mobs/Animals/penguin.rsi
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2077,6 +2094,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: snake
       sprite: Mobs/Animals/snake.rsi
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2131,6 +2149,7 @@
     noMovementLayers:
       movement:
         state: tarantula
+  - type: Carriable #DeltaV ##shiva deserves to be held
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2315,6 +2334,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: possum
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2390,6 +2410,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: raccoon
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2454,6 +2475,7 @@
     noMovementLayers:
       movement:
         state: fox
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2534,6 +2556,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: corgi
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Speech
     speechVerb: Canine
@@ -2689,6 +2712,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: cat
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2867,6 +2891,8 @@
         Base: kitten_dead
       Dead:
         Base: kitten_dead
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -2897,6 +2923,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: sloth
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2954,6 +2981,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: ferret
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -3153,6 +3181,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: pig
       sprite: Mobs/Animals/pig.rsi
+  - type: Carriable #DeltaV
   - type: Fixtures
     fixtures:
       fix1:
@@ -3228,6 +3257,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: nymph
       sprite: Mobs/Animals/nymph.rsi
+  - type: Carriable #DeltaV
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -13,7 +13,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: bat
       sprite: Mobs/Animals/bat.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Speech
     speechSounds: Squeak
     speechVerb: SmallMob
@@ -181,7 +181,7 @@
     noMovementLayers:
       movement:
         state: chicken-0
-  - type: Carriable #Delta-V
+  - type: Carriable
     freeHandsRequired: 1
   - type: Fixtures
     fixtures:
@@ -574,7 +574,7 @@
         - MobMask
         layer:
         - MobLayer
-  - type: Carriable #DeltaV
+  - type: Carriable
     freeHandsRequired: 1
   - type: Tag
     tags:
@@ -824,7 +824,7 @@
     noMovementLayers:
       movement:
         state: crab
-  - type: Carriable #DeltaV
+  - type: Carriable
     freeHandsRequired: 1
   - type: Physics
   - type: Fixtures
@@ -887,7 +887,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goat
       sprite: Mobs/Animals/goat.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Fixtures
     fixtures:
       fix1:
@@ -980,7 +980,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goose
       sprite: Mobs/Animals/goose.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Fixtures
     fixtures:
       fix1:
@@ -1227,7 +1227,7 @@
       sprite: "Effects/creampie.rsi"
       state: "creampie_human"
       visible: false
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Hands
   - type: GenericVisualizer
     visuals:
@@ -1746,7 +1746,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: lizard
       sprite: Mobs/Animals/lizard.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1801,8 +1801,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: slug
       sprite: Mobs/Animals/slug.rsi
-  - type: Carriable #DeltaV
-    freeHandsRequired: 1 
+  - type: Carriable
+    freeHandsRequired: 1
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1855,7 +1855,7 @@
     noMovementLayers:
       movement:
         state: frog
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -1907,7 +1907,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: parrot
       sprite: Mobs/Animals/parrot.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
     freeHandsRequired: 1
   - type: Fixtures
     fixtures:
@@ -1964,7 +1964,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: penguin
       sprite: Mobs/Animals/penguin.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2094,7 +2094,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: snake
       sprite: Mobs/Animals/snake.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2149,7 +2149,7 @@
     noMovementLayers:
       movement:
         state: tarantula
-  - type: Carriable #DeltaV ##shiva deserves to be held
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2334,7 +2334,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: possum
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2410,7 +2410,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: raccoon
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2475,7 +2475,7 @@
     noMovementLayers:
       movement:
         state: fox
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2556,7 +2556,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: corgi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Speech
     speechVerb: Canine
@@ -2712,7 +2712,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: cat
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2891,7 +2891,7 @@
         Base: kitten_dead
       Dead:
         Base: kitten_dead
-  - type: Carriable #DeltaV
+  - type: Carriable
     freeHandsRequired: 1
   - type: Butcherable
     spawned:
@@ -2923,7 +2923,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: sloth
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -2981,7 +2981,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: ferret
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -3181,7 +3181,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: pig
       sprite: Mobs/Animals/pig.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Fixtures
     fixtures:
       fix1:
@@ -3257,7 +3257,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: nymph
       sprite: Mobs/Animals/nymph.rsi
-  - type: Carriable #DeltaV
+  - type: Carriable
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -22,6 +22,7 @@
       layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
+    - type: Carriable #DeltaV - this is for you, deltanedas o7
     - type: CombatMode
     - type: Physics
     - type: Fixtures

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -22,7 +22,7 @@
       layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
-    - type: Carriable #DeltaV - this is for you, deltanedas o7
+    - type: Carriable # This one is for you, deltanedas o7
     - type: CombatMode
     - type: Physics
     - type: Fixtures

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -170,7 +170,7 @@
   description: He's da mini rat. He don't make da roolz.
   noSpawn: true #Must be configured to a King or the AI breaks.
   components:
-  - type: Carriable #DeltaV
+  - type: Carriable
     freeHandsRequired: 1
   - type: CombatMode
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -170,6 +170,8 @@
   description: He's da mini rat. He don't make da roolz.
   noSpawn: true #Must be configured to a King or the AI breaks.
   components:
+  - type: Carriable #DeltaV
+    freeHandsRequired: 1
   - type: CombatMode
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.5

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -17,7 +17,7 @@
     layers:
     - map: [ "enum.DamageStateVisualLayers.Base" ]
       state: blue_adult_slime
-  - type: Carriable #DeltaV 
+  - type: Carriable
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: basic slime
   id: MobAdultSlimes
   parent: [ SimpleMobBase, MobCombat ]
@@ -17,6 +17,7 @@
     layers:
     - map: [ "enum.DamageStateVisualLayers.Base" ]
       state: blue_adult_slime
+  - type: Carriable #DeltaV 
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: basic
   id: MobSpaceBasic
   parent: SimpleSpaceMobBase


### PR DESCRIPTION

# Description
Cherry-picks https://github.com/DeltaV-Station/Delta-v/pull/1145

All credit goes to the original author of the PR.

Original description is: "adds carriable component to a lot of animals that didn't have it"

---

# Why

## Renault my beloved!!!

---


<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/Simple-Station/Einstein-Engines/assets/69920617/12777e9b-7d00-4df2-8703-a7f9e42ea1c6)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Froffy025
- add: You can now carry most of the station pets.