### PR TITLE
Fix the Uncategorized Category Not Being Hidden

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -1578,7 +1578,7 @@ namespace Content.Client.Preferences.UI
 
 
             // Hide Uncategorized tab if it's empty, other tabs already shouldn't exist if they're empty
-            _traitsTabs.SetTabVisible(0, uncategorized.Children.Any());
+            _traitsTabs.SetTabVisible(0, uncategorized.Children.First().Children.First().Children.Any());
 
             // Add fake tabs until tab container is happy
             for (var i = _traitsTabs.ChildCount - 1; i < _traitsTabs.CurrentTab; i++)
@@ -1837,7 +1837,7 @@ namespace Content.Client.Preferences.UI
 
 
             // Hide Uncategorized tab if it's empty, other tabs already shouldn't exist if they're empty
-            _loadoutsTabs.SetTabVisible(0, uncategorized.Children.Any());
+            _loadoutsTabs.SetTabVisible(0, uncategorized.Children.First().Children.First().Children.Any());
 
             // Add fake tabs until tab container is happy
             for (var i = _loadoutsTabs.ChildCount - 1; i < _loadoutsTabs.CurrentTab; i++)


### PR DESCRIPTION
<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/8292491a-e3c6-4321-a2a9-acf3d7f92d3b)

</p>
</details>

---

# Changelog

:cl:
- fix: Fixed the Uncategorized category not being hidden when empty
