### PR TITLE
Lasers Have No Recoil

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -241,6 +241,12 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public float FireOnDropChance = 0.1f;
+
+    /// <summary>
+    ///     Whether or not this gun is truly Recoilless, such as Lasers, and therefore shouldn't move the user.
+    /// </summary>
+    [DataField]
+    public bool DoRecoil = true;
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -362,11 +362,11 @@ public abstract partial class SharedGunSystem : EntitySystem
         var shotEv = new GunShotEvent(user, ev.Ammo);
         RaiseLocalEvent(gunUid, ref shotEv);
 
-        if (userImpulse && TryComp<PhysicsComponent>(user, out var userPhysics))
-        {
-            if (_gravity.IsWeightless(user, userPhysics))
-                CauseImpulse(fromCoordinates, toCoordinates.Value, user, userPhysics);
-        }
+        if (gun.DoRecoil
+            && userImpulse
+            && TryComp<PhysicsComponent>(user, out var userPhysics)
+            && _gravity.IsWeightless(user, userPhysics))
+            CauseImpulse(fromCoordinates, toCoordinates.Value, user, userPhysics);
 
         Dirty(gunUid, gun);
     }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -21,6 +21,7 @@
     fireOnDropChance: 0.15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
+    doRecoil: false
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
@@ -48,6 +49,7 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
+    doRecoil: false
   - type: MagazineAmmoProvider
   - type: ItemSlots
     slots:


### PR DESCRIPTION
# Description

LASERS HAVE NO RECOIL, THEY SHOULD NOT PUSH YOU AROUND IN SPACE. THE CAPTAIN'S LASER PISTOL IS NOT AN INFINITE USE JET PACK. STUPID BUG. ME FIX. 

There are MANY things I hate about the gun system's code, I am going to revisit this later with a more comprehensive update. There are many hardcoded constants in it related to physics that I thoroughly despise. Guns should just be allowed to declare how much force of recoil they have, rather than it being hardcoded as "CONSTANT 25f". Also, I would like that if the Recoil value is greater than your character's mass, to then knock your character on their ass and/or send them flying. Imagine a Felinid getting thrown back by firing a shotgun. There's my justification for doing so. 

# Changelog

:cl:
- fix: Lasers no longer function as jetpacks in space. 
