### PR TITLE
Fix Multiple Species Requirements

### DIFF
--- a/Content.Shared/Customization/Systems/CharacterRequirements.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.cs
@@ -121,17 +121,20 @@ public sealed partial class CharacterClothingPreferenceRequirement : CharacterRe
 public sealed partial class CharacterSpeciesRequirement : CharacterRequirement
 {
     [DataField(required: true)]
-    public ProtoId<SpeciesPrototype> Species;
+    public List<ProtoId<SpeciesPrototype>> Species;
 
     public override bool IsValid(IPrototype prototype, JobPrototype job, HumanoidCharacterProfile profile,
         Dictionary<string, TimeSpan> playTimes,
         IEntityManager entityManager, IPrototypeManager prototypeManager, IConfigurationManager configManager,
         out FormattedMessage? reason)
     {
+        const string color = "green";
         reason = FormattedMessage.FromMarkup(Loc.GetString("character-species-requirement",
             ("inverted", Inverted),
-            ("species", Loc.GetString($"species-name-{Species.ToString().ToLower()}"))));
-        return profile.Species == Species;
+            ("species", $"[color={color}]{string.Join($"[/color], [color={color}]",
+                Species.Select(s => Loc.GetString(prototypeManager.Index(s).Name)))}[/color]")));
+
+        return Species.Contains(profile.Species);
     }
 }
 
@@ -150,8 +153,11 @@ public sealed partial class CharacterTraitRequirement : CharacterRequirement
         IEntityManager entityManager, IPrototypeManager prototypeManager, IConfigurationManager configManager,
         out FormattedMessage? reason)
     {
-        reason = FormattedMessage.FromMarkup(Loc.GetString("character-trait-requirement", ("inverted", Inverted),
-            ("traits", string.Join(", ", Traits.Select(t => Loc.GetString($"trait-name-{t}"))))));
+        const string color = "lightblue";
+        reason = FormattedMessage.FromMarkup(Loc.GetString("character-trait-requirement",
+            ("inverted", Inverted),
+            ("traits", $"[color={color}]{string.Join($"[/color], [color={color}]",
+                Traits.Select(t => Loc.GetString($"trait-name-{t}")))}[/color]")));
 
         return Traits.Any(t => profile.TraitPreferences.Contains(t.ToString()));
     }
@@ -168,11 +174,15 @@ public sealed partial class CharacterLoadoutRequirement : CharacterRequirement
     public List<ProtoId<LoadoutPrototype>> Loadouts;
 
     public override bool IsValid(IPrototype prototype, JobPrototype job, HumanoidCharacterProfile profile,
-        Dictionary<string, TimeSpan> playTimes, IEntityManager entityManager, IPrototypeManager prototypeManager,
-        IConfigurationManager configManager, out FormattedMessage? reason)
+        Dictionary<string, TimeSpan> playTimes,
+        IEntityManager entityManager, IPrototypeManager prototypeManager, IConfigurationManager configManager,
+        out FormattedMessage? reason)
     {
-        reason = FormattedMessage.FromMarkup(Loc.GetString("character-loadout-requirement", ("inverted", Inverted),
-            ("loadouts", string.Join(", ", Loadouts.Select(l => Loc.GetString($"loadout-{l}"))))));
+        const string color = "lightblue";
+        reason = FormattedMessage.FromMarkup(Loc.GetString("character-loadout-requirement",
+            ("inverted", Inverted),
+            ("loadouts", $"[color={color}]{string.Join($"[/color], [color={color}]",
+                Loadouts.Select(l => Loc.GetString($"loadout-name-{l}")))}[/color]")));
 
         return Loadouts.Any(l => profile.LoadoutPreferences.Contains(l.ToString()));
     }
@@ -464,66 +474,6 @@ public sealed partial class CharacterPlaytimeRequirement : CharacterRequirement
         }
 
         return true;
-    }
-}
-
-#endregion
-
-#region Prototype Groups
-
-/// <summary>
-///     Requires the profile to not have any of the specified traits
-/// </summary>
-/// <remarks>
-///     Only works if you put this prototype in the denied prototypes' requirements too.
-///     Can't be inverted, use <see cref="CharacterTraitRequirement"/>
-/// </remarks>
-[UsedImplicitly]
-[Serializable, NetSerializable]
-public sealed partial class TraitGroupExclusionRequirement : CharacterRequirement
-{
-    [DataField(required: true)]
-    public List<ProtoId<TraitPrototype>> Prototypes;
-
-    public override bool IsValid(IPrototype prototype, JobPrototype job, HumanoidCharacterProfile profile,
-        Dictionary<string, TimeSpan> playTimes,
-        IEntityManager entityManager, IPrototypeManager prototypeManager, IConfigurationManager configManager,
-        out FormattedMessage? reason)
-    {
-        var invalid = profile.TraitPreferences.Any(t => Prototypes.Contains(t));
-
-        reason = FormattedMessage.FromMarkup(Loc.GetString("character-trait-group-exclusion-requirement",
-            ("traits", string.Join(", ", Prototypes.Select(t => Loc.GetString($"trait-name-{t}"))))));
-
-        return Inverted ? invalid : !invalid;
-    }
-}
-
-/// <summary>
-///     Requires the profile to not have any of the specified loadouts
-/// </summary>
-/// <remarks>
-///     Only works if you put this prototype in the denied prototypes' requirements too.
-///     Can't be inverted, use <see cref="CharacterLoadoutRequirement"/>
-/// </remarks>
-[UsedImplicitly]
-[Serializable, NetSerializable]
-public sealed partial class LoadoutGroupExclusionRequirement : CharacterRequirement
-{
-    [DataField(required: true)]
-    public List<ProtoId<LoadoutPrototype>> Prototypes;
-
-    public override bool IsValid(IPrototype prototype, JobPrototype job, HumanoidCharacterProfile profile,
-        Dictionary<string, TimeSpan> playTimes,
-        IEntityManager entityManager, IPrototypeManager prototypeManager, IConfigurationManager configManager,
-        out FormattedMessage? reason)
-    {
-        var invalid = profile.LoadoutPreferences.Any(l => Prototypes.Contains(l));
-
-        reason = FormattedMessage.FromMarkup(Loc.GetString("character-loadout-group-exclusion-requirement",
-            ("loadouts", string.Join(", ", Prototypes.Select(l => Loc.GetString($"loadout-{l}"))))));
-
-        return Inverted ? invalid : !invalid;
     }
 }
 

--- a/Content.Shared/Customization/Systems/CharacterRequirementsSystem.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirementsSystem.cs
@@ -34,7 +34,7 @@ public sealed class CharacterRequirementsSystem : EntitySystem
                     valid = !requirement.Inverted;
             }
 
-            if (reason != null) // To appease the compiler
+            if (reason != null)
                 reasons.Add(reason);
         }
 

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -5,19 +5,23 @@ character-age-requirement = You must {$inverted ->
 character-species-requirement = You must {$inverted ->
     [true] not be
     *[other] be
-} a [color=green]{$species}[/color]
+} a {$species}
 character-trait-requirement = You must {$inverted ->
     [true] not have
     *[other] have
-} one of these traits: [color=lightblue]{$traits}[/color]
+} one of these traits: {$traits}
+character-loadout-requirement = You must {$inverted ->
+    [true] not have
+    *[other] have
+} one of these loadouts: {$loadouts}
 character-backpack-type-requirement = You must {$inverted ->
     [true] not use
     *[other] use
-} a [color=lightblue]{$type}[/color] as your bag
+} a [color=brown]{$type}[/color] as your bag
 character-clothing-preference-requirement = You must {$inverted ->
     [true] not wear
     *[other] wear
-} a [color=lightblue]{$type}[/color]
+} a [color=white]{$type}[/color]
 
 character-job-requirement = You must {$inverted ->
     [true] not be
@@ -34,6 +38,3 @@ character-timer-overall-insufficient = You require [color=yellow]{TOSTRING($time
 character-timer-overall-too-high = You require [color=yellow]{TOSTRING($time, "0")}[/color] fewer minutes of playtime
 character-timer-role-insufficient = You require [color=yellow]{TOSTRING($time, "0")}[/color] more minutes with [color={$departmentColor}]{$job}[/color]
 character-timer-role-too-high = You require[color=yellow] {TOSTRING($time, "0")}[/color] fewer minutes with [color={$departmentColor}]{$job}[/color]
-
-character-trait-group-exclusion-requirement = You cannot have one of the following traits if you select this: {$traits}
-character-loadout-group-exclusion-requirement = You cannot have one of the following loadouts if you select this: {$loadouts}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -35,14 +35,11 @@ trait-description-Stutter = You t-t-talk with a bit of a s-s-stutter...
 trait-name-Snoring = Snoring
 trait-description-Snoring = You will snore while sleeping.
 
-trait-name-NormalVisionHarpy = Trichromat Modification
-trait-description-NormalVisionHarpy = Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
-
 trait-name-Southern = Southern Drawl
 trait-description-Southern = You have a different way of speakin'.
 
-trait-name-NormalVisionVulpkanin = Trichromat Modification
-trait-description-NormalVisionVulpkanin = Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
+trait-name-NormalVision = Trichromat Modification
+trait-description-NormalVision = Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
 
 trait-name-Thieving = Thieving
 trait-description-Thieving =

--- a/Resources/Prototypes/DeltaV/Traits/altvision.yml
+++ b/Resources/Prototypes/DeltaV/Traits/altvision.yml
@@ -5,10 +5,9 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Vulpkanin
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species: Harpy
+      species:
+        - Vulpkanin
+        - Harpy
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -23,10 +22,9 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Vulpkanin
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species: Harpy
+      species:
+        - Vulpkanin
+        - Harpy
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Loadouts/Jobs/engineering.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/engineering.yml
@@ -6,7 +6,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer
@@ -54,7 +55,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -49,7 +49,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -67,7 +68,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -85,7 +87,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -103,7 +106,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -121,7 +125,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -139,7 +144,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -157,7 +163,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -211,7 +218,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Paramedic
@@ -262,7 +270,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -21,7 +21,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Scientist
@@ -116,7 +117,7 @@
   items:
     - ClothingEyesEyepatchHudDiag
 
-## Robes
+# Robes
 - type: loadout
   id: LoadoutOuterRobeTechPriest
   category: Outer

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -1,4 +1,4 @@
-## Uniforms
+# Uniforms
 - type: loadout
   id: LoadoutSecurityUniformJumpsuitBlue
   category: Jobs
@@ -7,7 +7,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -24,7 +25,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -93,7 +95,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -120,7 +123,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -135,7 +139,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -198,7 +203,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -216,7 +222,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -225,7 +232,7 @@
         - HeadOfSecurity
   items:
     - ClothingUniformJumpsuitSecSummer
-## Mask
+# Mask
 - type: loadout
   id: LoadoutSecurityMaskGasSwat
   category: Jobs
@@ -239,7 +246,7 @@
   items:
     - ClothingMaskGasSwat
 
-## Shoes
+# Shoes
 - type: loadout
   id: LoadoutSecurityShoesJackboots
   category: Jobs
@@ -247,7 +254,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -258,7 +266,7 @@
   items:
     - ClothingShoesBootsJack
 
-## Eyes
+# Eyes
 - type: loadout
   id: LoadoutSecurityEyesHudSecurity
   category: Jobs
@@ -307,7 +315,7 @@
   items:
     - ClothingEyesPrescriptionHudSecurity
 
-## Head
+# Head
 - type: loadout
   id: LoadoutSecurityHeadHatBeret
   category: Jobs
@@ -337,7 +345,7 @@
   items:
     - ClothingHeadHelmetInsulated
 
-## Belt
+# Belt
 - type: loadout
   id: LoadoutSecurityBeltWebbing
   category: Jobs
@@ -354,22 +362,24 @@
   items:
     - ClothingBeltSecurityWebbingFilled
 
-## Species
-#- type: loadout ##Uncomment this and reassess points when we can make it replace the secoff duty pistol
-#  id: LoadoutSecurityEquipmentTruncheon
-#  category: Jobs
-#  cost: 8 ## TODO: Make this replace the secoff handgun, and thus also make it cheaper
-#  requirements:
-#    - !type:CharacterJobRequirement
-#      jobs:
-#        - SecurityOfficer
-#        - Warden
-#        - HeadOfSecurity
-#        - Brigmedic
-#    - !type:CharacterPlaytimeRequirement
-#      tracker: JobSecurityOfficer
-#      min: 36000 # 10 hours
-#    - !type:CharacterSpeciesRequirement
-#      species: Oni
-#  items:
-#    - Truncheon
+# TODO: Make this replace the secoff handgun and make it cheaper
+# # Species
+# - type: loadout
+#   id: LoadoutSecurityEquipmentTruncheon
+#   category: Jobs
+#   cost: 8
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SecurityOfficer
+#         - Warden
+#         - HeadOfSecurity
+#         - Brigmedic
+#     - !type:CharacterPlaytimeRequirement
+#       tracker: JobSecurityOfficer
+#       min: 36000 # 10 hours
+#     - !type:CharacterSpeciesRequirement
+#       species:
+#         - Oni
+#   items:
+#     - Truncheon

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -1,4 +1,4 @@
-## Clown
+# Clown
 - type: loadout
   id: LoadoutServiceClownOutfitJester
   category: Jobs
@@ -27,7 +27,7 @@
     - ClothingHeadHatJesterAlt
     - ClothingShoesJester
 
-## Bartender
+# Bartender
 - type: loadout
   id: LoadoutServiceBartenderUniformPurple
   category: Jobs
@@ -40,7 +40,7 @@
   items:
     - ClothingUniformJumpsuitBartenderPurple
 
-## Botanist
+# Botanist
 - type: loadout
   id: LoadoutServiceBotanistUniformOveralls
   category: Jobs
@@ -53,7 +53,7 @@
   items:
     - ClothingUniformOveralls
 
-## Lawyer
+# Lawyer
 - type: loadout
   id: LoadoutServiceLawyerUniformBlueSuit
   category: Jobs
@@ -62,7 +62,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
      jobs:
         - Lawyer
@@ -89,7 +90,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -116,7 +118,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -143,7 +146,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -174,7 +178,7 @@
   items:
     - ClothingUniformJumpsuitJournalist
 
-## Reporter
+# Reporter
 - type: loadout
   id: LoadoutServiceReporterUniformDetectivesuit
   category: Jobs
@@ -183,7 +187,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Reporter
@@ -202,7 +207,7 @@
   items:
     - ClothingUniformJumpskirtDetective
 
-## Musician
+# Musician
 - type: loadout
   id: LoadoutItemSynthesizerInstrument
   category: Jobs

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -1,4 +1,4 @@
-## Hats
+# Hats
 - type: loadout
   id: LoadoutHeadBeaverHat
   category: Head
@@ -70,7 +70,8 @@
   exclusive: true
   items:
     - ClothingHeadHatBellhop
-## Color Hats
+
+# Color Hats
 - type: loadout
   id: LoadoutHeadHatBluesoft
   category: Head
@@ -199,7 +200,7 @@
   items:
     - ClothingHeadHatYellowsoftFlipped
 
-## Headbands
+# Headbands
 - type: loadout
   id: LoadoutHeadBandBlack
   category: Head

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -69,7 +69,7 @@
   items:
     - Matchbox
 
-## Instruments
+# Instruments
 - type: loadout
   id: LoadoutItemMicrophoneInstrument
   category: Items

--- a/Resources/Prototypes/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/outerClothing.yml
@@ -54,7 +54,7 @@
   items:
     - ClothingOuterVestValet
 
-## Letterman Jackets
+# Letterman Jackets
 - type: loadout
   id: LoadoutOuterCoatLettermanBlue
   category: Outer
@@ -69,7 +69,7 @@
   items:
     - ClothingOuterCoatLettermanRed
 
-## MNK
+# MNK
 - type: loadout
   id: LoadoutOuterCoatMNKWhiteHoodie
   category: Outer
@@ -91,7 +91,7 @@
   items:
     - ClothingOuterCoatMNKBlackJacket
 
-## Contractor Jackets
+# Contractor Jackets
 - type: loadout
   id: LoadoutOuterCorporateJacket
   category: Outer

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -7,7 +7,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorBlack
 
@@ -19,7 +20,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorBlue
 
@@ -31,7 +33,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorBrown
 
@@ -43,7 +46,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorGreen
 
@@ -55,7 +59,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorOrange
 
@@ -67,7 +72,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorPurple
 
@@ -79,7 +85,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorRed
 
@@ -91,7 +98,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorWhite
 
@@ -103,7 +111,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesColorYellow
 
@@ -115,11 +124,12 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesGeta
 
-## Boots
+# Boots
 - type: loadout
   id: LoadoutShoesBootsWork
   category: Shoes
@@ -128,7 +138,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsWork
 
@@ -140,7 +151,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsLaceup
 
@@ -152,7 +164,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsWinter
 
@@ -164,7 +177,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsCowboyBrown
 
@@ -176,7 +190,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsCowboyBlack
 
@@ -188,7 +203,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsCowboyWhite
 
@@ -200,7 +216,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsCowboyFancy
 
@@ -215,7 +232,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Clown
@@ -228,7 +246,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesLeather
 
@@ -240,6 +259,7 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
   items:
     - ClothingShoesMiscWhite

--- a/Resources/Prototypes/Loadouts/species.yml
+++ b/Resources/Prototypes/Loadouts/species.yml
@@ -4,9 +4,9 @@
   cost: 0
   requirements:
     - !type:CharacterSpeciesRequirement
-      species: SlimePerson
-    - !type:CharacterSpeciesRequirement
-      species: Vox
+      species:
+        - SlimePerson
+        - Vox
   items:
     - EmergencyNitrogenTankFilled
 
@@ -16,9 +16,9 @@
   cost: 1
   requirements:
     - !type:CharacterSpeciesRequirement
-      species: SlimePerson
-    - !type:CharacterSpeciesRequirement
-      species: Vox
+      species:
+        - SlimePerson
+        - Vox
   items:
     - ExtendedEmergencyNitrogenTankFilled
 
@@ -28,8 +28,8 @@
   cost: 3
   requirements:
     - !type:CharacterSpeciesRequirement
-      species: SlimePerson
-    - !type:CharacterSpeciesRequirement
-      species: Vox
+      species:
+        - SlimePerson
+        - Vox
   items:
     - DoubleEmergencyNitrogenTankFilled

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -6,7 +6,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -25,7 +26,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -52,7 +54,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -79,7 +82,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -106,7 +110,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -133,7 +138,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -160,7 +166,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -187,7 +194,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -214,7 +222,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -241,7 +250,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -268,7 +278,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -295,7 +306,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -322,7 +334,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -349,7 +362,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -376,7 +390,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -403,7 +418,8 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Harpy
+      species:
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -420,7 +436,7 @@
       jobs:
         - Passenger
 
-## Kendo
+# Kendo
 - type: loadout
   id: LoadoutUniformKendoHakama
   category: Uniform
@@ -437,7 +453,7 @@
   items:
     - ClothingUniformMartialGi
 
-## Kimono
+# Kimono
 - type: loadout
   id: LoadoutClothingKimonoBlue
   category: Uniform
@@ -478,7 +494,7 @@
   items:
     - ClothingKimonoGreen
 
-## Gakuran
+# Gakuran
 - type: loadout
   id: LoadoutUniformSchoolGakuranBlack
   category: Uniform
@@ -487,7 +503,7 @@
   items:
     - ClothingUniformSchoolGakuranBlack
 
-## MNK Uniforms
+# MNK Uniforms
 - type: loadout
   id: LoadoutClothingMNKOfficeSkirt
   category: Uniform

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -36,8 +36,10 @@
   category: Mental
   points: 1
   requirements:
-    - !type:TraitGroupExclusionRequirement
-      prototypes: [ Foreigner ]
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Foreigner
   components:
     - type: ForeignerTrait
       cantUnderstand: false # Allows to understand
@@ -48,8 +50,10 @@
   category: Mental
   points: 2
   requirements: # TODO: Add a requirement to know at least 1 non-gc language
-    - !type:TraitGroupExclusionRequirement
-      prototypes: [ ForeignerLight ]
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - ForeignerLight
   components:
     - type: ForeignerTrait
       baseTranslator: TranslatorForeigner

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -34,7 +34,8 @@
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
-      species: Harpy
+      species:
+        - Harpy
   components:
     - type: NormalVision
 
@@ -44,6 +45,6 @@
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
-      species: Vulpkanin
+      species: [Vulpkanin]
   components:
     - type: NormalVision

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -29,22 +29,13 @@
     - type: SouthernAccent
 
 - type: trait
-  id: NormalVisionHarpy
+  id: NormalVision
   category: Visual
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
         - Harpy
-  components:
-    - type: NormalVision
-
-- type: trait
-  id: NormalVisionVulpkanin
-  category: Visual
-  points: -1
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      species: [Vulpkanin]
+        - Vulpkanin
   components:
     - type: NormalVision

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -15,7 +15,7 @@
   components:
     - type: LightweightDrunk
       boozeStrengthMultiplier: 0.5
-  
+
 - type: trait
   id: Thieving
   category: Physical
@@ -29,4 +29,5 @@
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
-      species: Felinid
+      species:
+        - Felinid


### PR DESCRIPTION
# Description

Fixed species requirements, they can now be used for ORs.
Improved trait/loadout requirement code, made the colors per-item instead of on the commas too.
Removed group exclusion requirements in favor of the aforementioned.
