### PR TITLE
Frictionfull Space

### DIFF
--- a/Content.Server/Station/Systems/StationDampeningSystem.cs
+++ b/Content.Server/Station/Systems/StationDampeningSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.Station.Events;
+using Content.Shared.Physics;
+
+namespace Content.Server.Station.Systems;
+
+public sealed class StationDampeningSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<StationPostInitEvent>(OnInitStation);
+    }
+
+    private void OnInitStation(ref StationPostInitEvent ev)
+    {
+        foreach (var grid in ev.Station.Comp.Grids)
+        {
+            // If the station grid doesn't have defined dampening, give it a small dampening by default
+            // This will ensure cargo tech pros won't fling the station 1000 megaparsec away from the galaxy
+            if (!TryComp<PassiveDampeningComponent>(grid, out var dampening))
+            {
+                dampening = AddComp<PassiveDampeningComponent>(grid);
+                dampening.Enabled = true;
+                dampening.LinearDampening = 0.01f;
+                dampening.AngularDampening = 0.01f;
+            }
+        }
+    }
+}

--- a/Content.Shared/Physics/FrictionRemoverSystem.cs
+++ b/Content.Shared/Physics/FrictionRemoverSystem.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -19,7 +20,15 @@ public sealed class FrictionRemoverSystem : EntitySystem
 
     private void RemoveDampening(EntityUid uid, PhysicsComponent component, PhysicsSleepEvent args)
     {
-        _physics.SetAngularDamping(uid, component, 0f, false);
-        _physics.SetLinearDamping(uid, component, 0f);
+        var linear = 0f;
+        var angular = 0f;
+        if (TryComp<PassiveDampeningComponent>(uid, out var dampening) && dampening.Enabled)
+        {
+            linear = dampening.LinearDampening;
+            angular = dampening.AngularDampening;
+        }
+
+        _physics.SetAngularDamping(uid, component, angular, false);
+        _physics.SetLinearDamping(uid, component, linear);
     }
 }

--- a/Content.Shared/Physics/PassiveDampeningComponent.cs
+++ b/Content.Shared/Physics/PassiveDampeningComponent.cs
@@ -1,0 +1,18 @@
+namespace Content.Shared.Physics;
+
+/// <summary>
+///     A component that allows an entity to have friction (linear and angular dampening)
+///     even when not being affected by gravity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PassiveDampeningComponent : Component
+{
+    [DataField]
+    public bool Enabled = true;
+
+    [DataField]
+    public float LinearDampening = 0.2f;
+
+    [DataField]
+    public float AngularDampening = 0.2f;
+}

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -60,6 +60,9 @@ entities:
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
+    - type: PassiveDampening # To prevent cargotechs from flingling it away.
+      linearDampening: 0.01
+      angularDampening: 0.01
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree


### PR DESCRIPTION
# Description
Makes it so that the station and the ATS get a very tiny bit of friction to prevent cargo tech pros from sending either of those out of this galaxy cluster (which has actually happened multiple times on two servers and required either admin intervention or early round ending).

# Technical details
Added a PassiveDampeningComponent which defines how much friction an entity receives while in 0g. FrictionRemoverSystem was updated to try to fetch this component from an entity before updating its dampening. A new system was added to automatically add this component (if it's not already defined) to all station grids.

# Media
See the #when-you-code-it channel for a preview. It's kinda hard to demonstrate, but after a few minutes, stations and the ATS come to an almost complete stop.

# Changelog
:cl:
- tweak: Space stations now have a tiny bit of velocity dampening to prevent them from being flunged into the void.
