### PR TITLE
Add Species Restrictions to Loadout Items

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -234,7 +234,7 @@
     sprite: DeltaV/Clothing/Uniforms/Jumpsuit/centcom_officer.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpsuitKilt
   name: kilt
   description: A fine bit o' garb for the lad an' lasses.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/misc_roles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/misc_roles.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: UniformShortsRed
   name: boxing shorts
   description: These are shorts, not boxers.
@@ -10,7 +10,7 @@
     sprite: Clothing/Uniforms/Shorts/Color/red.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: UniformShortsRedWithTop
   name: boxing shorts with top
   description: These are shorts, not boxers.

--- a/Resources/Prototypes/Loadouts/Jobs/engineering.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/engineering.yml
@@ -4,6 +4,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer
@@ -49,6 +52,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -47,6 +47,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -62,6 +65,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -77,6 +83,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -92,6 +101,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -107,6 +119,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -122,6 +137,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -137,6 +155,9 @@
   cost: 3
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -188,6 +209,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Paramedic
@@ -236,6 +260,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -19,6 +19,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Scientist

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -5,6 +5,9 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -19,6 +22,9 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -85,6 +91,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -109,6 +118,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -121,6 +133,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -181,6 +196,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -196,6 +214,9 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -224,6 +245,9 @@
   category: Jobs
   cost: 1
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -60,6 +60,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
      jobs:
         - Lawyer
@@ -84,6 +87,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -108,6 +114,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -132,6 +141,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -169,6 +181,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Reporter

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -4,6 +4,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorBlack
 
@@ -12,6 +16,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorBlue
 
@@ -20,6 +28,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorBrown
 
@@ -28,6 +40,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorGreen
 
@@ -36,6 +52,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorOrange
 
@@ -44,6 +64,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorPurple
 
@@ -52,6 +76,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorRed
 
@@ -60,6 +88,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorWhite
 
@@ -68,6 +100,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesColorYellow
 
@@ -76,6 +112,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesGeta
 
@@ -85,6 +125,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsWork
 
@@ -93,6 +137,10 @@
   category: Shoes
   cost: 2
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsLaceup
 
@@ -101,6 +149,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsWinter
 
@@ -109,6 +161,10 @@
   category: Shoes
   cost: 2
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsCowboyBrown
 
@@ -117,6 +173,10 @@
   category: Shoes
   cost: 2
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsCowboyBlack
 
@@ -125,6 +185,10 @@
   category: Shoes
   cost: 2
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsCowboyWhite
 
@@ -133,6 +197,10 @@
   category: Shoes
   cost: 2
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesBootsCowboyFancy
 
@@ -145,6 +213,9 @@
   items:
     - ClothingShoeSlippersDuck
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Clown
@@ -154,6 +225,10 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesLeather
 
@@ -162,5 +237,9 @@
   category: Shoes
   cost: 1
   exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
   items:
     - ClothingShoesMiscWhite

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -4,6 +4,9 @@
   cost: 2
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -20,6 +23,9 @@
   items:
     - ClothingUniformJumpsuitColorBlack
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -44,6 +50,9 @@
   items:
     - ClothingUniformJumpsuitColorBlue
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -68,6 +77,9 @@
   items:
     - ClothingUniformJumpsuitColorGreen
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -92,6 +104,9 @@
   items:
     - ClothingUniformJumpsuitColorOrange
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -116,6 +131,9 @@
   items:
     - ClothingUniformJumpsuitColorPink
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -140,6 +158,9 @@
   items:
     - ClothingUniformJumpsuitColorRed
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -164,6 +185,9 @@
   items:
     - ClothingUniformJumpsuitColorWhite
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -188,6 +212,9 @@
   items:
     - ClothingUniformJumpsuitColorYellow
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -212,6 +239,9 @@
   items:
     - ClothingUniformJumpsuitColorDarkBlue
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -236,6 +266,9 @@
   items:
     - ClothingUniformJumpsuitColorTeal
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -260,6 +293,9 @@
   items:
     - ClothingUniformJumpsuitColorPurple
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -284,6 +320,9 @@
   items:
     - ClothingUniformJumpsuitColorDarkGreen
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -308,6 +347,9 @@
   items:
     - ClothingUniformJumpsuitColorLightBrown
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -332,6 +374,9 @@
   items:
     - ClothingUniformJumpsuitColorBrown
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -356,6 +401,9 @@
   items:
     - ClothingUniformJumpsuitColorMaroon
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species: Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/costumes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/costumes.yml
@@ -369,7 +369,7 @@
     sprite: Nyanotrasen/Clothing/Misc/under_garments.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformMNKGymBra
   name: MNK gym bra
   description: Maximum performance with MNK sweat blockers.
@@ -405,7 +405,7 @@
     femaleMask: NoMask
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformMNKBlackShoulder
   name: MNK exposed shoulders
   description: A MNK outfit with exposed shoulders.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/costumes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/costumes.yml
@@ -54,7 +54,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Costume/maid.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingCostumeBunnySuit
   name: bunny suit
   description: Ready to go with stockings and a bow tie.
@@ -89,10 +89,10 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpskirt/Decorskirt.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingCostumeNaota
   name: turquoise hoodie and shorts
-  description: A hoodie with a small kangaroo pouch. 
+  description: A hoodie with a small kangaroo pouch.
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/Uniforms/Costume/naota.rsi
@@ -113,7 +113,7 @@
     femaleMask: NoMask
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformDressRed
   name: red dress
   description: A voluminous, fancy red dress.
@@ -125,7 +125,7 @@
     femaleMask: NoMask
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformSwimsuitBlue
   name: blue swimsuit
   description: A form-fitting, hydrodynamic blue swimsuit.
@@ -358,7 +358,7 @@
     femaleMask: NoMask
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformMNKUnderGarment
   name: MNK under garment
   description: MNK ensured comfort for the important bits.
@@ -381,7 +381,7 @@
     femaleMask: NoMask
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformMNKDressBlack
   name: MNK black dress
   description: A sleek black dress sporting a MNK window.


### PR DESCRIPTION
# Description

This is kind of a small PR here, all I'm really doing is adding species(read: Harpy) restrictions to all items that are invalid for a Harpy to wear, and then reparenting items that have a skirt but aren't tagged as such, so that Harpies can wear them. This now makes widespread actual usage of species restrictions in Loadouts. And also this stops people complaining that Harpies can buy items that they cannot wear.

![image](https://github.com/user-attachments/assets/d90a3fdc-8b2c-4fa9-938b-bedcfac0dc7b)

Harpies coincidentally now have a blank Shoes tab.

![image](https://github.com/user-attachments/assets/f3585a90-3518-4288-b305-14c1a675c88d)


# Changelog

:cl:
- fix: Harpies can no longer buy Loadout items that are impossible for them to wear due to having digitigrade legs. 
