### PR TITLE
Fix FalseAlarmRule

### DIFF
--- a/Content.Server/StationEvents/Events/FalseAlarmRule.cs
+++ b/Content.Server/StationEvents/Events/FalseAlarmRule.cs
@@ -18,7 +18,9 @@ public sealed class FalseAlarmRule : StationEventSystem<FalseAlarmRuleComponent>
     {
         base.Started(uid, component, gameRule, args);
 
-        var allEv = _event.AllEvents().Select(p => p.Key).ToList();
+        var allEv = _event.AllEvents()
+            .Where(p => p.Value.StartAnnouncement)
+            .Select(p => p.Key).ToList();
         var picked = RobustRandom.Pick(allEv);
 
         _announcer.SendAnnouncement(


### PR DESCRIPTION
# Description
Grrr, 3 lines changed. Filter out events that don't have a start announcement.

# Changelog
:cl:
- fix: False alarm event will no longer report events that should not be reported.