### PR TITLE
More Loadout Items: Wave 2

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
@@ -130,6 +130,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Captain

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
@@ -39,6 +39,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ChiefEngineer

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
@@ -61,6 +61,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ChiefMedicalOfficer

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/command.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/command.yml
@@ -1,0 +1,12 @@
+- type: loadout
+  id: LoadoutCommandGlovesInspection
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfPersonnel
+        - Captain
+  items:
+    - ClothingHandsGlovesInspection

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
@@ -97,6 +97,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfPersonnel

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
@@ -102,3 +102,15 @@
         - HeadOfPersonnel
   items:
     - ClothingShoesBootsWinterHeadOfPersonel
+
+- type: loadout
+  id: LoadoutCommandHOPBedsheetIan
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfPersonnel
+  items:
+    - BedsheetIan

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
@@ -168,6 +168,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
@@ -64,6 +64,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Quartermaster

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
@@ -50,6 +50,11 @@
   cost: 1
   exclusive: true
   requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ResearchDirector

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -14,7 +14,7 @@
 - type: loadout
   id: LoadoutCargoShoesBootsWinterCargo
   category: Jobs
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -23,6 +23,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsWinterCargo

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -1,3 +1,42 @@
+# Cargo technician
+- type: loadout
+  id: LoadoutCargoOuterWinterCargo
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - CargoTechnician
+  items:
+    - ClothingOuterWinterCargo
+
+- type: loadout
+  id: LoadoutCargoShoesBootsWinterCargo
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - CargoTechnician
+  items:
+    - ClothingShoesBootsWinterCargo
+
+# Salvage specialist
+
+- type: loadout
+  id: LoadoutCargoOuterWinterMiner
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingOuterWinterMiner
+
 - type: loadout
   id: LoadoutCargoNeckGoliathCloak
   category: Jobs

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -20,6 +20,10 @@
     - !type:CharacterJobRequirement
       jobs:
         - CargoTechnician
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
   items:
     - ClothingShoesBootsWinterCargo
 

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -506,6 +506,10 @@
     - !type:CharacterJobRequirement
        jobs:
          - Chemist
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
   items:
     - ClothingUniformJumpsuitChemShirt
 
@@ -530,6 +534,10 @@
     - !type:CharacterJobRequirement
        jobs:
          - Chemist
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
   items:
     - ClothingShoesEnclosedChem
 

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -496,6 +496,18 @@
   items:
     - ClothingEyesPrescriptionMedHud
 
+- type: loadout
+  id: LoadoutMedicalEyesGlassesChemical
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+         - Chemist
+  items:
+    - ClothingEyesGlassesChemical
+
 # Chemist PPE gear
 - type: loadout
   id: LoadoutMedicalUniformJumpsuitChemShirt

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -508,6 +508,18 @@
   items:
     - ClothingEyesGlassesChemical
 
+- type: loadout
+  id: LoadoutMedicalBedsheetMedical
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Medical
+  items:
+    - BedsheetMedical
+
 # Chemist PPE gear
 - type: loadout
   id: LoadoutMedicalUniformJumpsuitChemShirt

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -495,3 +495,76 @@
         - Nearsighted
   items:
     - ClothingEyesPrescriptionMedHud
+
+# Chemist PPE gear
+- type: loadout
+  id: LoadoutMedicalUniformJumpsuitChemShirt
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingUniformJumpsuitChemShirt
+
+- type: loadout
+  id: LoadoutMedicalNeckTieChem
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingNeckTieChem
+
+- type: loadout
+  id: LoadoutMedicalShoesEnclosedChem
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingShoesEnclosedChem
+
+- type: loadout
+  id: LoadoutMedicalOuterApronChemist
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingOuterApronChemist
+
+- type: loadout
+  id: LoadoutMedicalEyesGlassesChemist
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingEyesGlassesChemist
+
+- type: loadout
+  id: LoadoutMedicalHandsGlovesChemist
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+       jobs:
+         - Chemist
+  items:
+    - ClothingHandsGlovesChemist

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -561,6 +561,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesEnclosedChem

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -255,6 +255,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
     - !type:CharacterJobRequirement
       jobs:

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -63,6 +63,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsWinterClown
@@ -152,6 +153,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsWinterMime

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -54,7 +54,7 @@
 - type: loadout
   id: LoadoutServiceClownBootsWinter
   category: Jobs
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -143,7 +143,7 @@
 - type: loadout
   id: LoadoutServiceMimeShoesBootsWinter
   category: Jobs
-  cost: 2
+  cost: 1
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -27,6 +27,31 @@
     - ClothingHeadHatJesterAlt
     - ClothingShoesJester
 
+- type: loadout
+  id: LoadoutServiceClownBedsheetClown
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+  items:
+    - BedsheetClown
+
+# Mime
+- type: loadout
+  id: LoadoutServiceMimeBedsheetMime
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - BedsheetMime
+
 # Bartender
 - type: loadout
   id: LoadoutServiceBartenderUniformPurple

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -28,6 +28,58 @@
     - ClothingShoesJester
 
 - type: loadout
+  id: LoadoutServiceClownOuterWinter
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+  items:
+    - ClothingOuterWinterClown
+
+- type: loadout
+  id: LoadoutServiceClownOuterClownPriest
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+  items:
+    - ClothingOuterClownPriest
+
+- type: loadout
+  id: LoadoutServiceClownBootsWinter
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingShoesBootsWinterClown
+
+- type: loadout
+  id: LoadoutServiceClownMaskSexy
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+  items:
+    - ClothingMaskSexyClown
+
+- type: loadout
   id: LoadoutServiceClownBedsheetClown
   category: Jobs
   cost: 2
@@ -40,6 +92,70 @@
     - BedsheetClown
 
 # Mime
+- type: loadout
+  id: LoadoutServiceMimeOuterWinter
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingOuterWinterMime
+
+- type: loadout
+  id: LoadoutServiceMimeMaskSad
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingMaskSadMime
+
+- type: loadout
+  id: LoadoutServiceMimeMaskScared
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingMaskScaredMime
+
+- type: loadout
+  id: LoadoutServiceMimeMaskSexy
+  category: Jobs
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingMaskSexyMime
+
+- type: loadout
+  id: LoadoutServiceMimeShoesBootsWinter
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingShoesBootsWinterMime
+
 - type: loadout
   id: LoadoutServiceMimeBedsheetMime
   category: Jobs

--- a/Resources/Prototypes/Loadouts/categories.yml
+++ b/Resources/Prototypes/Loadouts/categories.yml
@@ -19,6 +19,9 @@
   id: Jobs
 
 - type: loadoutCategory
+  id: Mask
+
+- type: loadoutCategory
   id: Neck
 
 - type: loadoutCategory

--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -6,11 +6,31 @@
     - ClothingEyesEyepatch
 
 - type: loadout
+  id: LoadoutEyesGlasses
+  category: Eyes
+  cost: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Nearsighted
+  items:
+    - ClothingEyesGlasses
+
+- type: loadout
   id: LoadoutEyesBlindfold
   category: Eyes
   cost: 2
   items:
     - ClothingEyesBlindfold
+
+- type: loadout
+  id: LoadoutItemCheapSunglasses
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesCheapSunglasses
 
 - type: loadout
   id: LoadoutItemSunglasses

--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -18,6 +18,22 @@
     - ClothingEyesGlasses
 
 - type: loadout
+  id: LoadoutEyesGlassesJamjar
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesJamjar
+
+- type: loadout
+  id: LoadoutEyesGlassesJensen
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesJensen
+
+- type: loadout
   id: LoadoutEyesBlindfold
   category: Eyes
   cost: 2

--- a/Resources/Prototypes/Loadouts/hands.yml
+++ b/Resources/Prototypes/Loadouts/hands.yml
@@ -113,3 +113,11 @@
   exclusive: true
   items:
     - ClothingHandsGlovesRobohands
+
+- type: loadout
+  id: LoadoutHandsGlovesFingerless
+  category: Hands
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingHandsGlovesFingerless

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -137,6 +137,22 @@
     - ClothingHeadHatGreysoftFlipped
 
 - type: loadout
+  id: LoadoutHeadHatMimesoft
+  category: Head
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingHeadHatMimesoft
+
+- type: loadout
+  id: LoadoutHeadHatMimesoftFlipped
+  category: Head
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingHeadHatMimesoftFlipped
+
+- type: loadout
   id: LoadoutHeadHatOrangesoft
   category: Head
   cost: 1
@@ -272,3 +288,86 @@
   exclusive: true
   items:
     - ClothingHeadBandBrown
+
+- type: loadout
+  id: LoadoutHeadFishCap
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadFishCap
+
+- type: loadout
+  id: LoadoutHeadRastaHat
+  category: Head
+  cost: 4
+  exclusive: true
+  items:
+    - ClothingHeadRastaHat
+
+# Flatcaps
+- type: loadout
+  id: LoadoutHeadGreyFlatcap
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatGreyFlatcap
+
+- type: loadout
+  id: LoadoutHeadBrownFlatcap
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatBrownFlatcap
+
+# Berets
+- type: loadout
+  id: LoadoutHeadBeret
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatBeret
+
+- type: loadout
+  id: LoadoutHeadBeretFrench
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatBeretFrench
+
+# Cowboy hats
+- type: loadout
+  id: LoadoutHeadCowboyBrown
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBrown
+
+- type: loadout
+  id: LoadoutHeadCowboyBlack
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBlack
+
+- type: loadout
+  id: LoadoutHeadCowboyWhite
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyWhite
+
+- type: loadout
+  id: LoadoutHeadCowboyGrey
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyGrey

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -6,6 +6,11 @@
   exclusive: true
   items:
     - ClothingHeadHatBeaverHat
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadTophat
@@ -30,6 +35,11 @@
   exclusive: true
   items:
     - ClothingHeadHatFedoraBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadFedoraGrey
@@ -46,6 +56,11 @@
   exclusive: true
   items:
     - ClothingHeadHatFedoraChoc
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadFedoraWhite
@@ -70,6 +85,11 @@
   exclusive: true
   items:
     - ClothingHeadHatFlatBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadTinfoil
@@ -95,6 +115,11 @@
   exclusive: true
   items:
     - ClothingHeadHatBluesoft
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatBluesoftFlipped
@@ -103,6 +128,11 @@
   exclusive: true
   items:
     - ClothingHeadHatBluesoftFlipped
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatCorpsoft
@@ -127,6 +157,11 @@
   exclusive: true
   items:
     - ClothingHeadHatGreensoft
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatGreensoftFlipped
@@ -135,6 +170,11 @@
   exclusive: true
   items:
     - ClothingHeadHatGreensoftFlipped
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatGreysoft
@@ -175,6 +215,11 @@
   exclusive: true
   items:
     - ClothingHeadHatOrangesoft
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatOrangesoftFlipped
@@ -183,6 +228,11 @@
   exclusive: true
   items:
     - ClothingHeadHatOrangesoftFlipped
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatPurplesoft
@@ -191,6 +241,11 @@
   exclusive: true
   items:
     - ClothingHeadHatPurplesoft
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatPurplesoftFlipped
@@ -199,6 +254,11 @@
   exclusive: true
   items:
     - ClothingHeadHatPurplesoftFlipped
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatRedsoft
@@ -223,6 +283,11 @@
   exclusive: true
   items:
     - ClothingHeadHatYellowsoft
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadHatYellowsoftFlipped
@@ -231,6 +296,11 @@
   exclusive: true
   items:
     - ClothingHeadHatYellowsoftFlipped
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 # Headbands
 - type: loadout
@@ -248,6 +318,11 @@
   exclusive: true
   items:
     - ClothingHeadBandBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadBandGold
@@ -256,6 +331,11 @@
   exclusive: true
   items:
     - ClothingHeadBandGold
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadBandGreen
@@ -264,6 +344,11 @@
   exclusive: true
   items:
     - ClothingHeadBandGreen
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadBandGrey
@@ -272,6 +357,11 @@
   exclusive: true
   items:
     - ClothingHeadBandGrey
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadBandRed
@@ -296,6 +386,11 @@
   exclusive: true
   items:
     - ClothingHeadBandMerc
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadBandBrown
@@ -304,6 +399,11 @@
   exclusive: true
   items:
     - ClothingHeadBandBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadFishCap
@@ -312,6 +412,11 @@
   exclusive: true
   items:
     - ClothingHeadFishCap
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadRastaHat
@@ -320,6 +425,11 @@
   exclusive: true
   items:
     - ClothingHeadRastaHat
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadFez
@@ -353,6 +463,11 @@
   exclusive: true
   items:
     - ClothingHeadHatBrownFlatcap
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 # Berets
 - type: loadout
@@ -379,6 +494,11 @@
   exclusive: true
   items:
     - ClothingHeadHatCowboyBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutHeadCowboyBlack

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -24,6 +24,22 @@
     - ClothingHeadHatFedoraBlack
 
 - type: loadout
+  id: LoadoutHeadFedoraBrown
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatFedoraBrown
+
+- type: loadout
+  id: LoadoutHeadFedoraGrey
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatFedoraGrey
+
+- type: loadout
   id: LoadoutHeadFedoraChoc
   category: Head
   cost: 2
@@ -305,6 +321,22 @@
   items:
     - ClothingHeadRastaHat
 
+- type: loadout
+  id: LoadoutHeadFez
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatFez
+
+- type: loadout
+  id: LoadoutHeadBowlerHat
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatBowlerHat
+
 # Flatcaps
 - type: loadout
   id: LoadoutHeadGreyFlatcap
@@ -371,3 +403,11 @@
   exclusive: true
   items:
     - ClothingHeadHatCowboyGrey
+
+- type: loadout
+  id: LoadoutHeadCowboyRed
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyRed

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -183,6 +183,22 @@
   items:
     - CrowbarRed
 
+# Plushies
+- type: loadout
+  id: LoadoutItemPlushieLizard
+  category: Items
+  cost: 2
+  items:
+    - PlushieLizard
+
+- type: loadout
+  id: LoadoutItemPlushieSpaceLizard
+  category: Items
+  cost: 2
+  items:
+    - PlushieSpaceLizard
+
+
 #Misc Items
 - type: loadout
   id: LoadoutItemPAI
@@ -197,6 +213,13 @@
   cost: 2
   items:
     - ClothingBeltStorageWaistbag
+
+- type: loadout
+  id: LoadoutItemCrayonBox
+  category: Items
+  cost: 5
+  items:
+    - CrayonBox
 
 - type: loadout
   id: LoadoutSolCommonTranslator

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -220,6 +220,13 @@
     - CrayonBox
 
 - type: loadout
+  id: LoadoutItemBarberScissors
+  category: Items
+  cost: 4
+  items:
+    - BarberScissors
+
+- type: loadout
   id: LoadoutSolCommonTranslator
   category: Items
   cost: 3

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -192,6 +192,13 @@
     - PersonalAI
 
 - type: loadout
+  id: LoadoutItemBackpackSatchelLeather
+  category: Items
+  cost: 2
+  items:
+    - ClothingBackpackSatchelLeather
+
+- type: loadout
   id: LoadoutItemWaistbag
   category: Items
   cost: 2

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -215,7 +215,7 @@
 - type: loadout
   id: LoadoutItemCrayonBox
   category: Items
-  cost: 5
+  cost: 4
   items:
     - CrayonBox
 

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -183,22 +183,6 @@
   items:
     - CrowbarRed
 
-# Plushies
-- type: loadout
-  id: LoadoutItemPlushieLizard
-  category: Items
-  cost: 2
-  items:
-    - PlushieLizard
-
-- type: loadout
-  id: LoadoutItemPlushieSpaceLizard
-  category: Items
-  cost: 2
-  items:
-    - PlushieSpaceLizard
-
-
 #Misc Items
 - type: loadout
   id: LoadoutItemPAI

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -204,6 +204,11 @@
   cost: 2
   items:
     - ClothingBackpackSatchelLeather
+  requirements:
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - Prisoner
 
 - type: loadout
   id: LoadoutItemWaistbag
@@ -211,6 +216,11 @@
   cost: 2
   items:
     - ClothingBeltStorageWaistbag
+  requirements:
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - Prisoner
 
 - type: loadout
   id: LoadoutItemCrayonBox

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -183,6 +183,13 @@
   items:
     - CrowbarRed
 
+- type: loadout
+  id: LoadoutItemFireExtinguisher
+  category: Items
+  cost: 3
+  items:
+    - FireExtinguisher
+
 #Misc Items
 - type: loadout
   id: LoadoutItemPAI

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -201,7 +201,7 @@
 - type: loadout
   id: LoadoutItemBackpackSatchelLeather
   category: Items
-  cost: 2
+  cost: 1
   items:
     - ClothingBackpackSatchelLeather
   requirements:

--- a/Resources/Prototypes/Loadouts/mask.yml
+++ b/Resources/Prototypes/Loadouts/mask.yml
@@ -17,7 +17,7 @@
 - type: loadout
   id: LoadoutMaskGas
   category: Mask
-  cost: 3
+  cost: 1
   exclusive: true
   items:
     - ClothingMaskGas

--- a/Resources/Prototypes/Loadouts/mask.yml
+++ b/Resources/Prototypes/Loadouts/mask.yml
@@ -1,0 +1,113 @@
+- type: loadout
+  id: LoadoutMaskSterile
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskSterile
+
+- type: loadout
+  id: LoadoutMaskMuzzle
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskMuzzle
+
+- type: loadout
+  id: LoadoutMaskGas
+  category: Mask
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingMaskGas
+
+# Maskbands
+- type: loadout
+  id: LoadoutMaskBandBlack
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandBlack
+
+- type: loadout
+  id: LoadoutMaskBandBlue
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandBlue
+
+- type: loadout
+  id: LoadoutMaskBandGold
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandGold
+
+- type: loadout
+  id: LoadoutMaskBandGreen
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandGreen
+
+- type: loadout
+  id: LoadoutMaskBandGrey
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandGrey
+
+- type: loadout
+  id: LoadoutMaskBandRed
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandRed
+
+- type: loadout
+  id: LoadoutMaskBandSkull
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandSkull
+
+- type: loadout
+  id: LoadoutMaskBandMerc
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskBandMerc
+
+- type: loadout
+  id: LoadoutMaskBandBrown
+  category: Mask
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingMaskBandBrown
+
+# Gaiters
+- type: loadout
+  id: LoadoutMaskNeckGaiter
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskNeckGaiter
+
+- type: loadout
+  id: LoadoutMaskNeckGaiterRed
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskNeckGaiterRed

--- a/Resources/Prototypes/Loadouts/mask.yml
+++ b/Resources/Prototypes/Loadouts/mask.yml
@@ -38,6 +38,11 @@
   exclusive: true
   items:
     - ClothingMaskBandBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutMaskBandGold
@@ -46,6 +51,11 @@
   exclusive: true
   items:
     - ClothingMaskBandGold
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutMaskBandGreen
@@ -54,6 +64,11 @@
   exclusive: true
   items:
     - ClothingMaskBandGreen
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutMaskBandGrey
@@ -62,6 +77,11 @@
   exclusive: true
   items:
     - ClothingMaskBandGrey
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutMaskBandRed
@@ -86,6 +106,11 @@
   exclusive: true
   items:
     - ClothingMaskBandMerc
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 - type: loadout
   id: LoadoutMaskBandBrown
@@ -94,6 +119,11 @@
   exclusive: true
   items:
     - ClothingMaskBandBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
 
 # Gaiters
 - type: loadout

--- a/Resources/Prototypes/Loadouts/neck.yml
+++ b/Resources/Prototypes/Loadouts/neck.yml
@@ -79,6 +79,48 @@
   items:
     - ClothingNeckScarfStripedZebra
 
+# Ties
+- type: loadout
+  id: LoadoutNeckTieRed
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckTieRed
+
+- type: loadout
+  id: LoadoutNeckTieWhite
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckTieWhite
+
+- type: loadout
+  id: LoadoutNeckTieBlack
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckTieBlack
+
+- type: loadout
+  id: LoadoutNeckTieBlue
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckTieBlue
+
+- type: loadout
+  id: LoadoutNeckTieGreen
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckTieGreen
+
+
 #Pride Accessories
 - type: loadout
   id: LoadoutItemsPrideLGBTPin

--- a/Resources/Prototypes/Loadouts/neck.yml
+++ b/Resources/Prototypes/Loadouts/neck.yml
@@ -194,22 +194,6 @@
   items:
     - ClothingNeckTransPin
 
-- type: loadout
-  id: LoadoutItemsAutismPin
-  category: Neck
-  cost: 1
-  exclusive: true
-  items:
-    - ClothingNeckAutismPin
-
-- type: loadout
-  id: LoadoutItemsGoldAutismPin
-  category: Neck
-  cost: 1
-  exclusive: true
-  items:
-    - ClothingNeckGoldAutismPin
-
 # Bedsheets
 - type: loadout
   id: LoadoutNeckBedsheetBlack

--- a/Resources/Prototypes/Loadouts/neck.yml
+++ b/Resources/Prototypes/Loadouts/neck.yml
@@ -23,6 +23,46 @@
     - ClothingNeckScarfStripedGreen
 
 - type: loadout
+  id: LoadoutNeckScarfStripedBlack
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckScarfStripedBlack
+
+- type: loadout
+  id: LoadoutNeckScarfStripedBrown
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckScarfStripedBrown
+
+- type: loadout
+  id: LoadoutNeckScarfStripedLightBlue
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckScarfStripedLightBlue
+
+- type: loadout
+  id: LoadoutNeckScarfStripedOrange
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckScarfStripedOrange
+
+- type: loadout
+  id: LoadoutNeckScarfStripedPurple
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckScarfStripedPurple
+
+- type: loadout
   id: LoadoutNeckScarfStripedZebra
   category: Neck
   cost: 1
@@ -102,3 +142,19 @@
   exclusive: true
   items:
     - ClothingNeckTransPin
+
+- type: loadout
+  id: LoadoutItemsAutismPin
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckAutismPin
+
+- type: loadout
+  id: LoadoutItemsGoldAutismPin
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingNeckGoldAutismPin

--- a/Resources/Prototypes/Loadouts/neck.yml
+++ b/Resources/Prototypes/Loadouts/neck.yml
@@ -158,3 +158,216 @@
   exclusive: true
   items:
     - ClothingNeckGoldAutismPin
+
+# Bedsheets
+- type: loadout
+  id: LoadoutNeckBedsheetBlack
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetBlack
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetBlue
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetBrown
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetBrown
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetCosmos
+  category: Neck
+  cost: 3
+  exclusive: true
+  items:
+    - BedsheetCosmos
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetGreen
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetGreen
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetGrey
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetGrey
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetOrange
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetOrange
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+         - Logistics
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - HeadOfPersonnel # Need to blacklist HoP and not command so other heads can wear this bedsheet
+
+- type: loadout
+  id: LoadoutNeckBedsheetPurple
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetPurple
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+         - Epistemics
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - HeadOfPersonnel # Need to blacklist HoP and not command so other heads can wear this bedsheet
+
+- type: loadout
+  id: LoadoutNeckBedsheetRainbow
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetRainbow
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetRed
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetRed
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+         - Security
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - HeadOfPersonnel # Need to blacklist HoP and not command so other heads can wear this bedsheet
+
+- type: loadout
+  id: LoadoutNeckBedsheetWhite
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetWhite
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
+- type: loadout
+  id: LoadoutNeckBedsheetYellow
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetYellow
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+         - Engineering
+    - !type:CharacterJobRequirement
+       inverted: true
+       jobs:
+         - HeadOfPersonnel # Need to blacklist HoP and not command so other heads can wear this bedsheet
+
+- type: loadout
+  id: LoadoutNeckBedsheetNT
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - BedsheetNT
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command

--- a/Resources/Prototypes/Loadouts/neck.yml
+++ b/Resources/Prototypes/Loadouts/neck.yml
@@ -1,4 +1,13 @@
 - type: loadout
+  id: LoadoutNeckHeadphones
+  category: Neck
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingNeckHeadphones
+
+# Scarves
+- type: loadout
   id: LoadoutNeckScarfStripedRed
   category: Neck
   cost: 1

--- a/Resources/Prototypes/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/outerClothing.yml
@@ -211,3 +211,17 @@
   cost: 3
   items:
     - ClothingOuterCoatTrench
+
+- type: loadout
+  id: LoadoutOuterCoatJensen
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterCoatJensen
+
+- type: loadout
+  id: LoadoutOuterCoatGentle
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterCoatGentle

--- a/Resources/Prototypes/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/outerClothing.yml
@@ -54,6 +54,13 @@
   items:
     - ClothingOuterVestValet
 
+- type: loadout
+  id: LoadoutOuterVest
+  category: Outer
+  cost: 1
+  items:
+    - ClothingOuterVest
+
 # Letterman Jackets
 - type: loadout
   id: LoadoutOuterCoatLettermanBlue
@@ -168,3 +175,39 @@
   cost: 2
   items:
     - ClothingOuterZhCorporateJacket
+
+- type: loadout
+  id: LoadoutOuterDenimJacket
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterDenimJacket
+
+# Flannel
+- type: loadout
+  id: LoadoutOuterFlannelRed
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterFlannelRed
+
+- type: loadout
+  id: LoadoutOuterFlannelGreen
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterFlannelGreen
+
+- type: loadout
+  id: LoadoutOuterFlannelBlue
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterFlannelBlue
+
+- type: loadout
+  id: LoadoutOuterCoatTrench
+  category: Outer
+  cost: 3
+  items:
+    - ClothingOuterCoatTrench

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -302,3 +302,31 @@
         - Harpy
   items:
     - ClothingShoesHighheelBoots
+
+# Socks
+- type: loadout
+  id: LoadoutShoesUnderSocksCoder
+  category: Shoes
+  cost: 3
+  exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingUnderSocksCoder
+
+# Socks
+- type: loadout
+  id: LoadoutShoesUnderSocksBee
+  category: Shoes
+  cost: 3
+  exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingUnderSocksBee

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -8,6 +8,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorBlack
@@ -21,6 +22,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorBlue
@@ -34,6 +36,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorBrown
@@ -47,6 +50,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorGreen
@@ -60,6 +64,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorOrange
@@ -73,6 +78,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorPurple
@@ -86,6 +92,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorRed
@@ -99,6 +106,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorWhite
@@ -112,6 +120,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesColorYellow
@@ -125,6 +134,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesGeta
@@ -138,6 +148,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesTourist
@@ -152,6 +163,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsWork
@@ -165,6 +177,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsLaceup
@@ -178,6 +191,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsWinter
@@ -191,6 +205,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsCowboyBrown
@@ -204,6 +219,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsCowboyBlack
@@ -217,6 +233,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsCowboyWhite
@@ -230,6 +247,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsCowboyFancy
@@ -243,6 +261,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesBootsFishing
@@ -259,6 +278,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
     - !type:CharacterJobRequirement
       jobs:
@@ -273,6 +293,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesLeather
@@ -286,6 +307,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesMiscWhite
@@ -299,6 +321,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingShoesHighheelBoots
@@ -313,6 +336,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingUnderSocksCoder
@@ -327,6 +351,7 @@
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
+        - Diona
         - Harpy
   items:
     - ClothingUnderSocksBee

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -129,6 +129,19 @@
   items:
     - ClothingShoesGeta
 
+- type: loadout
+  id: LoadoutShoesTourist
+  category: Shoes
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingShoesTourist
+
 # Boots
 - type: loadout
   id: LoadoutShoesBootsWork
@@ -221,6 +234,19 @@
   items:
     - ClothingShoesBootsCowboyFancy
 
+- type: loadout
+  id: LoadoutShoesBootsFishing
+  category: Shoes
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingShoesBootsFishing
+
 # Miscellaneous
 - type: loadout
   id: LoadoutShoesSlippersDuck
@@ -263,3 +289,16 @@
         - Harpy
   items:
     - ClothingShoesMiscWhite
+
+- type: loadout
+  id: LoadoutShoesHighheelBoots
+  category: Shoes
+  cost: 3
+  exclusive: true
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  items:
+    - ClothingShoesHighheelBoots

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -722,6 +722,87 @@
   items:
     - ClothingUniformSchoolGakuranBlack
 
+# Schoolgirl uniform
+- type: loadout
+  id: LoadoutUniformSchoolgirlBlack
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlBlack
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlBlue
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlBlue
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlCyan
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlCyan
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlGreen
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlGreen
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlOrange
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlOrange
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlPink
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlPink
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlPurple
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlPurple
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlRed
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlRed
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlDusk
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlDusk
+
+- type: loadout
+  id: LoadoutUniformSchoolgirlBlazerTan
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformSchoolgirlBlazerTan
+
 # MNK Uniforms
 - type: loadout
   id: LoadoutClothingMNKOfficeSkirt

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -31,6 +31,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Security
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -47,6 +48,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Security
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -211,6 +213,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Security
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -227,6 +230,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Security
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -682,7 +686,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -700,7 +703,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -736,7 +738,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -877,7 +878,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -891,7 +891,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -994,7 +993,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1108,7 +1106,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 # Schoolgirl uniform
@@ -1123,7 +1120,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -448,6 +448,10 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualBlue
@@ -456,6 +460,12 @@
   exclusive: true
   items:
     - ClothingUniformJumpskirtCasualBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitCasualPurple
@@ -469,6 +479,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualPurple
@@ -477,6 +492,12 @@
   exclusive: true
   items:
     - ClothingUniformJumpskirtCasualPurple
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitCasualRed
@@ -490,6 +511,10 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualRed
@@ -498,6 +523,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpskirtCasualRed
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitTshirtJeans
@@ -511,6 +541,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitTshirtJeansGray
@@ -524,6 +559,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitTshirtJeansPeach
@@ -537,6 +577,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansGreen
@@ -550,6 +595,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansRed
@@ -563,6 +613,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansBrown
@@ -576,6 +631,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitLostTourist
@@ -589,6 +649,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Hawaiian shirts
 - type: loadout
@@ -603,6 +668,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiBlue
@@ -616,6 +686,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiRed
@@ -629,6 +704,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiYellow
@@ -642,6 +722,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # AutoDrobe clothes
 - type: loadout
@@ -651,6 +736,11 @@
   exclusive: true
   items:
     - ClothingUniformDressRed
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitSober
@@ -664,6 +754,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSkirtTurtle
@@ -672,6 +767,12 @@
   exclusive: true
   items:
     - ClothingUniformSkirtTurtle
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformGeisha
@@ -680,6 +781,11 @@
   exclusive: true
   items:
     - UniformGeisha
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformCostumeArcDress
@@ -688,6 +794,12 @@
   exclusive: true
   items:
     - ClothingCostumeArcDress
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformCostumeMioSkirt
@@ -696,6 +808,12 @@
   exclusive: true
   items:
     - ClothingCostumeMioSkirt
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformCostumeNaota
@@ -704,6 +822,12 @@
   exclusive: true
   items:
     - ClothingCostumeNaota
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Bartender clothes
 - type: loadout
@@ -718,6 +842,11 @@
       inverted: true
       species:
         - Harpy
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtBartender
@@ -726,6 +855,12 @@
   exclusive: true
   items:
     - ClothingUniformJumpskirtBartender
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Kendo
 - type: loadout
@@ -735,6 +870,12 @@
   exclusive: true
   items:
     - ClothingUniformKendoHakama
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformMartialGi
@@ -743,6 +884,12 @@
   exclusive: true
   items:
     - ClothingUniformMartialGi
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Kimono
 - type: loadout
@@ -752,6 +899,12 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitKimono
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingKimonoBlue
@@ -760,6 +913,12 @@
   exclusive: true
   items:
     - ClothingKimonoBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingKimonoPink
@@ -768,6 +927,12 @@
   exclusive: true
   items:
     - ClothingKimonoPink
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingKimonoPurple
@@ -776,6 +941,12 @@
   exclusive: true
   items:
     - ClothingKimonoPurple
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingKimonoSky
@@ -784,6 +955,12 @@
   exclusive: true
   items:
     - ClothingKimonoSky
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingKimonoGreen
@@ -792,6 +969,12 @@
   exclusive: true
   items:
     - ClothingKimonoGreen
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Gakuran
 - type: loadout
@@ -801,6 +984,12 @@
   exclusive: true
   items:
     - ClothingUniformSchoolGakuranBlack
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # Schoolgirl uniform
 - type: loadout
@@ -810,6 +999,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlBlack
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlBlue
@@ -818,6 +1013,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlBlue
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlCyan
@@ -826,6 +1027,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlCyan
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlGreen
@@ -834,6 +1041,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlGreen
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlOrange
@@ -842,6 +1055,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlOrange
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlPink
@@ -850,6 +1069,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlPink
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlPurple
@@ -858,6 +1083,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlPurple
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlRed
@@ -866,6 +1097,11 @@
   exclusive: true
   items:
     - UniformSchoolgirlRed
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlDusk
@@ -874,6 +1110,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlDusk
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutUniformSchoolgirlBlazerTan
@@ -882,6 +1124,12 @@
   exclusive: true
   items:
     - UniformSchoolgirlBlazerTan
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 # MNK Uniforms
 - type: loadout
@@ -891,6 +1139,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKOfficeSkirt
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKUnderGarment
@@ -899,6 +1153,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKUnderGarment
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKGymBra
@@ -907,6 +1167,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKGymBra
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKDressBlack
@@ -915,6 +1181,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKDressBlack
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKBlackOveralls
@@ -923,6 +1195,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKBlackOveralls
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKBlackShoulder
@@ -931,6 +1209,12 @@
   exclusive: true
   items:
     - ClothingUniformMNKBlackShoulder
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
 
 - type: loadout
   id: LoadoutClothingMNKTracksuitBlack
@@ -939,3 +1223,9 @@
   exclusive: true
   items:
     - ClothingUniformMNKTracksuitBlack
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -443,6 +443,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannel
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualBlue
@@ -459,6 +464,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitCasualPurple
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualPurple
@@ -475,6 +485,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitCasualRed
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpskirtCasualRed
@@ -491,6 +506,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitTshirtJeans
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitTshirtJeansGray
@@ -499,6 +519,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitTshirtJeansGray
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitTshirtJeansPeach
@@ -507,6 +532,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitTshirtJeansPeach
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansGreen
@@ -515,6 +545,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitJeansGreen
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansRed
@@ -523,6 +558,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitJeansRed
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitJeansBrown
@@ -531,6 +571,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitJeansBrown
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitLostTourist
@@ -539,6 +584,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitLostTourist
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 # Hawaiian shirts
 - type: loadout
@@ -548,6 +598,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiBlack
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiBlue
@@ -556,6 +611,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiBlue
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiRed
@@ -564,6 +624,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiRed
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiYellow
@@ -572,6 +637,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiYellow
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 # AutoDrobe clothes
 - type: loadout
@@ -589,6 +659,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitSober
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformSkirtTurtle
@@ -638,6 +713,11 @@
   exclusive: true
   items:
     - ClothingUniformJumpsuitBartender
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
 
 - type: loadout
   id: LoadoutUniformJumpskirtBartender

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -1143,7 +1143,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1157,7 +1156,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1171,7 +1169,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1185,7 +1182,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1199,7 +1195,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1213,7 +1208,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout
@@ -1227,5 +1221,4 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -28,9 +28,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorBlack
@@ -40,9 +44,13 @@
   items:
     - ClothingUniformJumpskirtColorBlack
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorBlue
@@ -56,9 +64,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorBlue
@@ -68,9 +80,13 @@
   items:
     - ClothingUniformJumpskirtColorBlue
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorGreen
@@ -84,9 +100,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorGreen
@@ -96,9 +116,13 @@
   items:
     - ClothingUniformJumpskirtColorGreen
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorOrange
@@ -112,9 +136,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorOrange
@@ -124,9 +152,13 @@
   items:
     - ClothingUniformJumpskirtColorOrange
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorPink
@@ -140,9 +172,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorPink
@@ -152,9 +188,13 @@
   items:
     - ClothingUniformJumpskirtColorPink
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorRed
@@ -168,9 +208,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorRed
@@ -180,9 +224,13 @@
   items:
     - ClothingUniformJumpskirtColorRed
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorWhite
@@ -196,9 +244,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorWhite
@@ -208,9 +260,13 @@
   items:
     - ClothingUniformJumpskirtColorWhite
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorYellow
@@ -224,9 +280,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorYellow
@@ -236,9 +296,13 @@
   items:
     - ClothingUniformJumpskirtColorYellow
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorDarkBlue
@@ -252,9 +316,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorDarkBlue
@@ -264,9 +332,13 @@
   items:
     - ClothingUniformJumpskirtColorDarkBlue
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorTeal
@@ -280,9 +352,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorTeal
@@ -292,9 +368,13 @@
   items:
     - ClothingUniformJumpskirtColorTeal
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorPurple
@@ -308,9 +388,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorPurple
@@ -320,9 +404,13 @@
   items:
     - ClothingUniformJumpskirtColorPurple
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorDarkGreen
@@ -336,9 +424,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorDarkGreen
@@ -348,9 +440,13 @@
   items:
     - ClothingUniformJumpskirtColorDarkGreen
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorLightBrown
@@ -364,9 +460,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorLightBrown
@@ -376,9 +476,13 @@
   items:
     - ClothingUniformJumpskirtColorLightBrown
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorBrown
@@ -392,9 +496,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorBrown
@@ -404,9 +512,13 @@
   items:
     - ClothingUniformJumpskirtColorBrown
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitColorMaroon
@@ -420,9 +532,13 @@
       inverted: true
       species:
         - Harpy
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpskirtColorMaroon
@@ -432,9 +548,13 @@
   items:
     - ClothingUniformJumpskirtColorMaroon
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Passenger
+    - !type:CharacterDepartmentRequirement
+       departments:
+         - Civilian
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
 
 - type: loadout
   id: LoadoutUniformJumpsuitFlannel

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -838,7 +838,6 @@
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
-         - Security
          - Command
 
 - type: loadout

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -958,6 +958,19 @@
          - Security
          - Command
 
+- type: loadout
+  id: LoadoutUniformJumpsuitLoungewear
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitLoungewear
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Command
+
 # Bartender clothes
 - type: loadout
   id: LoadoutUniformJumpsuitBartender

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -68,6 +68,7 @@
         - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
+         - Medical
          - Civilian
     - !type:CharacterDepartmentRequirement
        inverted: true
@@ -84,6 +85,7 @@
   requirements:
     - !type:CharacterDepartmentRequirement
        departments:
+         - Medical
          - Civilian
     - !type:CharacterDepartmentRequirement
        inverted: true
@@ -251,6 +253,8 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Medical
+         - Epistemics
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -267,6 +271,8 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Medical
+         - Epistemics
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -287,6 +293,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Engineering
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -303,6 +310,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Engineering
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -395,6 +403,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Epistemics
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -411,6 +420,7 @@
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
+         - Epistemics
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -436,6 +436,217 @@
       jobs:
         - Passenger
 
+- type: loadout
+  id: LoadoutUniformJumpsuitFlannel
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitFlannel
+
+- type: loadout
+  id: LoadoutUniformJumpskirtCasualBlue
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtCasualBlue
+
+- type: loadout
+  id: LoadoutUniformJumpsuitCasualPurple
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitCasualPurple
+
+- type: loadout
+  id: LoadoutUniformJumpskirtCasualPurple
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtCasualPurple
+
+- type: loadout
+  id: LoadoutUniformJumpsuitCasualRed
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitCasualRed
+
+- type: loadout
+  id: LoadoutUniformJumpskirtCasualRed
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtCasualRed
+
+- type: loadout
+  id: LoadoutUniformJumpsuitTshirtJeans
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitTshirtJeans
+
+- type: loadout
+  id: LoadoutUniformJumpsuitTshirtJeansGray
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitTshirtJeansGray
+
+- type: loadout
+  id: LoadoutUniformJumpsuitTshirtJeansPeach
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitTshirtJeansPeach
+
+- type: loadout
+  id: LoadoutUniformJumpsuitJeansGreen
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitJeansGreen
+
+- type: loadout
+  id: LoadoutUniformJumpsuitJeansRed
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitJeansRed
+
+- type: loadout
+  id: LoadoutUniformJumpsuitJeansBrown
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitJeansBrown
+
+- type: loadout
+  id: LoadoutUniformJumpsuitLostTourist
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitLostTourist
+
+# Hawaiian shirts
+- type: loadout
+  id: LoadoutUniformJumpsuitHawaiBlack
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitHawaiBlack
+
+- type: loadout
+  id: LoadoutUniformJumpsuitHawaiBlue
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitHawaiBlue
+
+- type: loadout
+  id: LoadoutUniformJumpsuitHawaiRed
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitHawaiRed
+
+- type: loadout
+  id: LoadoutUniformJumpsuitHawaiYellow
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitHawaiYellow
+
+# AutoDrobe clothes
+- type: loadout
+  id: LoadoutUniformDressRed
+  category: Uniform
+  cost: 4
+  exclusive: true
+  items:
+    - ClothingUniformDressRed
+
+- type: loadout
+  id: LoadoutUniformJumpsuitSober
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitSober
+
+- type: loadout
+  id: LoadoutUniformSkirtTurtle
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingUniformSkirtTurtle
+
+- type: loadout
+  id: LoadoutUniformGeisha
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - UniformGeisha
+
+- type: loadout
+  id: LoadoutUniformCostumeArcDress
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingCostumeArcDress
+
+- type: loadout
+  id: LoadoutUniformCostumeMioSkirt
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingCostumeMioSkirt
+
+- type: loadout
+  id: LoadoutUniformCostumeNaota
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingCostumeNaota
+
+# Bartender clothes
+- type: loadout
+  id: LoadoutUniformJumpsuitBartender
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitBartender
+
+- type: loadout
+  id: LoadoutUniformJumpskirtBartender
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtBartender
+
 # Kendo
 - type: loadout
   id: LoadoutUniformKendoHakama
@@ -454,6 +665,14 @@
     - ClothingUniformMartialGi
 
 # Kimono
+- type: loadout
+  id: LoadoutClothingJumpsuitKimono
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitKimono
+
 - type: loadout
   id: LoadoutClothingKimonoBlue
   category: Uniform


### PR DESCRIPTION
# Description

Adds significantly more items to Loadouts. Notably, it adds almost every item from the ClothesMate, a decent amount of clothing from the AutoDrobe, and some missing clothes from the WinterDrobe.

Other changes:

- Restrict Command from wearing uniforms outside of their job
- Limit Security's non-sec uniform/head/mask options to those that maintain the Security aesthetic, such as clothes that are red, black, and some blue/beige, and all MNK gear.
- Restrict all shoes from Dionas and Harpies properly. I have a feeling that there's a better way to get around this issue, perhaps by preventing these species from selecting items that are based on `ClothingShoesBase`.
- Make all colored jumpsuits available to all Civilians, and select jumpsuits for departments such as white/blue for Medical, white/purple for Epistemics, and yellow for Engineering.

## New Items

### Uniform

Command cannot select any listed uniforms. Security (except HoS) can only select items marked with (*).

- [2] white shirt and purple skirt
- [2] yellow skirt with rose hoodie
- [2] turquoise hoodie and shorts
- [2] casual blue jumpsuit
- [2] casual blue jumpskirt
- [2] casual purple jumpsuit
- [2] casual purple jumpskirt
- [2] casual red jumpsuit (*)
- [2] casual red jumpskirt (*)
- [2] flannel jumpsuit (*)
- [2] black hawaiian shirt
- [2] blue hawaiian shirt
- [2] red hawaiian shirt (*)
- [2] yellow hawaiian shirt
- [2] brown sweater with jeans
- [2] green sweater with jeans
- [2] red sweater with jeans (*)
- [2] loungewear (*)
- [2] sober sweater
- [2] white t-shirt and jeans
- [2] gray t-shirt and jeans (*)
- [2] peach t-shirt and jeans (*)
- [2] decorated turtle skirt (*)
- [3] kimono
- [3] geisha dress (*)
- [3] bartender's uniform (jumpsuit)
- [3] bartender's uniform (jumpskirt)
  - I find the bartender's uniform to be a neutral and very versatile piece, fitting the MNK aesthetic. This uniform with a white shirt and black bottom pairs well with the MNK black jacket and flannel jumpsuits. For this reason, I think the bartender's uniform should be accessible to everyone.  
- [3] lost tourist uniform
- [3] black schoolgirl uniform (*)
- [3] tan blazer schoolgirl uniform
- [3] blue schoolgirl uniform
- [3] cyan schoolgirl uniform
- [3] dusk schoolgirl uniform
- [3] green schoolgirl uniform
- [3] orange schoolgirl uniform
- [3] pink schoolgirl uniform
- [3] purple schoolgirl uniform
- [3] red schoolgirl uniform (*)
- [4] red dress (*)

## Outer

- [1] vest
- [3] gentle coat
- [3] jensen coat
- [3] trench coat
- [3] Denim jacket
- [3] blue flannel jacket
- [3] green flannel jacket
- [3] red flannel jacket

## Head

Security (including HoS) can only select items marked with (*).

- [1] mime cap (*)
- [1] mime cap (flipped) (*)
  - The mime cap is just a plain white cap, the same as the other caps in the Loadouts.
- [2] beret (*)
- [2] French beret (*)
- [2] bowler hat (*)
- [2] brown flatcap
- [2] grey flatcap (*)
  - There already exists a "brown flat cap" (note the extra space) in the Loadouts, but it's a different item with a different style. 
- [2] black cowboy hat (*)
- [2] brown cowboy hat
- [2] red cowboy hat (*)
- [2] grey cowboy hat (*) 
- [2] white cowboy hat (*)
- [2] brown fedora (chocolate)
- [2] grey fedora (*)
- [2] fez (*)
- [2] fishing cap
- [4] rasta hat

## Shoes

- [2] fishing boots
- [2] tourist shoes
- [3] high-heeled boots
- [3] coder socks
- [3] bee socks

## Neck

Added some missing scarves and pins. Pins suggested by @Tmanzxd

- [1] striped black scarf
- [1] striped brown scarf
- [1] striped light blue scarf
- [1] striped orange scarf
- [1] striped purple scarf
- [1] black tie
- [1] blue tie
- [1] green tie
- [1] red-tie
- [1] white tie
- [2] headphones

Added bedsheets. Bedsheets are restricted to Civilian (excluding HoP) unless stated otherwise.

- [2] black bedsheet
- [2] blue bedsheet
- [2] brown bedsheet
- [2] green bedsheet
- [2] grey bedsheet
- [2] NT bedsheet
- [2] orange bedsheet
  - Usable by all Logistics roles
- [2] purple bedsheet
  - Usable by all Epistemics roles. We are one step closer to RD wizard
- [2] rainbow bedsheet
- [2] red bedsheet
  - Usable by all Security roles
- [2] white bedsheet
- [2] yellow bedsheet
  - Usable by all Engineering roles
- [3] cosmos bedsheet

## Mask

New category. There is conveniently already localization for the Mask category.

Security (including HoS) can only select items marked with (*).

- [1] black bandana (*)
- [1] blue bandana
- [1] brown bandana
- [1] gold bandana
- [1] green bandana
- [1] grey bandana
- [1] red bandana (*)
- [1] skull bandana (*)
- [1] gas mask (*)
- [1] sterile mask (*)
- [2] mercenary bandana
- [2] muzzle (*)
- [2] neck gaiter (*)
- [2] red neck gaiter (*)

## Eyes

- [1] glasses 
  - Can't be used by characters with the Nearsighted trait as they already spawn with glasses
- [2] jamjar glasses
- [2] jensen glasses
- [2] cheap sunglasses
  - A cheaper alternative to sunglasses (5 loadout points), without flash protection

## Items

- [1] leather satchel
  - Leather satchels used to be a default backpack type in SS13
- [3] fire extinguisher
  - For when you need to put out fires from fire anomalies and pyromancy
- [4] crayon box
  - Crew can use this to ~~vandalize sec front~~ decorate their workplaces with love 
- [4] barber scissors

## Jobs

### Chemist

Suggested by @Tmanzxd

- [1] heavy nitrile gloves
- [1] chemistry tie
- [1] enclosed shoes
- [2] safety glasses
- [2] chemical resistant apron
- [2] formal chemistry suit

### Captain/HoP

- [1] inspection gloves

### Head of Personnel

- [2] Ian's bedsheet

### Medical

- [2] medical bedsheet

### Clown

- [1] sexy clown mask
- [1] clown winter boots
- [2] clown's bedsheet
- [2] robes of the honkmother
- [2] clown winter coat

### Mime

- [1] sad mime mask
- [1] scary mime mask
- [1] sexy mime mask
- [1] mime's winter boots
- [2] mime's bedsheet
- [2] mime's winter coat

### Cargo Technician

- [1] logistics winter boots
- [2] logistics winter coat

### Salvage Specialist

- [2] mining winter coat

---

<details><summary><h1>Media (Character Lookbook)</h1></summary>
<p>

## Stylish Cowboy

![image](https://github.com/user-attachments/assets/23d78f00-a601-4fd7-8139-990850afc912)

**Loadout:** black cowboy hat, bartender's uniform (jumpsuit), striped black scarf, red flannel jacket, fingerless gloves, fishing boots

## Secret agent

![image](https://github.com/user-attachments/assets/8d89a944-c147-47ce-b06a-21a2d0dee4dc)

**Loadout:** french beret, cheap sunglasses, bartender's uniform (jumpskirt), MNK black jacket

## Cybernetic Tourist

![image](https://github.com/user-attachments/assets/ddd28b02-5211-4803-a5ae-6c37872f7d94)

**Loadout:** glasses, blue hawaiian shirt, striped light blue scarf, geta sandals

## Cowgirl

![image](https://github.com/user-attachments/assets/25c6b5dd-30ff-4096-a710-fb785219958a)

**Loadout:** white cowboy hat, MNK gym bra, high-heeled boots

## Cat schoolgirl

![image](https://github.com/user-attachments/assets/f97cd552-ddd2-49d0-8f4e-dcada261ec7f)

**Loadout:** pink schoolgirl uniform, coder socks

## Olive Rancher

![image](https://github.com/user-attachments/assets/8f31921c-14e9-43c5-bd65-0c90ec9c3a5a)

**Loadout:** grey cowboy hat, gray t-shirt and jeans, vest, leather shoes

## Casual

![image](https://github.com/user-attachments/assets/9610822b-cd3e-4dab-a06c-2a0f30f43866)

**Loadout:** Beret, cheap sunglasses, sober sweater, laceup shoes

## French Chemist

![image](https://github.com/user-attachments/assets/325653a9-ddba-4670-bac2-67cda1d90b5c)

**Loadout:** french beret, formal chemistry suit, chemistry tie, chemical resistant apron, heavy nitrile gloves, enclosed shoes

(Hey Heidi!)

## RD Wizard

![image](https://github.com/user-attachments/assets/8807e3a8-12ec-4ed7-80c7-62952ebe39f0)

*For my next magic trick, I cast Pyromancy!*

**Loadout:** top hat, glasses, mystagogue lab coat, purple bedsheet, fishing boots

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Skubman
- add: Added dozens of new clothes and items to Loadouts, including the new Mask category. Have fun dressing up your characters!
- tweak: Restrict Command Loadouts from selecting uniforms outside of their job.
- tweak: Limit the selection in Security Loadouts of non-sec uniforms, hats, and masks to those that maintain the Security aesthetic.
- tweak: Made all types of colored jumpsuits in Loadouts available to Civilian roles (excluding HoP), and suitable jumpsuits to Epistemics, Engineering, and Medical.
- fix: Prevent dionas and harpies from selecting shoes in Loadouts.