### PR TITLE
Remove Clothesmate Bloat

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 1000
+  cost: 1410
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 1410
+  cost: 1500
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 4500
+  cost: 1000
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -5,6 +5,7 @@
     ClothingBackpack: 2
     ClothingBackpackDuffel: 2
     ClothingBackpackSatchel: 2
+    ClothingBackpackSatchelLeather: 2
     ClothingRandomSpawner: 6
     ClothingHeadBandBlack: 2
     ClothingHeadHatGreyFlatcap: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -1,116 +1,24 @@
 - type: vendingMachineInventory
   id: ClothesMateInventory
   startingInventory:
-    ClothingBackpack: 5
-    ClothingBackpackDuffel: 5
-    ClothingBackpackSatchel: 3
-    ClothingBackpackSatchelLeather: 2
-    ClothingRandomSpawner: 8
-    ClothingHeadHatBeret: 4
+  # STOP! ADD NOTHING TO THIS! GO PUT YOUR CLOTHES IN LOADOUTS INSTEAD!
+    ClothingBackpack: 2
+    ClothingBackpackDuffel: 2
+    ClothingBackpackSatchel: 2
+    ClothingRandomSpawner: 6
     ClothingHeadBandBlack: 2
-    ClothingHeadBandBlue: 2
-    ClothingHeadBandGreen: 2
-    ClothingHeadBandRed: 2
-    ClothingHeadBandSkull: 2
-    ClothingHeadHatGreyFlatcap: 3
-    ClothingHeadHatBrownFlatcap: 3
-    ClothingUniformJumpsuitColorGrey: 8
-    ClothingUniformJumpskirtColorGrey: 8
-    ClothingUniformJumpsuitColorWhite: 3
-    ClothingUniformJumpskirtColorWhite: 3
-    ClothingUniformJumpsuitColorBlack: 3
-    ClothingUniformJumpskirtColorBlack: 3
-    ClothingUniformJumpsuitColorBlue: 2
-    ClothingUniformJumpskirtColorBlue: 2
-    ClothingUniformJumpsuitColorYellow: 2
-    ClothingUniformJumpskirtColorYellow: 2
-    ClothingUniformJumpsuitColorGreen: 2
-    ClothingUniformJumpskirtColorGreen: 2
-    ClothingUniformJumpsuitColorOrange: 2
-    ClothingUniformJumpskirtColorOrange: 2
-    ClothingUniformJumpsuitColorRed: 2
-    ClothingUniformJumpskirtColorRed: 2
-    ClothingUniformJumpsuitColorPurple: 2
-    ClothingUniformJumpskirtColorPurple: 2
-    ClothingUniformJumpsuitColorPink: 2
-    ClothingUniformJumpskirtColorPink: 2
-    ClothingUniformJumpsuitColorDarkBlue: 2
-    ClothingUniformJumpskirtColorDarkBlue: 2
-    ClothingUniformJumpsuitColorDarkGreen:  2
-    ClothingUniformJumpskirtColorDarkGreen: 2
-    ClothingUniformJumpsuitColorTeal: 2
-    ClothingUniformJumpskirtColorTeal: 2
-    ClothingUniformJumpsuitHawaiBlack: 2
-    ClothingUniformJumpsuitHawaiBlue: 2
-    ClothingUniformJumpsuitHawaiRed: 2
-    ClothingUniformJumpsuitHawaiYellow: 2
-    ClothingUniformJumpsuitFlannel: 2
-    ClothingUniformJumpsuitCasualBlue: 2
-    ClothingUniformJumpskirtCasualBlue: 2
-    ClothingUniformJumpsuitCasualPurple: 2
-    ClothingUniformJumpskirtCasualPurple: 2
-    ClothingUniformJumpsuitCasualRed: 2
-    ClothingUniformJumpskirtCasualRed: 2
-    ClothingUniformJumpsuitTshirtJeans: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitTshirtJeansGray: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitTshirtJeansPeach: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitJeansGreen: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitJeansRed: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitJeansBrown: 2 # Nyano - Clothing addition
-    ClothingUniformJumpsuitLostTourist: 2 # Nyano - Clothing addition
-    ClothingShoesColorBlack: 8
-    ClothingShoesColorBrown: 4
-    ClothingShoesColorWhite: 3
-    ClothingShoesColorBlue: 2
-    ClothingShoesColorYellow: 2
-    ClothingShoesColorGreen: 2
-    ClothingShoesColorOrange: 2
-    ClothingShoesColorRed: 2
-    ClothingShoesColorPurple: 2
-    ClothingHeadHatGreysoft: 8
-    ClothingHeadHatMimesoft: 3
-    ClothingHeadHatBluesoft: 2
-    ClothingHeadHatYellowsoft: 2
-    ClothingHeadHatGreensoft: 2
-    ClothingHeadHatOrangesoft: 2
-    ClothingHeadHatRedsoft: 2
-    ClothingHeadHatBlacksoft: 2
-    ClothingHeadHatPurplesoft: 2
+    ClothingHeadHatGreyFlatcap: 2
+    ClothingUniformJumpsuitColorGrey: 2
+    ClothingUniformJumpskirtColorGrey: 2
+    ClothingShoesColorBlack: 4
+    ClothingHeadHatGreysoft: 2
     ClothingHeadHatCorpsoft: 2
-    ClothingOuterWinterCoat: 2 # Nyano - Clothing addition
-    ClothingOuterWinterCoatLong: 2 # Nyano - Clothing addition
-    ClothingOuterWinterCoatPlaid: 2 # Nyano - Clothing addition
-    ClothingOuterCoatHyenhSweater: 2 # Nyano - Clothing addition
-    ClothingOuterCoatLettermanBlue: 2 # Nyano - Clothing addition
-    ClothingOuterCoatLettermanRed: 2 # Nyano - Clothing addition
-    ClothingOuterDenimJacket: 2 # DeltaV - Clothing addition
-    ClothingOuterCorporateJacket: 2 # DeltaV - Clothing addition
-    ClothingOuterCsCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterEeCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterHiCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterHmCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterIdCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterZhCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterGeCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterFaCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterDdCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingOuterBcCorporateJacket: 2 # Einstein Engines - Clothing addition
-    ClothingShoesBootsFishing: 2 # Nyano - Clothing addition
-    ClothingHeadTinfoil: 2 # Nyano - Clothing addition
-    ClothingHeadFishCap: 2
-    ClothingHeadRastaHat: 2
+    ClothingOuterWinterCoat: 2
+    ClothingOuterCorporateJacket: 2
     ClothingBeltStorageWaistbag: 3
     ClothingEyesGlasses: 6
     ClothingHandsGlovesColorBlack: 4
-    ClothingHandsGlovesColorGray: 4
-    ClothingHandsGlovesColorBrown: 2
-    ClothingHandsGlovesColorWhite: 2
-    ClothingHandsGlovesColorRed: 2
-    ClothingHandsGlovesColorBlue: 2
-    ClothingHandsGlovesColorGreen: 2
-    ClothingHandsGlovesColorOrange: 2
-    ClothingHandsGlovesColorPurple: 2
-    ClothingEyesGlassesCheapSunglasses: 3
+    ClothingEyesGlassesCheapSunglasses: 2
   contrabandInventory:
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -322,7 +322,7 @@
   parent: VendingMachine
   id: VendingMachineClothing
   name: ClothesMate
-  description: A vending machine for clothing.
+  description: A vending machine for dispensing the cheapest clothing Nanotrasen can buy.
   components:
   - type: VendingMachine
     pack: ClothesMateInventory


### PR DESCRIPTION
# Description

The original intended purpose of Loadouts as designed by Death was to serve as the ultimate solution to the Clothesmate BLOAT. Ironically, when Wizden made their own Loadouts, they made a version of Loadout that is incapable of this. Now that we've more significantly fleshed out EE Loadouts to fulfill that purpose, I can finally trim down the Clothesmate. I haven't touched any of the other vendors, just the Clothesmate. 

As an aside, the cost of a Clothing restock has gone down from a fucking ridiculous 4500, down to only 1500. Making it something Cargo techs can actually reasonably buy. Clothesmates now only contain the absolute barest minimum clothes for a greytider. This also helpfully serves as a balancing act against Loadouts being able to provide items other than clothes. It is much harder to get clothing outside of loadouts, preventing people from spamming useless clothing entities on the station. If you spend all your loadout points on items, you are locking yourself out of wearing actually nice drip. Choose how you spend your points wisely!

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/9f6d7668-c8ba-4404-834c-b4f885b6617f)

</p>
</details>

---

# Changelog

:cl:
- tweak: Due to budget cuts, Nanotrasen has ceased stocking Clothesmate vendors with more clothing than the average cargo tech can afford. Civilians are advised to bring their own clothes to the station if they wish to wear anything other than grey. 
