### PR TITLE
Disable height.modifies_zoom

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2260,7 +2260,7 @@ namespace Content.Shared.CCVar
         ///     Whether height & width sliders adjust a player's max view distance
         /// </summary>
         public static readonly CVarDef<bool> HeightAdjustModifiesZoom =
-            CVarDef.Create("heightadjust.modifies_zoom", true, CVar.SERVERONLY);
+            CVarDef.Create("heightadjust.modifies_zoom", false, CVar.SERVERONLY);
 
         /// <summary>
         ///     Enables station goals


### PR DESCRIPTION
# Description

Height Sliders modifying zoom was always going to be temporary, and long term we had planned on phasing it out in favor of allowing Physics to be the balancing factor against players making their characters small. Now that we have features such as Space Wind, Mass Contests, Frictionless Space, and so on, this has come to fruition, and we no longer necessarily need zoom-adjusting to be a balancing factor. Zoom is cited as one of the most common complaints about our codebase, players absolutely seem to not like this, especially since it's not communicated to them in character creation that their viewmodel is going to be adjusted.

This PR does not permanently remove the Modifies_Zoom feature, merely setting it to false by default. Server hosts are still able to re-enable it in their TOML configs if desired, but by default it should be disabled. 