### PR TITLE
Cherry-Pick PR "Wallmount Substations Can Once Again Be Created" #27138

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -157,6 +157,7 @@
       - APCElectronics
       - SMESMachineCircuitboard
       - SubstationMachineCircuitboard
+      - WallmountSubstationElectronics
       - CellRechargerCircuitboard
       - BorgChargerCircuitboard
       - WeaponCapacitorRechargerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -244,6 +244,16 @@
   - type: Battery
     maxCharge: 2000000
     startingCharge: 2000000
+  - type: ContainerFill
+    containers:
+      board: [ WallmountSubstationElectronics ]
+      capacitor: [ CapacitorStockPart ]
+      powercell: [ PowerCellSmall ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+      capacitor: !type:Container
+      powercell: !type:Container
 
 # Construction Frame
 - type: entity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -26,7 +26,13 @@
         steps:
         - material: Cable
           amount: 5
-          doAfter: 2
+          doAfter: 0.5
+        - material: CableMV
+          amount: 5
+          doAfter: 0.5
+        - material: CableHV
+          amount: 5
+          doAfter: 0.5
         - tool: Screwing
           doAfter: 2
 
@@ -41,11 +47,33 @@
           icon:
             sprite: "Objects/Misc/module.rsi"
             state: "charger_APC"
-          doAfter: 1
+          doAfter: 0.5
+        - anyTags:
+            - PowerCell
+            - PowerCellSmall
+          store: powercell
+          name: a powercell
+          icon:
+            sprite: "Objects/Power/power_cells.rsi"
+            state: "medium"
+          doAfter: 0.5
+        - tag: CapacitorStockPart
+          name: a capacitor
+          store: capacitor
+          icon:
+            sprite: "Objects/Misc/stock_parts.rsi"
+            state: "capacitor"
+          doAfter: 0.5
       - to: frame
         completed:
         - !type:GivePrototype
           prototype: CableApcStack1
+          amount: 5
+        - !type:GivePrototype
+          prototype: CableMVStack1
+          amount: 5
+        - !type:GivePrototype
+          prototype: CableHVStack1
           amount: 5
         steps:
         - tool: Cutting

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -604,7 +604,7 @@
   completetime: 4
   materials:
      Steel: 50
-     Glass: 350
+     Glass: 450
 
 - type: latheRecipe
   id: SMESMachineCircuitboard


### PR DESCRIPTION
# Description

Cherry-picks https://github.com/space-wizards/space-station-14/pull/27138

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: osjarw
- add: Wallmount substation electronics can now be created at an autolathe.
