### PR TITLE
Restore HoP As A Functional Job

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -3,8 +3,19 @@
   startingInventory:
     PassengerPDA: 5
     ClearPDA: 5
-# Begin Delta-V additions
-    ServiceWorkerPDA: 2
+  # Basic Department PDAs
+    SecurityPDA: 2
+    SecurityCadetPDA: 4
+    MedicalPDA: 2
+    MedicalInternPDA: 4
+    EngineerPDA: 2
+    TechnicalAssistantPDA: 4
+    SciencePDA: 2
+    ResearchAssistantPDA: 4
+    CargoPDA: 2
+    SalvagePDA: 2
+  # HOP's service department
+    ServiceWorkerPDA: 4
     ChefPDA: 2
     BotanistPDA: 2
     BartenderPDA: 2
@@ -17,18 +28,18 @@
     ClownPDA: 1
     MimePDA: 1
     MusicianPDA: 1
-# End Delta-V additions
-    PassengerIDCard: 5
     ClothingHeadsetGrey: 5
-    ClothingHeadsetService: 5 # Delta-V
+    ClothingHeadsetService: 4
+    ClothingHeadsetCargo: 2
+    ClothingHeadsetEngineering: 2
+    ClothingHeadsetMedical: 2
+    ClothingHeadsetScience: 2
     RubberStampApproved: 1
     RubberStampDenied: 1
     Paper: 10
-# Begin Delta-V subtractions
-  #  EncryptionKeyCargo: 2
-  #  EncryptionKeyEngineering: 2
-  #  EncryptionKeyMedical: 2
-  #  EncryptionKeyScience: 2
-  #  EncryptionKeySecurity: 1
-# End Delta-V subtractions
-    EncryptionKeyService: 3
+    EncryptionKeyCargo: 2
+    EncryptionKeyEngineering: 2
+    EncryptionKeyMedical: 2
+    EncryptionKeyScience: 2
+    EncryptionKeySecurity: 2
+    EncryptionKeyService: 4

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -50,7 +50,7 @@
 #  - Security # NoooOoOo!! My HoPcurity!1
 #  - Brig
   - Lawyer
-#  - Cargo
+  - Cargo
 #  - Atmospherics
 #  - Medical
   - Boxer # DeltaV - Add Boxer access


### PR DESCRIPTION
# Description

By request from @OldDanceJacket, this PR does two things. First, it gives the HoP access to Cargo, so that in ODJ's own words, "The Hop can be like the Warden to Cargo. They are Brothers In Bureaucracy". The second thing this PR does is add BASIC department PDAs for each department to the PTECH vendor, enabling the HOP to hire people on as the basic roles for every department, with additional PDAs for the teaching roles(Interns). 

By design, all specialized department roles(Such as Chemistry) cannot be granted by the HOP, and must instead be given by their respective heads of staff. 

# Media

![image](https://github.com/user-attachments/assets/601cee43-f23a-4119-9e5a-e7f987fbd6d8)


# Changelog

:cl:
- add: The Head Of Personnel can now hire people onto basic roles for each department by vending PDAs. 
