### PR TITLE
Shock Collar Tweak

### DIFF
--- a/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarComponent.cs
+++ b/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarComponent.cs
@@ -2,5 +2,11 @@ namespace Content.Server.ShockCollar;
 
 [RegisterComponent]
 public sealed partial class ShockCollarComponent : Component
-{}
+{
+    [DataField]
+    public int ShockDamage = 1;
+
+    [DataField]
+    public TimeSpan ShockTime = TimeSpan.FromSeconds(2);
+}
 

--- a/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class ShockCollarSystem : EntitySystem
             && !_useDelay.TryResetDelay((uid, useDelay), true))
             return;
 
-        _electrocutionSystem.TryDoElectrocution(containerEnt, null, 5, TimeSpan.FromSeconds(2), true);
+        _electrocutionSystem.TryDoElectrocution(containerEnt, null, 1, TimeSpan.FromSeconds(2), true, ignoreInsulation: true);
     }
 }
 

--- a/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class ShockCollarSystem : EntitySystem
             && !_useDelay.TryResetDelay((uid, useDelay), true))
             return;
 
-        _electrocutionSystem.TryDoElectrocution(containerEnt, null, 1, TimeSpan.FromSeconds(2), true, ignoreInsulation: true);
+        _electrocutionSystem.TryDoElectrocution(containerEnt, null, component.ShockDamage, component.ShockTime, true, ignoreInsulation: true);
     }
 }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -743,6 +743,7 @@
       - ShellShotgunPractice
       - WeaponLaserCarbinePractice
       - WeaponDisablerPractice
+      - ShockCollard
       # DeltaV - .38 special ammo - Add various .38 special ammo to security techfab
       - MagazineBoxSpecial
       - MagazineBoxSpecialPractice

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -743,7 +743,7 @@
       - ShellShotgunPractice
       - WeaponLaserCarbinePractice
       - WeaponDisablerPractice
-      - ShockCollard
+      - ShockCollar
       # DeltaV - .38 special ammo - Add various .38 special ammo to security techfab
       - MagazineBoxSpecial
       - MagazineBoxSpecialPractice


### PR DESCRIPTION
# Description
Shock collars were a useful thing in nyano for a long time, but security could never put them to use because they could be removed instantly, so they were forgotten about.

Now that we have enquip delays, shock collars can be useful for controlling unruly prisoners (or unruly secoffs who like to harm baton passengers). Only two problems is there's no way to manufacture them, and they can be quite deadly when used repeatedly. This PR solves both of these issues, and also fixes a little bug:
- Shock collars can be manufactured at the secfab.
- Shock collars deal 1 shock damage instead of 5.
- The shock ignores insulation.

<details><summary><h1>Media</h1></summary><p>

![image](https://github.com/user-attachments/assets/16d8efdf-c3de-46de-9a48-401d99c92b29)

</p></details>

---

# Changelog
:cl:
- tweak: Shock collars can now be manufactured in the security techfab. They also deal less damage and ignore insulated gloves.
