### PR TITLE
Fix Them Pesky Job Requirements

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -96,7 +96,7 @@ public sealed partial class JobRequirementsManager
         return CheckRoleTime(job.Requirements, out reason);
     }
 
-    public bool CheckRoleTime(HashSet<JobRequirement>? requirements, [NotNullWhen(false)] out FormattedMessage? reason, string? localePrefix = null)
+    public bool CheckRoleTime(HashSet<JobRequirement>? requirements, [NotNullWhen(false)] out FormattedMessage? reason, string? localePrefix = "role-timer-")
     {
         reason = null;
 


### PR DESCRIPTION

# Description
Fixes job requirements using wrong locales

Happened because one function had role-timer- as its default locale prefix and the other that called the first had null as the default.

---

<details><summary><h1>Media</h1></summary><p>

![image](https://github.com/Simple-Station/Einstein-Engines/assets/69920617/0d02c40a-a58f-4b48-89f5-e0a6b4ff75b9)

![image](https://github.com/Simple-Station/Einstein-Engines/assets/69920617/f3b651dd-492e-47c0-aa9f-74998c78f792)

</p></details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Job requirements are now displayed correctly.