### PR TITLE
"Buff" Vision Traits

### DIFF
--- a/Resources/Prototypes/DeltaV/Traits/altvision.yml
+++ b/Resources/Prototypes/DeltaV/Traits/altvision.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: UltraVision
   category: Visual
-  points: -1
+  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
@@ -18,7 +18,7 @@
 - type: trait
   id: DogVision
   category: Visual
-  points: -1
+  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true

--- a/Resources/Prototypes/DeltaV/Traits/altvision.yml
+++ b/Resources/Prototypes/DeltaV/Traits/altvision.yml
@@ -1,7 +1,6 @@
 - type: trait
   id: UltraVision
   category: Visual
-  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
@@ -18,7 +17,6 @@
 - type: trait
   id: DogVision
   category: Visual
-  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -31,7 +31,6 @@
 - type: trait
   id: NormalVision
   category: Visual
-  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -31,7 +31,7 @@
 - type: trait
   id: NormalVision
   category: Visual
-  points: -1
+  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       species:


### PR DESCRIPTION
# Description

This takes Ultravision, Dogvision, and Normalvision, making all 3 traits into our first set of "Neutral" traits. They now cost 0 points, but still occupy one of the 5 trait selections. In the future we should have a decent roster of Positive, Neutral, and Negative traits. If Death ever finishes making Subcategories, we'll probably want to have Positive, Neutral, and Negative be the 3 "Main" categories, and all subcategories sit underneath them.


<details><summary><h1>Media</h1></summary>
<p>

Token screenshot for a 3 line PR because my maintainers will get onto me if I don't include some kind of media. :trollface: 

![image](https://github.com/user-attachments/assets/27a7feea-a347-41bf-ae01-099eb84ed7af)

</p>
</details>

# Changelog

:cl:
- tweak: Ultraviolet Vision, Deuteranopia, and Trichromat Modification are all now 0 point Neutral traits. They still occupy one of your trait selections.
