### PR TITLE
Radiation Doesn't Prevent DoAfters

### DIFF
--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -65,7 +65,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     {
         // If we're applying state then let the server state handle the do_after prediction.
         // This is to avoid scenarios where a do_after is erroneously cancelled on the final tick.
-        if (!args.InterruptsDoAfters || !args.DamageIncreased || args.DamageDelta == null || GameTiming.ApplyingState)
+        if (!args.InterruptsDoAfters || !args.DamageIncreased || args.DamageDelta == null || GameTiming.ApplyingState
+            || args.DamageDelta.DamageDict.ContainsKey("Radiation")) //Sanity check so people can crowbar doors open to flee from Lord Singuloth
             return;
 
         var delta = args.DamageDelta.GetTotal();


### PR DESCRIPTION
# Description

I got so pissed off that being near a singularity means you can't crowbar doors, that shortly after dying to a singularity because of said bullshit, I had written this before an emergency shuttle even arrived to pick up the crew. 

# Changelog

:cl:
- fix: Radiation damage no longer interrupts DoAfters.
