### PR TITLE
More Zoom Levels

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1642,6 +1642,23 @@ namespace Content.Shared.CCVar
             CVarDef.Create("viewport.width", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /*
+         * FOV
+         */
+
+        /// <summary>
+        ///     The number by which the current FOV size is divided for each level.
+        /// </summary>
+        public static readonly CVarDef<float> ZoomLevelStep =
+            CVarDef.Create("fov.zoom_step", 1.2f, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
+        ///     How many times the player can zoom in until they reach the minimum zoom.
+        ///     This does not affect the maximum zoom.
+        /// </summary>
+        public static readonly CVarDef<int> ZoomLevels =
+            CVarDef.Create("fov.zoom_levels", 7, CVar.SERVER | CVar.REPLICATED);
+
+        /*
          * UI
          */
 

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -17,9 +17,9 @@ public abstract class SharedContentEyeSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminManager _admin = default!;
 
-    public const float ZoomMod = 1.5f;
+    public const float ZoomMod = 1.2f;
     public static readonly Vector2 DefaultZoom = Vector2.One;
-    public static readonly Vector2 MinZoom = DefaultZoom * (float)Math.Pow(ZoomMod, -3);
+    public static readonly Vector2 MinZoom = DefaultZoom * (float)Math.Pow(1.5f, -3); // Using 1.5f because that's what used to be default ZoomMod before.
 
     [Dependency] private readonly SharedEyeSystem _eye = default!;
 

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -1,9 +1,11 @@
 using System.Numerics;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Managers;
+using Content.Shared.CCVar;
 using Content.Shared.Ghost;
 using Content.Shared.Input;
 using Content.Shared.Movement.Components;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
@@ -16,10 +18,13 @@ namespace Content.Shared.Movement.Systems;
 public abstract class SharedContentEyeSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminManager _admin = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
-    public const float ZoomMod = 1.2f;
-    public static readonly Vector2 DefaultZoom = Vector2.One;
-    public static readonly Vector2 MinZoom = DefaultZoom * (float)Math.Pow(1.5f, -3); // Using 1.5f because that's what used to be default ZoomMod before.
+    // Will be overridden according to config.
+    public readonly Vector2 DefaultZoom = Vector2.One;
+    public float ZoomMod { get; private set; } = 1f;
+    public int ZoomLevels { get; private set; } = 1;
+    public Vector2 MinZoom { get; private set; } = Vector2.One;
 
     [Dependency] private readonly SharedEyeSystem _eye = default!;
 
@@ -38,12 +43,28 @@ public abstract class SharedContentEyeSystem : EntitySystem
 
         Log.Level = LogLevel.Info;
         UpdatesOutsidePrediction = true;
+
+        Subs.CVar(_config, CCVars.ZoomLevelStep, value =>
+        {
+            ZoomMod = value;
+            RecalculateZoomLevels();
+        }, true);
+        Subs.CVar(_config, CCVars.ZoomLevels, value =>
+        {
+            ZoomLevels = value;
+            RecalculateZoomLevels();
+        }, true);
     }
 
     public override void Shutdown()
     {
         base.Shutdown();
         CommandBinds.Unregister<SharedContentEyeSystem>();
+    }
+
+    private void RecalculateZoomLevels()
+    {
+        MinZoom = DefaultZoom * (float) Math.Pow(ZoomMod, -ZoomLevels);
     }
 
     private void ResetZoom(ICommonSession? session)


### PR DESCRIPTION
# Description
Adds more zoom levels and CVars to configure them.

The defaults make it so that the new minimum zoom is roughly equal to what ss14 had before (29.6%).

# Why
Playing as a tiny character made me love having the screen zoomed in, but having only 3 zoom levels didn't quite allow to set the zoom level to what I wanted. This PR fixes that.

<details><summary><h1>Media</h1></summary><p>


https://github.com/user-attachments/assets/61e56913-1c9d-4590-95ac-686018b5caa9



</p></details>

# Changelog
:cl:
- add: You can now configure your zoom more precisely.
