### PR TITLE
Fix Sound Params

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -34,11 +34,20 @@
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
   - type: EmitSoundOnPickup
-    sound: /Audio/SimpleStation14/Items/Handling/drinkglass_pickup.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/drinkglass_pickup.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnDrop
-    sound: /Audio/SimpleStation14/Items/Handling/drinkglass_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/drinkglass_drop.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnLand
-    sound: /Audio/SimpleStation14/Items/Handling/drinkglass_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/drinkglass_drop.ogg
+      params:
+        volume: -2
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -5,12 +5,20 @@
   description: This kills the wire.
   components:
   - type: EmitSoundOnPickup
-    sound: /Audio/SimpleStation14/Items/Handling/wirecutter_pickup.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/wirecutter_pickup.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnDrop
-    sound: /Audio/SimpleStation14/Items/Handling/wirecutter_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/wirecutter_drop.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Items/wirecutter_drop.ogg
+      params:
+        volume: -2
   - type: Tag
     tags:
     - PlantSampleTaker
@@ -55,12 +63,20 @@
   description: Industrial grade torque in a small screwdriving package.
   components:
   - type: EmitSoundOnPickup
-    sound: /Audio/SimpleStation14/Items/Handling/screwdriver_pickup.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/screwdriver_pickup.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnDrop
-    sound: /Audio/SimpleStation14/Items/Handling/screwdriver_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/screwdriver_drop.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Items/screwdriver_drop.ogg
+      params:
+        volume: -2
   - type: Tag
     tags:
     - Screwdriver
@@ -103,12 +119,20 @@
   description: 'A common tool for assembly and disassembly. Remember: righty tighty, lefty loosey.'
   components:
   - type: EmitSoundOnPickup
-    sound: /Audio/SimpleStation14/Items/Handling/wrench_pickup.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/wrench_pickup.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnDrop
-    sound: /Audio/SimpleStation14/Items/Handling/wrench_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/wrench_drop.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Items/wrench_drop.ogg
+      params:
+        volume: -2
   - type: Tag
     tags:
     - Wrench
@@ -146,12 +170,20 @@
   description: A multipurpose tool to pry open doors and fight interdimensional invaders.
   components:
   - type: EmitSoundOnPickup
-    sound: /Audio/SimpleStation14/Items/Handling/crowbar_pickup.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/crowbar_pickup.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnDrop
-    sound: /Audio/SimpleStation14/Items/Handling/crowbar_drop.ogg
+    sound:
+      path: /Audio/SimpleStation14/Items/Handling/crowbar_drop.ogg
+      params:
+        volume: -2
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Items/crowbar_drop.ogg
+      params:
+        volume: -2
   - type: Tag
     tags:
     - Crowbar

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -14,8 +14,6 @@
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Effects/drop.ogg
-      params:
-        volume: 2
   - type: DamageOnHighSpeedImpact
     damage:
       types:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -50,8 +50,12 @@
   - type: EntityStorage
     closeSound:
       path: /Audio/Effects/closet_close.ogg
+      params:
+        volume: -4
     openSound:
       path: /Audio/Effects/closet_open.ogg
+      params:
+        volume: -4
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container


### PR DESCRIPTION
# Description

Done by request from several people who have some issues with the sound mixing of certain items being very off. I did a little digging, and discovered that the heart of the issue is that id: BaseItem had for whatever utterly strange reason, set the volume for every item not overriding it to be above people's sound settings, resulting in pickup and drop sounds being strangely inconsistent with all other volumes. It got so bad that some people reportedly couldn't play the game.

# Changelog

:cl:
- fix: Fixed Tools, Drink Containers, Lockers, and all base items having inconsistent sound settings. 
