### PR TITLE
Make Boxes Not Useless

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -11,7 +11,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,2,2
+    - 0,0,3,3
   - type: Sprite
     state: box
   - type: EmitSoundOnPickup

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/Containers/lunchbox.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/Containers/lunchbox.yml
@@ -18,9 +18,9 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,1,1
-    - 3,0,1,1
-    - 4,0,4,1
+    - 0,0,1,2
+    - 3,0,1,2
+    - 4,0,4,2
   - type: PhysicalComposition
     materialComposition:
       Plastic: 100

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -10,7 +10,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,3,1
+    - 0,0,3,2
   - type: Item
     size: Large
     sprite: Objects/Specific/Medical/firstaidkits.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -17,7 +17,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,6,3
+    - 0,0,6,4
   - type: Item
     size: Ginormous
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -17,7 +17,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,6,4
+    - 0,0,6,3
   - type: Item
     size: Ginormous
   - type: MeleeWeapon


### PR DESCRIPTION
# Description

Subcontainers such as Boxes, Medkits, and Lunchboxes are essentially useless items that players always throw away. The given reason for this is that because the boxes only ever provided the same or less inventory slots than the inventory slots they take away, using boxes only ever penalizes players. Since you can only ever open one container at a time, placing items in boxes means you have to first open your backpack, then open the box, then take the item out.

How it SHOULD work instead, is that boxes contain slightly more inventory slots than what they remove. You would effectively be trading the ability to quickly and efficiently access all your items, for having slightly more inventory capacity. This PR buffs the parent of four different categories of items, such that 3x3 boxes occupy 9 inventory spaces and provide 16 spaces, and 2x4 boxes occupy 8 spaces and provide 12 spaces. The difference accounts for 3x3 boxes being significantly more inventory-awkward to put in your backpack than the 2x4 containers. 

Toolboxes are unchanged because they're already huge, and don't fit in backpacks anyway.

Here's a demonstration of inventory management with a backpack full of boxes.

https://github.com/user-attachments/assets/40b184f6-b061-4f0a-8e8b-7e2a7b9793bc

# Changelog

:cl:
- add: Boxes(Cardboard, Medkits, Lunchboxes) now contain slightly more inventory slots than they occupy.
