### PR TITLE
More Gamemodes

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -3,6 +3,30 @@
 [RegisterComponent, Access(typeof(RampingStationEventSchedulerSystem))]
 public sealed partial class RampingStationEventSchedulerComponent : Component
 {
+    /// <summary>
+    ///     The maximum number by which the event rate will be multiplied when shift time reaches the end time.
+    /// </summary>
+    [DataField]
+    public float ChaosModifier = 3f;
+
+    /// <summary>
+    ///     The minimum number by which the event rate will be multiplied when the shift has just begun.
+    /// </summary>
+    [DataField]
+    public float StartingChaosRatio = 0.1f;
+
+    /// <summary>
+    ///     The number by which all event delays will be multiplied. Unlike chaos, remains constant throughout the shift.
+    /// </summary>
+    [DataField]
+    public float EventDelayModifier = 1f;
+
+    /// <summary>
+    ///     The number by which average expected shift length is multiplied. Higher values lead to slower chaos growth.
+    /// </summary>
+    public float ShiftLengthModifier = 1f;
+
+    // Everything below is overridden in the RampingStationEventSchedulerSystem based on CVars
     [DataField("endTime"), ViewVariables(VVAccess.ReadWrite)]
     public float EndTime;
 

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
@@ -1,2 +1,5 @@
 survival-title = Survival
 survival-description = No internal threats, but how long can the station survive increasingly chaotic and frequent events?
+
+hellshift-title = Hellshift
+hellshift-description = The station rolled a "one" in a luck check. Can the crew make it to the end?

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -132,6 +132,16 @@
   components:
   - type: RampingStationEventScheduler
 
+- type: entity
+  id: HellshiftStationEventScheduler
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: RampingStationEventScheduler
+    chaosModifier: 4 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
+    startingChaosRatio: 0.025 # Starts as slow as survival, but quickly ramps up
+    shiftLengthModifier: 2.5
+
 # variation passes
 - type: entity
   id: BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -10,6 +10,17 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
+  id: SurvivalHellshift
+  alias:
+    - hellshift
+  showInVote: true
+  name: hellshift-title
+  description: hellshift-description
+  rules:
+    - HellshiftStationEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
   id: AllAtOnce
   name: all-at-once-title
   description: all-at-once-description
@@ -90,7 +101,7 @@
     - traitor
   name: traitor-title
   description: traitor-description
-  showInVote: false
+  showInVote: true # if people want to antag let it be traitors instead of self-antaggers
   rules:
     - Traitor
     - SubGamemodesRule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -101,7 +101,7 @@
     - traitor
   name: traitor-title
   description: traitor-description
-  showInVote: true # if people want to antag let it be traitors instead of self-antaggers
+  showInVote: true
   rules:
     - Traitor
     - SubGamemodesRule


### PR DESCRIPTION
# Description
Adds traitors and hellshift to the list of gamemodes offered by the gamemode vote.

Traitors just make sense.

Hellshift is a new version of survival. It starts out roughly as slow as survival, but it slowly devolves into a torrent of station events as frequent as one every 10-30 seconds. Good for when there's no other ~~self-antaggers~~ players to spice up the shift, or when there's one too many security officers to deal with all the threats this brings.

# Technical details
Had to refactor a lot of RampingStationEventScheduler. Firstly, it was total shitcode, secondly, it had everything hardcoded, thirdly, it had a bug that made it possible for events to appear with little to no delay whatsoever. Now its component features four data fields that can be used to configure the scheduler and its system contains cleaner and more readable code.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/Simple-Station/Einstein-Engines/assets/69920617/e9831b63-0339-4849-981a-bdc58c7beabe)

![image](https://github.com/Simple-Station/Einstein-Engines/assets/69920617/bfa117d3-cb66-456b-9425-1b3bf80cd60f)


</p>
</details>

# Changelog
:cl:
- tweak: Players can now vote on two more gamemodes: Traitors and Hellshift.
