### PR TITLE
Add 4 Missing Vendors To Vendor Spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vending.yml
@@ -31,4 +31,8 @@
       - VendingMachineSoda
       - VendingMachineStarkist
       - VendingMachineSpaceUp
+      - VendingMachineFitness
+      - VendingMachineHotfood
+      - VendingMachineSolsnack
+      - VendingMachineWeeb
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/vendingdrinks.yml
@@ -22,4 +22,5 @@
       - VendingMachineSoda
       - VendingMachineStarkist
       - VendingMachineSpaceUp
+      - VendingMachineFitness
     chance: 1


### PR DESCRIPTION
# Description

https://github.com/Simple-Station/Einstein-Engines/pull/400 added 4 new vendors that were never implemented in the game's spawners, so they never actually appeared ingame. This PR adds them to random vendor spawners, so that they'll show up on stations.

# Changelog

:cl:
- add: SweatMAX, "hot foods", Mars Mart, and Nippon-tan vendors have all been added to vendor spawners. 
