### PR TITLE
Fix Clothing Quick-Equip

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -62,6 +62,11 @@ public abstract class ClothingSystem : EntitySystem
     {
         foreach (var slotDef in userEnt.Comp1.Slots)
         {
+            // Do not attempt to quick-equip clothing in pocket slots.
+            // We should probably add a special flag to SlotDefinition to skip quick equip if more similar slots get added.
+            if (slotDef.SlotFlags.HasFlag(SlotFlags.POCKET))
+                continue;
+
             if (!_invSystem.CanEquip(userEnt, toEquipEnt, slotDef.Name, out _, slotDef, userEnt, toEquipEnt))
                 continue;
 

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -176,7 +176,7 @@ public abstract partial class InventorySystem
             };
 
             _doAfter.TryStartDoAfter(args);
-            return false;
+            return true; // Changed to return true even if the item wasn't equipped instantly
         }
 
         if (!_containerSystem.Insert(itemUid, slotContainer))


### PR DESCRIPTION
# Description
For some reason, ClothingSystem.TryEquip would return false if there's a do-after to equip the clothing. This had caused all quick-equip attempts on SMALL ITEMS to fail and ended up with every SMALL clothing item being equipped into one of the pocket slots (which have no equip delays).

Also fixes quick swap - see the comments below.

# Changelog

:cl:
- fix: Equipping clothing using the Z key works correctly again.
