### PR TITLE
Mass Contests Affect Camera Shake

### DIFF
--- a/Content.Client/Camera/CameraRecoilSystem.cs
+++ b/Content.Client/Camera/CameraRecoilSystem.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Content.Client.Overlays;
 using Content.Shared.Camera;
 using Content.Shared.CCVar;
 using Content.Shared.Contests;

--- a/Content.Client/Camera/CameraRecoilSystem.cs
+++ b/Content.Client/Camera/CameraRecoilSystem.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
+using Content.Client.Overlays;
 using Content.Shared.Camera;
 using Content.Shared.CCVar;
+using Content.Shared.Contests;
 using Robust.Shared.Configuration;
 
 namespace Content.Client.Camera;
@@ -8,6 +10,7 @@ namespace Content.Client.Camera;
 public sealed class CameraRecoilSystem : SharedCameraRecoilSystem
 {
     [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly ContestsSystem _contests = default!;
 
     private float _intensity;
 
@@ -37,15 +40,15 @@ public sealed class CameraRecoilSystem : SharedCameraRecoilSystem
         if (!Resolve(uid, ref component, false))
             return;
 
-        recoil *= _intensity;
+        var massRatio = _contests.MassContest(uid);
+        var maxRecoil = KickMagnitudeMax / massRatio;
+        recoil *= _intensity / massRatio;
 
-        // Use really bad math to "dampen" kicks when we're already kicked.
         var existing = component.CurrentKick.Length();
-        var dampen = existing / KickMagnitudeMax;
-        component.CurrentKick += recoil * (1 - dampen);
+        component.CurrentKick += recoil * (1 - existing);
 
-        if (component.CurrentKick.Length() > KickMagnitudeMax)
-            component.CurrentKick = component.CurrentKick.Normalized() * KickMagnitudeMax;
+        if (component.CurrentKick.Length() > maxRecoil)
+            component.CurrentKick = component.CurrentKick.Normalized() * maxRecoil;
 
         component.LastKickTime = 0;
     }


### PR DESCRIPTION
# Description

I made this entirely on a whim to prove a point in the middle of a conversation. I have not tested this code, but I'm confident that it will work as advertised. 

This refactors the public KickCamera function so that it no longer: Divides by 1, divides by 1 again, multiplies by 1, normalizes a vector(turning its A value to 1), and then divides said vector by 1 again for good measure.

Instead 1 has been replaced by MassContest, wooh! I also got rid of redundant steps. The effect of this is that characters with greater than human-standard mass are slightly more resistant to all sources of camera shake(Explosions, gravity generator turning off, gunfire, being hit by flying objects, etc), while characters with less than standard human mass experience a greater amount of camera shake.

You're welcome. Now go find a Felinid to shake vigorously. 

# Changelog


:cl:
- add: Camera Shake is now affected by character mass. Small characters experience more camera shake. Large characters experience less. 
