### PR TITLE
Event Rebalance

### DIFF
--- a/Resources/Locale/en-US/deltav/station-events/events/xeno-vent.ftl
+++ b/Resources/Locale/en-US/deltav/station-events/events/xeno-vent.ftl
@@ -1,1 +1,2 @@
 station-event-xeno-vents-announcement = Confirmed sightings of hostile alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
+station-event-xeno-vents-weak-announcement = Suspected signatures of hostile alien wildlife detected on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.

--- a/Resources/Locale/en-US/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/station-events/events/vent-critters.ftl
@@ -2,3 +2,7 @@
 station-event-slimes-spawn-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
 station-event-vent-critters-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
 station-event-spider-spawn-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+
+# Weak
+station-event-slimes-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+station-event-spider-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -6,8 +6,9 @@
   - type: StationEvent
     startAnnouncement: true
     earliestStart: 20
+    reoccurrenceDelay: 12
     minimumPlayers: 15
-    weight: 1
+    weight: 6 # Really weak compared to other critters
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -28,6 +29,33 @@
     - id: MobXenoQueen
       prob: 0.005
 
+# Weaker version of xenos, meant to provide some dangers in low pop.
+- type: entity
+  id: XenoVentsWeak
+  parent: XenoVents
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: true
+    reoccurrenceDelay: 12
+    minimumPlayers: 1
+  - type: VentCrittersRule
+    entries:
+    - id: MobXeno
+      prob: 0.006
+    - id: MobXenoDrone
+      prob: 0.004
+    - id: MobXenoSpitter
+      prob: 0.003
+    - id: MobXenoRouny
+      prob: 0.001
+    - id: MobXenoRunner
+      prob: 0.001
+    - id: MobXenoPraetorian
+      prob: 0.001
+    - id: MobXenoRavager
+      prob: 0.001
+
 - type: entity
   id: MothroachSpawn
   parent: BaseGameRule
@@ -36,7 +64,7 @@
   - type: StationEvent
     id: VentCritters
     earliestStart: 15
-    minimumPlayers: 15
+    minimumPlayers: 1
     weight: 4
     duration: 60
   - type: VentCrittersRule
@@ -44,7 +72,7 @@
     - id: MobMothroach
       prob: 0.05
 
-- type: entity # Delta-V : Midround Syndie Listening Station Spawn
+- type: entity
   id: PirateRadioSpawn
   parent: BaseGameRule
   noSpawn: true

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -5,7 +5,7 @@
   components:
   - type: StationEvent
     weight: 12
-    startDelay: 15
+    startDelay: 30
     reoccurrenceDelay: 8
     duration: 35
   - type: AnomalySpawnRule
@@ -17,7 +17,7 @@
   components:
   - type: StationEvent
     weight: 5
-    startDelay: 15
+    startDelay: 30
     reoccurrenceDelay: 5
     duration: 35
   - type: BluespaceArtifactRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -4,8 +4,9 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 12 # DeltaV - was 10
-    startDelay: 30
+    weight: 12
+    startDelay: 15
+    reoccurrenceDelay: 8
     duration: 35
   - type: AnomalySpawnRule
 
@@ -16,7 +17,8 @@
   components:
   - type: StationEvent
     weight: 5
-    startDelay: 30
+    startDelay: 15
+    reoccurrenceDelay: 5
     duration: 35
   - type: BluespaceArtifactRule
 
@@ -27,8 +29,9 @@
   components:
   - type: StationEvent
     weight: 1
-    reoccurrenceDelay: 5
+    maxOccurrences: 4 # Very annoying, makes containers unusable
     earliestStart: 1
+    reoccurrenceDelay: 15
     duration: 1
   - type: BluespaceLockerRule
 
@@ -40,7 +43,8 @@
   - type: StationEvent
     weight: 10
     duration: 1
-    minimumPlayers: 15
+    minimumPlayers: 7
+    reoccurrenceDelay: 5
   - type: BreakerFlipRule
 
 - type: entity
@@ -53,6 +57,7 @@
     minimumPlayers: 25
     weight: 5
     duration: 1
+    reoccurrenceDelay: 5
   - type: BureaucraticErrorRule
 
 - type: entity
@@ -65,18 +70,21 @@
     minimumPlayers: 15
     weight: 5
     duration: 1
+    reoccurrenceDelay: 5
   - type: ClericalErrorRule
 
-#- type: entity
-#  parent: BaseGameRule # DeltaV - this shit is busted most of the time
-#  id: ClosetSkeleton
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    weight: 10
-#    duration: 1
-#  - type: RandomEntityStorageSpawnRule
-#    prototype: MobSkeletonCloset
+- type: entity
+  parent: BaseGameRule
+  id: ClosetSkeleton
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 10
+    duration: 1
+    minimumPlayers: 15
+    reoccurrenceDelay: 25
+  - type: RandomEntityStorageSpawnRule
+    prototype: MobSkeletonCloset
 
 - type: entity
   parent: BaseGameRule
@@ -84,7 +92,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 1 # DeltaV - was 5
+    weight: 2
     duration: 1
     earliestStart: 45
     reoccurrenceDelay: 60
@@ -98,13 +106,14 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 3 # DeltaV - was 10
+    weight: 3
     duration: 1
-    earliestStart: 45 # DeltaV - was 30
-    reoccurrenceDelay: 60
-    minimumPlayers: 40
+    earliestStart: 45
+    reoccurrenceDelay: 45
+    minimumPlayers: 20
   - type: NinjaSpawnRule
 
+# TODO there's already a glimmer revenant rule. One of them might be broken.
 - type: entity
   parent: BaseGameRule
   id: RevenantSpawn
@@ -124,8 +133,9 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 15
+    weight: 10
     duration: 1
+    reoccurrenceDelay: 4 # Please no 10 false alarms in a row.
   - type: FalseAlarmRule
 
 - type: entity
@@ -137,6 +147,7 @@
     startAnnouncement: true
     endAnnouncement: true
     earliestStart: 10
+    reoccurrenceDelay: 7
     minimumPlayers: 5
     weight: 10
     startDelay: 20
@@ -149,6 +160,7 @@
   components:
   - type: StationEvent
     earliestStart: 15
+    reoccurrenceDelay: 10
     minimumPlayers: 15
     weight: 5
     startDelay: 50
@@ -162,8 +174,9 @@
   components:
   - type: StationEvent
     earliestStart: 30
+    reoccurrenceDelay: 5
     weight: 7.5
-    minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
+    minimumPlayers: 7 #Enough to hopefully have at least one engineering guy
     startAnnouncement: true
     endAnnouncement: true
     duration: null #ending is handled by MeteorSwarmRule
@@ -178,8 +191,8 @@
   - type: StationEvent
     startAnnouncement: true
     startDelay: 10
-    earliestStart: 30
-    minimumPlayers: 35
+    earliestStart: 15
+    reoccurrenceDelay: 3
     weight: 5
     duration: 50
   - type: VentCrittersRule
@@ -190,11 +203,6 @@
       prob: 0.02
     - id: MobMouse2
       prob: 0.02
-    # DeltaV - Rat King spawns under MidRoundAntag - Comment out Rat King from spawning with MouseMigration gamerule
-    # specialEntries:
-    # - id: SpawnPointGhostRatKing
-    #   prob: 0.005
-    # End of modified code
 
 - type: entity
   id: CockroachMigration
@@ -206,12 +214,35 @@
     startDelay: 10
     weight: 5
     duration: 50
+    reoccurrenceDelay: 15 # Cockroaches en masse are utmost annoying to deal with.
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
       prob: 0.03
     - id: MobMothroach
       prob: 0.008
+
+# TODO this is the same as mouse migration, but with different announcer.
+- type: entity
+  id: VentCritters
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: true
+    startDelay: 10
+    earliestStart: 15
+    reoccurrenceDelay: 3
+    weight: 5
+    duration: 60
+  - type: VentCrittersRule
+    entries:
+    - id: MobMouse
+      prob: 0.02
+    - id: MobMouse1
+      prob: 0.02
+    - id: MobMouse2
+      prob: 0.02
 
 - type: entity
   id: PowerGridCheck
@@ -225,17 +256,20 @@
     startDelay: 24
     duration: 60
     maxDuration: 120
+    reoccurrenceDelay: 2 # Gives a chance for multiple checks in a row, but not in parallel
   - type: PowerGridCheckRule
 
-# - type: entity # DeltaV - Removes the random sentience.
-#   id: RandomSentience
-#   parent: BaseGameRule
-#   noSpawn: true
-#   components:
-#   - type: StationEvent
-#     weight: 10
-#     duration: 1
-#   - type: RandomSentienceRule
+- type: entity
+  id: RandomSentience
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 5
+    duration: 1
+    reoccurrenceDelay: 10
+    maxOccurrences: 3 # Annoying and rarely if ever interesting
+  - type: RandomSentienceRule
 
 - type: entity
   parent: BaseGameRule
@@ -248,6 +282,7 @@
     endAnnouncement: true
     duration: 120
     maxDuration: 240
+    reoccurrenceDelay: 5
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -285,32 +320,12 @@
   - type: StationEvent
     startAnnouncement: true
     earliestStart: 15
+    reoccurrenceDelay: 5
     minimumPlayers: 15
     weight: 5
     startDelay: 50
     duration: 60
   - type: VentClogRule
-
-- type: entity
-  id: VentCritters
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: true
-    startDelay: 10
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
 
 - type: entity
   id: SlimesSpawn
@@ -321,6 +336,7 @@
     startAnnouncement: true
     startDelay: 10
     earliestStart: 20
+    reoccurrenceDelay: 12
     minimumPlayers: 15
     weight: 5
     duration: 60
@@ -342,6 +358,7 @@
     startAnnouncement: true
     startDelay: 10
     earliestStart: 20
+    reoccurrenceDelay: 15
     minimumPlayers: 15
     weight: 5
     duration: 60
@@ -349,6 +366,35 @@
     entries:
     - id: MobGiantSpiderAngry
       prob: 0.05
+
+# Weaker versions of the above
+- type: entity
+  id: SlimesSpawnWeak
+  parent: SlimesSpawn
+  noSpawn: true
+  components:
+  - type: StationEvent
+    minimumPlayers: 1
+  - type: VentCrittersRule
+    entries:
+    - id: MobAdultSlimesBlueAngry
+      prob: 0.005
+    - id: MobAdultSlimesGreenAngry
+      prob: 0.005
+    - id: MobAdultSlimesYellowAngry
+      prob: 0.005
+
+- type: entity
+  id: SpiderSpawnWeak
+  parent: SpiderSpawn
+  noSpawn: true
+  components:
+  - type: StationEvent
+    minimumPlayers: 1
+  - type: VentCrittersRule
+    entries:
+    - id: MobGiantSpiderAngry
+      prob: 0.01
 
 # - type: entity # DeltaV - Prevent normal spawning of MobClownSpider
 #  id: SpiderClownSpawn
@@ -373,15 +419,16 @@
   noSpawn: true
   components:
   - type: StationEvent
-    earliestStart: 90 # DeltaV - was 50
+    earliestStart: 60
+    reoccurrenceDelay: 60
     minimumPlayers: 15
-    weight: 2.5 # DeltaV - was 5
+    weight: 2
     duration: 1
   - type: ZombieRule
     minStartDelay: 0 #let them know immediately
     maxStartDelay: 10
-    maxInitialInfected: 3 #fewer zombies
-    minInitialInfectedGrace: 300 #less time to prepare
+    maxInitialInfected: 2
+    minInitialInfectedGrace: 300
     maxInitialInfectedGrace: 450
 
 - type: entity
@@ -392,8 +439,8 @@
   - type: StationEvent
     earliestStart: 60
     weight: 3
-    minimumPlayers: 20
-    reoccurrenceDelay: 30
+    minimumPlayers: 15
+    reoccurrenceDelay: 45
     duration: 1
   - type: LoneOpsSpawnRule
 
@@ -444,6 +491,7 @@
   components:
     - type: StationEvent
       earliestStart: 0
+      reoccurrenceDelay: 5
       minimumPlayers: 20
       weight: 5
     - type: MobReplacementRule

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -6,8 +6,9 @@
   components:
     - type: StationEvent
       startAnnouncement: true
-      weight: 5
+      weight: 10
       earliestStart: 15
+      reoccurrenceDelay: 5
     - type: NoosphericStormRule
 
 # Mid round antag spawns
@@ -51,11 +52,14 @@
     - type: GlimmerEvent
 
 ## Glimmer events
+# Blank discharge
 - type: entity
   id: MundaneDischarge
   parent: BaseGlimmerEvent
   noSpawn: true
   components:
+    - type: StationEvent
+      reoccurrenceDelay: 15
     - type: GlimmerEvent
       maximumGlimmer: 300
       glimmerBurnLower: 18
@@ -67,17 +71,21 @@
   parent: BaseGlimmerEvent
   noSpawn: true
   components:
+    - type: StationEvent
+      weight: 25 # Guaranteed to happen every once in a while, but with intervals between incidents
+      reoccurrenceDelay: 15
     - type: GlimmerEvent
     - type: NoosphericZapRule
 
+# Fry tinfoil hats and shoot lightnings from probers
 - type: entity
   id: NoosphericFry
   parent: BaseGlimmerEvent
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 300
-      maximumGlimmer: 900
+      minimumGlimmer: 550
+      maximumGlimmer: 1000
     - type: NoosphericFryRule
 
 - type: entity
@@ -86,8 +94,8 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 200
-      maximumGlimmer: 500
+      minimumGlimmer: 590
+      maximumGlimmer: 1000
       glimmerBurnLower: 18
       glimmerBurnUpper: 40
     - type: PsionicCatGotYourTongueRule
@@ -99,9 +107,10 @@
   components:
     - type: GlimmerEvent
       minimumGlimmer: 900
-      glimmerBurnLower: 50
-      glimmerBurnUpper: 110
+      glimmerBurnLower: 350
+      glimmerBurnUpper: 450 # Unless epistemics badly f-d up, this will restore the glimmer balance for a while.
     - type: MassMindSwapRule
+      isTemporary: true # Permanent mindswap is hell.
 
 #- type: entity
 #  id: GlimmerWispSpawn
@@ -120,7 +129,7 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 300
+      minimumGlimmer: 550 # Requires at least some noospheric activity
       maximumGlimmer: 1000
       report: glimmer-event-report-signatures
     - type: FreeProberRule
@@ -131,9 +140,15 @@
   parent: BaseGlimmerEvent
   noSpawn: true
   components:
+    - type: StationEvent
+      weight: 7
+      duration: 1
+      earliestStart: 15
+      reoccurrenceDelay: 15
+      minimumPlayers: 10
     - type: GlimmerEvent
-      minimumGlimmer: 300
-      maximumGlimmer: 600
+      minimumGlimmer: 500
+      maximumGlimmer: 900
       report: glimmer-event-report-signatures
     - type: GlimmerRandomSentienceRule
 
@@ -143,7 +158,7 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 500
+      minimumGlimmer: 700
       maximumGlimmer: 900
       report: glimmer-event-report-signatures
     - type: GlimmerRevenantRule

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -6,7 +6,7 @@
   components:
     - type: StationEvent
       startAnnouncement: true
-      weight: 10
+      weight: 5
       earliestStart: 15
       reoccurrenceDelay: 5
     - type: NoosphericStormRule


### PR DESCRIPTION
# Description
Significant event rebalance based on my own experience and feedback from some players, mostly aimed to improve low-pop experience and prevent multiple instances of same event occurring at once.

Added weaker versions of hostile critter events. Those versions spawn 2-3 times less critters and come with a different announcement: SlimesSpawnWeak, SpidersSpawnWeak, XenoVentsWeak.

Rebalanced the following events:
- AnomalySpawn - reoccurrence delay of 8 minutes to prevent multiple anomalies from spawning with a delay of a few seconds (which has happened many times).
- BluespaceArtifact - same, but 5 minutes.
- BluespaceLocker - 15 minute reoccurrence delay and no more than 4 occurrences per shift because it's really annoying.
- BreakerFlip, BureaucraticError, ClericalError - reoccurrence delay of 5 minutes.
- GasLeak - reoccurrence delay of 7 minutes.
- KudzuGrowth - reoccurrence delay of 10 minutes.
- MeteorSwarm - reoccurrence delay of 5 minutes, reduced player count requirement from 10 to 7.
- MouseMigration, VentCritters (mice) - reoccurrence delay of 3 minutes, reduced playercount requirement from 35 to 0. (Those two events are identical but have different announcements, might as well remove one of them)
- CockroachMigration - reoccurrence delay of 15 minutes.
- PowerGridCheck - reoccurrence delay of 2 minutes (same as the maximum duration of the event).
- SolarFlare, VentClog - reoccurrence delay of 5 minutes.
- SlimesSpawn, SpiderSpawn - reoccurrence delay of 12 minutes.
- MimicVendorRule - reoccurrence delay of 5 minutes.
- XenoVents - increased weight from 1 to 6.
- MothroachSpawn - decreased player requirement from 15 to 1.
- MundaneDischarge - reoccurrence delay of 15 minutes.
- NoosphericZap - increased the weight from 12 to 25 and added a reoccurrence delay of 15 minutes. (Making it more likely to occur on regular intervals rather than randomly throughout the shift).
- NoosphericFry - changed the glimmer range to 550-1000Ψ.
- PsionicCatGotYourTongue - changed the glimmer range to 590-1000Ψ.
- MassMindSwap - **MADE TEMPORARY** and increased glimmer burn range to 350-450Ψ.
- FreeProber - changed the glimmer range to 550-1000Ψ.
- GlimmerRandomSentience - reoccurence delay of 15 minutes, minimum of 10 player, and a glimmer range of 500-900Ψ.
- GlimmerRevenantSpawn - glimmer range of 700-900Ψ. (There's already another revenant spawn event that isn't based on glimmer, wtf?)

Rebalanced the following midround antags:
- DragonSpawn - doubled the weight, from 1 to 2.
- NinjaSpawn - reduced the player requirement from 40 to 20 (loneop had 20, and is far more destructive than a ninja). Also reduced reoccurrence delay to 45 minutes.
- ZombieOutbreak - earliest start moved from 90 minutes to 60, weight reduced from 2.5 to 2, number of initial infected cut down from 3 to 2.
- LoneOpsSpawn - reduced the player requirement from 20 to 15 and increased the reoccurrence delay from 30 to 45 minutes.
- 

Re-added the following events:
- ClosetSkeleton, with a minimum of 15 players and reoccurence delay of 25 minutes.
- RandomSentience - with a reoccurence delay of 10 minutes and a maximum of 3 occurences.

<details><summary><h1>Media</h1></summary>
<p>

New events:

![image](https://github.com/user-attachments/assets/032fdd04-5030-4336-8af9-b5f4f0484443)

![image](https://github.com/user-attachments/assets/283423aa-a059-47b4-9eea-c235b6cb1254)


</p>
</details>

---

# Changelog
:cl:
- tweak: Most station events were rebalanced to better suit low-pop rounds.
- add: Weakened versions of vent critter events can now occur on low-pop rounds.
- tweak: After a lot of complaints, the mass mindswap event is no longer permanent.
