### PR TITLE
Minor Language Fixes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -525,19 +525,19 @@ public sealed partial class ChatSystem : SharedChatSystem
             {
                 // Scenario 1: the listener can clearly understand the message
                 result = perceivedMessage;
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, perceivedMessage, language);
+                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, result, language);
             }
             else if (_interactionSystem.InRangeUnobstructed(source, listener, WhisperMuffledRange, Shared.Physics.CollisionGroup.Opaque))
             {
-                // Scenerio 2: if the listener is too far, they only hear fragments of the message
+                // Scenario 2: if the listener is too far, they only hear fragments of the message
                 result = ObfuscateMessageReadability(perceivedMessage);
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", nameIdentity, perceivedMessage, language);
+                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", nameIdentity, result, language);
             }
             else
             {
                 // Scenario 3: If listener is too far and has no line of sight, they can't identify the whisperer's identity
                 result = ObfuscateMessageReadability(perceivedMessage);
-                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-unknown-wrap-message", string.Empty, perceivedMessage, language);
+                wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-unknown-wrap-message", string.Empty, result, language);
             }
 
             _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, false, session.Channel);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -881,7 +881,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             : _random.Pick(speech.SpeechVerbStrings);
         var color = DefaultSpeakColor;
         if (language.SpeechOverride.Color is { } colorOverride)
-            color *= colorOverride;
+            color = Color.InterpolateBetween(color, colorOverride, colorOverride.A);
 
         return Loc.GetString(wrapId,
             ("color", color),

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -78,6 +78,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     public const int WhisperMuffledRange = 5; // how far whisper goes at all, in world units
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
     public const float DefaultObfuscationFactor = 0.2f; // Percentage of symbols in a whispered message that can be seen even by "far" listeners
+    public readonly Color DefaultSpeakColor = Color.White;
 
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;
@@ -543,10 +544,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, false, session.Channel);
         }
 
-        var replayWrap = Loc.GetString("chat-manager-entity-whisper-wrap-message",
-            ("color", language.SpeechOverride.Color),
-            ("entityName", name),
-            ("message", FormattedMessage.EscapeText(message)));
+        var replayWrap = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, FormattedMessage.EscapeText(message), language);
         _replay.RecordServerMessage(new ChatMessage(ChatChannel.Whisper, message, replayWrap, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
 
         var ev = new EntitySpokeEvent(source, message, channel, true, language);
@@ -881,9 +879,12 @@ public sealed partial class ChatSystem : SharedChatSystem
         var verbId = language.SpeechOverride.SpeechVerbOverrides is { } verbsOverride
             ? _random.Pick(verbsOverride).ToString()
             : _random.Pick(speech.SpeechVerbStrings);
+        var color = DefaultSpeakColor;
+        if (language.SpeechOverride.Color is { } colorOverride)
+            color *= colorOverride;
 
         return Loc.GetString(wrapId,
-            ("color", language.SpeechOverride.Color),
+            ("color", color),
             ("entityName", entityName),
             ("verb", Loc.GetString(verbId)),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),

--- a/Content.Server/Language/TranslatorSystem.cs
+++ b/Content.Server/Language/TranslatorSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.PowerCell;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Language;
+using Content.Shared.Language.Components;
 using Content.Shared.Language.Systems;
 using Content.Shared.PowerCell;
 using Content.Shared.Language.Components.Translators;
@@ -173,11 +174,13 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
         {
             intrinsic.SpokenLanguages = [..comp.SpokenLanguages];
             intrinsic.UnderstoodLanguages = [..comp.UnderstoodLanguages];
+            intrinsic.RequiredLanguages = [..comp.RequiredLanguages];
         }
         else
         {
             intrinsic.SpokenLanguages.Clear();
             intrinsic.UnderstoodLanguages.Clear();
+            intrinsic.RequiredLanguages.Clear();
         }
 
         intrinsic.Enabled = isEnabled;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -179,8 +179,9 @@ public sealed class RadioSystem : EntitySystem
     private string WrapRadioMessage(EntityUid source, RadioChannelPrototype channel, string name, string message, LanguagePrototype language)
     {
         var speech = _chat.GetSpeechVerb(source, message);
-        // TODO this is done just to preserve the old look of radio, perhaps we can change it as well?
-        var languageColor = language.SpeechOverride.Color == Color.White ? channel.Color : language.SpeechOverride.Color;
+        var languageColor = channel.Color;
+        if (language.SpeechOverride.Color is { } colorOverride)
+            languageColor *= colorOverride;
 
         return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", channel.Color),

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -178,10 +178,11 @@ public sealed class RadioSystem : EntitySystem
 
     private string WrapRadioMessage(EntityUid source, RadioChannelPrototype channel, string name, string message, LanguagePrototype language)
     {
+        // TODO: code duplication with ChatSystem.WrapMessage
         var speech = _chat.GetSpeechVerb(source, message);
         var languageColor = channel.Color;
         if (language.SpeechOverride.Color is { } colorOverride)
-            languageColor *= colorOverride;
+            languageColor = Color.InterpolateBetween(languageColor, colorOverride, colorOverride.A);
 
         return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", channel.Color),

--- a/Content.Shared/Language/LanguagePrototype.cs
+++ b/Content.Shared/Language/LanguagePrototype.cs
@@ -37,8 +37,11 @@ public sealed class LanguagePrototype : IPrototype
 [DataDefinition]
 public sealed partial class SpeechOverrideInfo
 {
+    /// <summary>
+    ///     Color mask for text written in this language. If null, text color will not be affected.
+    /// </summary>
     [DataField]
-    public Color Color = Color.White;
+    public Color? Color = null;
 
     [DataField]
     public string? FontId;

--- a/Content.Shared/Language/LanguagePrototype.cs
+++ b/Content.Shared/Language/LanguagePrototype.cs
@@ -38,7 +38,8 @@ public sealed class LanguagePrototype : IPrototype
 public sealed partial class SpeechOverrideInfo
 {
     /// <summary>
-    ///     Color mask for text written in this language. If null, text color will not be affected.
+    ///     Color which text in this language will be blended with.
+    ///     Alpha blending is used, which means the alpha component of the color controls the intensity of this color.
     /// </summary>
     [DataField]
     public Color? Color = null;

--- a/Resources/Locale/en-US/language/languages.ftl
+++ b/Resources/Locale/en-US/language/languages.ftl
@@ -70,5 +70,8 @@ language-Crab-description = Click!
 language-Kobold-name = Kobold
 language-Kobold-description = Hiss!
 
+language-Hissing-name = Hissing
+language-Hissing-description = Hiss!
+
 language-Sign-name = Sign Language
 language-Sign-description = The standard Galactic sign language, used by those that are unable to speak Galactic Common or at all.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2442,6 +2442,12 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: LanguageKnowledge
+    speaks:
+    - Hissing
+    understands:
+    - Hissing
+
 
 - type: entity
   name: possum
@@ -2519,6 +2525,11 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: LanguageKnowledge
+    speaks:
+    - Hissing
+    understands:
+    - Hissing
 
 - type: entity
   name: fox
@@ -2886,9 +2897,9 @@
     - Syndicate
   - type: LanguageKnowledge
     speaks:
-    - Xeno
+    - Cat
     understands:
-    - Xeno
+    - Cat
     - GalacticCommon
 
 - type: entity
@@ -3060,6 +3071,11 @@
     barkMultiplier: 10
     barks:
       - Sloth
+  - type: LanguageKnowledge # WHAT DOES THE SLOTH SAY???????
+    speaks:
+    - Hissing
+    understands:
+    - Hissing
 
 - type: entity
   name: ferret
@@ -3119,6 +3135,11 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: LanguageKnowledge
+    speaks:
+    - Hissing
+    understands:
+    - Hissing
 
 - type: entity
   name: hamster

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -215,6 +215,7 @@
     - Pig
     - Crab
     - Kobold
+    - Hissing
     requires:
     - GalacticCommon
     setLanguageOnInteract: false

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -61,3 +61,12 @@
   - type: LightningTarget
     priority: 1
   - type: RequireProjectileTarget
+  - type: LanguageSpeaker
+    currentLanguage: GalacticCommon
+  - type: LanguageKnowledge
+    speaks:
+    - GalacticCommon
+    - RobotTalk
+    understands:
+    - GalacticCommon
+    - RobotTalk

--- a/Resources/Prototypes/Language/languages.yml
+++ b/Resources/Prototypes/Language/languages.yml
@@ -576,6 +576,18 @@
     - ss
     - ee
 
+- type: language
+  id: Hissing
+  obfuscation:
+    !type:SyllableObfuscation
+    minSyllables: 2
+    maxSyllables: 4
+    replacement:
+    - hss
+    - iss
+    - ss
+    - is
+
 # Example of a sign language. Not currently used anyhow.
 - type: language
   id: Sign

--- a/Resources/Prototypes/Language/languages.yml
+++ b/Resources/Prototypes/Language/languages.yml
@@ -39,7 +39,7 @@
 - type: language
   id: Bubblish
   speech:
-    color: "#0077aadd"
+    color: "#00a3e2dd"
     fontId: RubikBubbles
   obfuscation:
     !type:SyllableObfuscation
@@ -56,7 +56,7 @@
 - type: language
   id: Moffic
   speech:
-    color: "#869b29dd"
+    color: "#c7df2edd"
     fontId: Copperplate
   obfuscation:
     !type:SyllableObfuscation
@@ -125,7 +125,7 @@
 - type: language
   id: RootSpeak
   speech:
-    color: "#804000dd"
+    color: "#ce5e14dd"
     fontId: Noganas
   obfuscation:
     !type:SyllableObfuscation
@@ -142,7 +142,7 @@
 - type: language
   id: Nekomimetic
   speech:
-    color: "#803B56ee"
+    color: "#df57aaee"
     fontId: Manga
   obfuscation:
     !type:SyllableObfuscation
@@ -202,7 +202,7 @@
 - type: language
   id: Draconic
   speech:
-    color: "#228b22dd"
+    color: "#2aca2add"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 2
@@ -297,7 +297,7 @@
 - type: language
   id: Canilunzt
   speech:
-    color: "#b97a57cc"
+    color: "#d69b3dcc"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1

--- a/Resources/Prototypes/Language/languages.yml
+++ b/Resources/Prototypes/Language/languages.yml
@@ -39,7 +39,7 @@
 - type: language
   id: Bubblish
   speech:
-    color: "#0077aa"
+    color: "#0077aadd"
     fontId: RubikBubbles
   obfuscation:
     !type:SyllableObfuscation
@@ -56,7 +56,7 @@
 - type: language
   id: Moffic
   speech:
-    color: "#869b29"
+    color: "#869b29dd"
     fontId: Copperplate
   obfuscation:
     !type:SyllableObfuscation
@@ -125,7 +125,7 @@
 - type: language
   id: RootSpeak
   speech:
-    color: "#804000"
+    color: "#804000dd"
     fontId: Noganas
   obfuscation:
     !type:SyllableObfuscation
@@ -142,7 +142,7 @@
 - type: language
   id: Nekomimetic
   speech:
-    color: "#803B56"
+    color: "#803B56ee"
     fontId: Manga
   obfuscation:
     !type:SyllableObfuscation
@@ -202,7 +202,7 @@
 - type: language
   id: Draconic
   speech:
-    color: "#228b22"
+    color: "#228b22dd"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 2
@@ -297,7 +297,7 @@
 - type: language
   id: Canilunzt
   speech:
-    color: "#b97a57"
+    color: "#b97a57cc"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1
@@ -365,7 +365,7 @@
 - type: language
   id: SolCommon
   speech:
-    color: "#8282fb"
+    color: "#8282fbaa"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1


### PR DESCRIPTION
# Description
Fixes:
- Whisper not undergoing readability obfuscation when out of range
- Handheld translators ignoring language knowledge requirements
- Several animals not having defined languages
- Computers not having languages (this primarily affects the RnD console and in the future the cargo request console which send radio messages)
- Some languages lacking brightness and thus being hard to read

Also makes language colors from language markers use alpha blending instead of overriding the original color. The change is subtle, kinda hard to make it noticable without defeating the original purpose...

<details><summary><h1>Media</h1></summary><p>

Example of the new colors

![image](https://github.com/user-attachments/assets/291c1a6d-829b-43ec-afb7-5c902a1e4aff)

</p></details>

---

# Changelog
:cl:
- fix: Whisper can no longer be heard clearly outside the intended range.
- fix: Translators can no longer be used without knowing the languages they require.
- fix: Computers (primarily RnD console) now speak GC by default instead of Universal.
- tweak: Readjusted colors of all languages to make them easier to read.
