### PR TITLE
Lay Down via Keybind

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -69,6 +69,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.OfferItem);
+            human.AddFunction(ContentKeyFunctions.ToggleStanding);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -184,6 +184,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.MoveStoredItem);
             AddButton(ContentKeyFunctions.RotateStoredItem);
             AddButton(ContentKeyFunctions.OfferItem);
+            AddButton(ContentKeyFunctions.ToggleStanding);
 
             AddHeader("ui-options-header-interaction-adv");
             AddButton(ContentKeyFunctions.SmartEquipBackpack);

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -203,6 +203,7 @@ public sealed partial class NPCCombatSystem
                 return;
             }
 
+            gun.Target = comp.Target; // This ensures that the bullet won't fly over the target if it's downed
             _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
         }
     }

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -203,7 +203,7 @@ public sealed partial class NPCCombatSystem
                 return;
             }
 
-            gun.Target = comp.Target; // This ensures that the bullet won't fly over the target if it's downed
+            _gun.SetTarget(gun, comp.Target);
             _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
         }
     }

--- a/Content.Server/Standing/LayingDownComponent.cs
+++ b/Content.Server/Standing/LayingDownComponent.cs
@@ -3,9 +3,6 @@ namespace Content.Server.Standing;
 [RegisterComponent]
 public sealed partial class LayingDownComponent : Component
 {
-    /// <summary>
-    ///     Movement speed multiplier when not standing.
-    /// </summary>
     [DataField]
     public float DownedSpeedMultiplier = 0.15f;
 

--- a/Content.Server/Standing/LayingDownComponent.cs
+++ b/Content.Server/Standing/LayingDownComponent.cs
@@ -10,5 +10,5 @@ public sealed partial class LayingDownComponent : Component
     public TimeSpan Cooldown = TimeSpan.FromSeconds(2.5f);
 
     [DataField]
-    public TimeSpan CooldownUntil = TimeSpan.Zero;
+    public TimeSpan NextToggleAttempt = TimeSpan.Zero;
 }

--- a/Content.Server/Standing/LayingDownComponent.cs
+++ b/Content.Server/Standing/LayingDownComponent.cs
@@ -1,0 +1,17 @@
+namespace Content.Server.Standing;
+
+[RegisterComponent]
+public sealed partial class LayingDownComponent : Component
+{
+    /// <summary>
+    ///     Movement speed multiplier when not standing.
+    /// </summary>
+    [DataField]
+    public float DownedSpeedMultiplier = 0.15f;
+
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(2.5f);
+
+    [DataField]
+    public TimeSpan CooldownUntil = TimeSpan.Zero;
+}

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.Standing;
 
-// Unfortunately cannot be shared because some standing conditions are server-side only
+/// <remarks>Unfortunately cannot be shared because some standing conditions are server-side only</remarks>
 public sealed class LayingDownSystem : EntitySystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
@@ -17,6 +17,7 @@ public sealed class LayingDownSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popups = default!;
     [Dependency] private readonly Shared.Standing.StandingStateSystem _standing = default!; // WHY IS THERE TWO DIFFERENT STANDING SYSTEMS?!
     [Dependency] private readonly IGameTiming _timing = default!;
+
 
     public override void Initialize()
     {
@@ -35,6 +36,7 @@ public sealed class LayingDownSystem : EntitySystem
 
         CommandBinds.Unregister<LayingDownSystem>();
     }
+
 
     private void DoRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, object args)
     {
@@ -77,7 +79,6 @@ public sealed class LayingDownSystem : EntitySystem
     {
         var success = layingDown.CooldownUntil <= _timing.CurTime;
 
-        // Note: &= leads to the right-hand side being evaluated regardless of what's on left-hand, so we use normal assignment here instead.
         if (_standing.IsDown(uid, standingState))
         {
             success = success && _standing.Stand(uid, standingState, force: false);

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -53,11 +53,10 @@ public sealed class LayingDownSystem : EntitySystem
 
     private void ToggleStanding(ICommonSession? session)
     {
-        if (session is not { } playerSession
-            || ((playerSession.AttachedEntity is not { Valid: true } uid
-                || !Exists(uid)))
-            || (!TryComp<StandingStateComponent>(uid, out var standingState)
-                || !TryComp<LayingDownComponent>(uid, out var layingDown)))
+        if (session is not { AttachedEntity: { Valid: true } uid } playerSession
+            || !Exists(uid)
+            || !TryComp<StandingStateComponent>(uid, out var standingState)
+            || !TryComp<LayingDownComponent>(uid, out var layingDown))
             return;
 
         // If successful, show popup to self and others. Otherwise, only to self.

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Standing;
 public sealed class LayingDownSystem : EntitySystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
-    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;r
+    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedPopupSystem _popups = default!;
     [Dependency] private readonly Shared.Standing.StandingStateSystem _standing = default!; // WHY IS THERE TWO DIFFERENT STANDING SYSTEMS?!
     [Dependency] private readonly IGameTiming _timing = default!;

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -1,0 +1,94 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Input;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Standing;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Standing;
+
+// Unfortunately cannot be shared because some standing conditions are server-side only
+public sealed class LayingDownSystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;r
+    [Dependency] private readonly SharedPopupSystem _popups = default!;
+    [Dependency] private readonly Shared.Standing.StandingStateSystem _standing = default!; // WHY IS THERE TWO DIFFERENT STANDING SYSTEMS?!
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.ToggleStanding, InputCmdHandler.FromDelegate(ToggleStanding, handle: false, outsidePrediction: false))
+            .Register<LayingDownSystem>();
+
+        SubscribeLocalEvent<LayingDownComponent, StoodEvent>(DoRefreshMovementSpeed);
+        SubscribeLocalEvent<LayingDownComponent, DownedEvent>(DoRefreshMovementSpeed);
+        SubscribeLocalEvent<LayingDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeed);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        CommandBinds.Unregister<LayingDownSystem>();
+    }
+
+    private void DoRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, object args)
+    {
+        _movement.RefreshMovementSpeedModifiers(uid);
+    }
+
+    private void OnRefreshMovementSpeed(EntityUid uid, LayingDownComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (TryComp<StandingStateComponent>(uid, out var standingState) && standingState.Standing)
+            return;
+
+        args.ModifySpeed(component.DownedSpeedMultiplier, component.DownedSpeedMultiplier);
+    }
+
+    private void ToggleStanding(ICommonSession? session)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if ((playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid)))
+            return;
+
+        if (!TryComp<StandingStateComponent>(uid, out var standingState) || !TryComp<LayingDownComponent>(uid, out var layingDown))
+            return;
+
+        var success = ToggleStandingImpl(uid, standingState, layingDown, out var popupBranch);
+
+        // If successful, show popup to self and others. Otherwise, only to self.
+        _popups.PopupEntity(Loc.GetString($"laying-comp-{popupBranch}-self", ("entity", uid)), uid, uid);
+
+        if (success)
+        {
+            _popups.PopupEntity(Loc.GetString($"laying-comp-{popupBranch}-other", ("entity", uid)), uid, Filter.PvsExcept(uid), true);
+
+            layingDown.CooldownUntil = _timing.CurTime + layingDown.Cooldown;
+        }
+    }
+
+    private bool ToggleStandingImpl(EntityUid uid, StandingStateComponent standingState, LayingDownComponent layingDown, out string popupBranch)
+    {
+        var success = layingDown.CooldownUntil <= _timing.CurTime;
+
+        // Note: &= leads to the right-hand side being evaluated regardless of what's on left-hand, so we use normal assignment here instead.
+        if (_standing.IsDown(uid, standingState))
+        {
+            success = success && _standing.Stand(uid, standingState, force: false);
+            popupBranch = success ? "stand-success" : "stand-fail";
+        }
+        else
+        {
+            success = success && _standing.Down(uid, standingState: standingState, playSound: true, dropHeldItems: false);
+            popupBranch = success ? "lay-success" : "lay-fail";
+        }
+
+        return success;
+    }
+}

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -53,13 +53,11 @@ public sealed class LayingDownSystem : EntitySystem
 
     private void ToggleStanding(ICommonSession? session)
     {
-        if (session is not { } playerSession)
-            return;
-
-        if ((playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid)))
-            return;
-
-        if (!TryComp<StandingStateComponent>(uid, out var standingState) || !TryComp<LayingDownComponent>(uid, out var layingDown))
+        if (session is not { } playerSession
+            || ((playerSession.AttachedEntity is not { Valid: true } uid
+                || !Exists(uid)))
+            || (!TryComp<StandingStateComponent>(uid, out var standingState)
+                || !TryComp<LayingDownComponent>(uid, out var layingDown)))
             return;
 
         var success = ToggleStandingImpl(uid, standingState, layingDown, out var popupBranch);

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -54,8 +54,7 @@ public sealed class LayingDownSystem : EntitySystem
     private void OnParentChanged(EntityUid uid, LayingDownComponent component, EntParentChangedMessage args)
     {
         // If the entity is not on a grid, try to make it stand up to avoid issues
-        if (!_standing.IsDown(uid)
-            || !TryComp<StandingStateComponent>(uid, out var standingState)
+        if (!TryComp<StandingStateComponent>(uid, out var standingState)
             || standingState.Standing
             || Transform(uid).GridUid != null)
             return;

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -55,6 +55,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction ZoomIn = "ZoomIn";
         public static readonly BoundKeyFunction ResetZoom = "ResetZoom";
         public static readonly BoundKeyFunction OfferItem = "OfferItem";
+        public static readonly BoundKeyFunction ToggleStanding = "ToggleStanding";
 
         public static readonly BoundKeyFunction ArcadeUp = "ArcadeUp";
         public static readonly BoundKeyFunction ArcadeDown = "ArcadeDown";

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -143,7 +143,7 @@ public sealed partial class GunComponent : Component
     /// <summary>
     /// Who the gun is being requested to shoot at directly.
     /// </summary>
-    [ViewVariables, Access(Other = AccessPermissions.ReadWrite)]
+    [ViewVariables]
     public EntityUid? Target = null;
 
     /// <summary>

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -143,7 +143,7 @@ public sealed partial class GunComponent : Component
     /// <summary>
     /// Who the gun is being requested to shoot at directly.
     /// </summary>
-    [ViewVariables]
+    [ViewVariables, Access(Other = AccessPermissions.ReadWrite)]
     public EntityUid? Target = null;
 
     /// <summary>

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -206,6 +206,14 @@ public abstract partial class SharedGunSystem : EntitySystem
     }
 
     /// <summary>
+    /// Sets the targeted entity of the gun. Should be called before attempting to shoot to avoid shooting over the target.
+    /// </summary>
+    public void SetTarget(GunComponent gun, EntityUid target)
+    {
+        gun.Target = target;
+    }
+
+    /// <summary>
     /// Attempts to shoot at the target coordinates. Resets the shot counter after every shot.
     /// </summary>
     public void AttemptShoot(EntityUid user, EntityUid gunUid, GunComponent gun, EntityCoordinates toCoordinates)

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -137,6 +137,7 @@ ui-options-function-swap-hands = Swap hands
 ui-options-function-move-stored-item = Move stored item
 ui-options-function-rotate-stored-item = Rotate stored item
 ui-options-function-offer-item = Offer something
+ui-options-function-toggle-standing = Toggle standing
 ui-options-static-storage-ui = Lock storage window to hotbar
 
 ui-options-function-smart-equip-backpack = Smart-equip to backpack

--- a/Resources/Locale/en-US/movement/laying.ftl
+++ b/Resources/Locale/en-US/movement/laying.ftl
@@ -1,0 +1,7 @@
+laying-comp-lay-success-self = You lay down.
+laying-comp-lay-success-other = {THE($entity)} lays down.
+laying-comp-lay-fail-self = You can't lay down right now.
+
+laying-comp-stand-success-self = You stand up.
+laying-comp-stand-success-other = {THE($entity)} stands up.
+laying-comp-stand-fail-self = You can't stand up right now.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -310,6 +310,7 @@
   - type: FireVisuals
     alternateState: Standing
   - type: OfferItem
+  - type: LayingDown
 
 - type: entity
   save: false

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -258,6 +258,9 @@ binds:
 - function: OfferItem
   type: State
   key: F
+- function: ToggleStanding
+  type: State
+  key: R
 - function: ShowDebugConsole
   type: State
   key: Tilde


### PR DESCRIPTION
# Description
Adds a way to lay down/crawl using a keybind (R by default) similarly to ss13. It has the same effects as falling down after slipping or buckling to a bed, except you don't drop items while doing so and can (very slowly) move around. This opens new gameplay and roleplay possibilities.

You can only toggle standing/laying once in 2.5 seconds (this cooldown is to prevent pro gamers from spamming it). It shows a small popup to everyone. If the attempt fails for whatever reason - being buckled, sleeping, stunned, or anything else - another popup is shown that's only visible to you.

It's been tested and made sure that the system works correctly with buckling, sleeping, being stunned, and shocked.

<details><summary><h1>Media</h1></summary>
<p>

18 mb recording won't fit on github:

https://cdn.discordapp.com/attachments/1255902264309321851/1260354667578261504/weeee-2024-07-10_00.57.23.mp4?ex=668f0441&is=668db2c1&hm=d338a3499bf47780a66b7ba96d5e8830d8cb4167064423b8983b2d0144b7aa88&

</p>
</details>

---

# Changelog

:cl:
- add: You can now lie down and stand up at will! The default keybind for it is "R", but it can be changed in settings.
