### PR TITLE
Fix Talking Across Docked Grids

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -748,7 +748,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         var language = languageOverride ?? _language.GetLanguage(source);
         foreach (var (session, data) in GetRecipients(source, Transform(source).GridUid == null ? 0.3f : VoiceRange))
         {
-            if (session.AttachedEntity != null && Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid
+            if (session.AttachedEntity != null
+                && Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid
                 && !CheckAttachedGrids(source, session.AttachedEntity.Value))
                 continue;
 
@@ -986,10 +987,9 @@ public sealed partial class ChatSystem : SharedChatSystem
             return false;
 
         foreach (var (id, _) in sourceJoints.GetJoints)
-        {
             if (receiverJoints.GetJoints.ContainsKey(id))
                 return true;
-        }
+
         return false;
     }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -33,11 +33,15 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
+using Content.Server.Shuttles.Components;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics.Joints;
 
 namespace Content.Server.Chat.Systems;
 
@@ -510,7 +514,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (session.AttachedEntity is not { Valid: true } listener)
                 continue;
 
-            if (Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid)
+            if (Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid
+                && !CheckAttachedGrids(source, session.AttachedEntity.Value))
                 continue;
 
             if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
@@ -743,7 +748,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         var language = languageOverride ?? _language.GetLanguage(source);
         foreach (var (session, data) in GetRecipients(source, Transform(source).GridUid == null ? 0.3f : VoiceRange))
         {
-            if (session.AttachedEntity != null && Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid)
+            if (session.AttachedEntity != null && Transform(session.AttachedEntity.Value).GridUid != Transform(source).GridUid
+                && !CheckAttachedGrids(source, session.AttachedEntity.Value))
                 continue;
 
             var entRange = MessageRangeCheck(session, data, range);
@@ -971,6 +977,20 @@ public sealed partial class ChatSystem : SharedChatSystem
             sb.Append(_random.Pick(charOptions));
         }
         return sb.ToString();
+    }
+
+    private bool CheckAttachedGrids(EntityUid source, EntityUid receiver)
+    {
+        if (!TryComp<JointComponent>(Transform(source).GridUid, out var sourceJoints)
+            || !TryComp<JointComponent>(Transform(receiver).GridUid, out var receiverJoints))
+            return false;
+
+        foreach (var (id, _) in sourceJoints.GetJoints)
+        {
+            if (receiverJoints.GetJoints.ContainsKey(id))
+                return true;
+        }
+        return false;
     }
 
     #endregion


### PR DESCRIPTION
# Description

https://github.com/Simple-Station/Einstein-Engines/pull/574 introduced a bug whereby people who are each on separate grids, but the grids were attached, could not talk to each other. I have corrected this by making it so that when the Cross-Grid check is handled, it also checks to see if the two different grids are JOINTed to each other. Therefore allowing sound to travel across the connection. This should also work from Shuttle To Planet, since it's also handled via the same system. This means that docked shuttles allow sound to travel across to the docked station(or other shuttle), as well as shuttles docked to a planet's surface will permit sound to travel to the planet.

# Changelog

:cl:
- fix: Fixed a bug where sound was not traveling over a Shuttle-Docking connection. Attached grids now permit sound to travel through.
