### PR TITLE
Fix 125 Toolshed Commands Being Unusable for Anyone without +HOST

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -279,7 +279,13 @@ namespace Content.Server.Administration.Managers
                 _commandPermissions.LoadPermissionsFromStream(efs);
             }
 
-            if (_res.TryContentFileRead(new ResPath("/toolshedEngineCommandPerms.yml"), out var toolshedPerms))
+            var toolshedPermsPath = new ResPath("/toolshedEngineCommandPerms.yml");
+            if (_res.TryContentFileRead(toolshedPermsPath, out var toolshedPerms))
+            {
+                _commandPermissions.LoadPermissionsFromStream(toolshedPerms);
+            }
+            // This may or may not be necessary. We read the same file again and load the same permissions into a different manager.
+            if (_res.TryContentFileRead(toolshedPermsPath, out toolshedPerms))
             {
                 _toolshedCommandPermissions.LoadPermissionsFromStream(toolshedPerms);
             }

--- a/Resources/toolshedEngineCommandPerms.yml
+++ b/Resources/toolshedEngineCommandPerms.yml
@@ -50,7 +50,8 @@
     - methods
     - ioc
 
-- Commands:
+- Flags: ADMIN
+  Commands:
     - fuck
     - ent
     - as


### PR DESCRIPTION
# Description
For reasons unknown, AdminManager has two command permission managers: _commandPermissions and _toolshedCommandPermissions. It used to load normal command permissions into the former, and toolshed command permissions into the latter. Since _toolshedCommandPermissions is NEVER actually used in checking whether a player can execute a command, all toolshed commands remained unavailable to anyone without +HOST.

This PR provides a bandaid fix for that: it makes it so that the same permissions are loaded into both managers at the same time. It's necessary to load them into _commandPermissions in order to allow regular players to execute them, and it's also necessary to load them into _toolshedCommandPermissions because otherwise the ToolshedManager will complain about those commands lacking permission flags.

This should also fixes some commands such as `spawn`, `pos`, `comp` being inaccessible to admins with +DEBUG and more.

<details><summary><h1>Media</h1></summary><p>

![image](https://github.com/user-attachments/assets/12afedef-0db3-43f2-8335-e95582a4a3f9)

![image](https://github.com/user-attachments/assets/f23ae98a-1e1b-4d28-8446-ca60e8239a03)

Admin-only commands are unaffected:

![image](https://github.com/user-attachments/assets/d64a5a8d-f184-4a9d-bc71-ae80635df626)


</p></details>

---

# Changelog

:cl:
- fix: Fixed toolshed command permissions. This will mostly affect admins who don't have full host access.