### PR TITLE
Rename the Social Anxiety Trait

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -29,8 +29,8 @@ trait-description-Accentless = You don't have the accent that your species would
 trait-name-FrontalLisp = Frontal Lisp
 trait-description-FrontalLisp = You thpeak with a lithp
 
-trait-name-SocialAnxiety = Social Anxiety
-trait-description-SocialAnxiety = You are anxious when you speak and stutter.
+trait-name-Stutter = Stutter
+trait-description-Stutter = You t-t-talk with a bit of a s-s-stutter...
 
 trait-name-Snoring = Snoring
 trait-description-Snoring = You will snore while sleeping.

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -16,7 +16,7 @@
       boozeStrengthMultiplier: 2
 
 - type: trait
-  id: SocialAnxiety
+  id: Stutter
   category: Mental
   requirements:
     - !type:CharacterJobRequirement


### PR DESCRIPTION
# Description

I always believed the Social Anxiety Trait to be wrongfully named such, and therefore present this very simple PR, which changes the Name Description and ID's associated with the Social Anxiety Trait to fit the new name of the Stutter Trait.

Description.

---

# TODO

- [X] Change the Names, ID's, and Descriptions of the Social Anxiety Trait

---

---

# Changelog

:mefinks:
- tweak: Changed the name of the Social Anxiety Trait.

