### PR TITLE
Foreigner Minor Fixes

### DIFF
--- a/Content.Server/Traits/Assorted/ForeignerTraitComponent.cs
+++ b/Content.Server/Traits/Assorted/ForeignerTraitComponent.cs
@@ -21,11 +21,13 @@ public sealed partial class ForeignerTraitComponent : Component
     /// <summary>
     ///     Whether this trait prevents the entity from understanding the base language.
     /// </summary>
+    [DataField]
     public bool CantUnderstand = true;
 
     /// <summary>
     ///     Whether this trait prevents the entity from speaking the base language.
     /// </summary>
+    [DataField]
     public bool CantSpeak = true;
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -24,7 +24,7 @@
   - type: HandheldTranslator
     enabled: false
   - type: Clothing # To allow equipping translators on the neck slot
-    slots: [neck, pocket]
+    slots: [neck]
     equipDelay: 0.3
     unequipDelay: 0.3
     quickEquip: false # Would conflict
@@ -52,7 +52,7 @@
 - type: entity
   noSpawn: true
   id: TranslatorForeigner
-  parent: [ Translator, PowerCellSlotHighItem ]
+  parent: [ TranslatorUnpowered, PowerCellSlotHighItem ]
   name: foreigner's translator
   description: A special-issue translator that helps foreigner's speak and understand this station's primary language.
 


### PR DESCRIPTION
# Description

#525 Added foreigner traits, now during testing I revealed a few bugs. This PR fixes them:
- The light version now correctly allows you to understand common (it would not because I forgot to add [DataField])
- The translator now correctly starts with a high-capacity power cell
- Equipping the translator in a pocket slot no longer takes time

<details><summary><h1>Media</h1></summary><p>

![image](https://github.com/user-attachments/assets/4d2cabc7-2ce2-498b-822b-8ff9b82eea7d)

</p></details>

# Changelog
:cl:
- fix: Foreigner traits now work correctly.