### PR TITLE
Increase Combat Knife Availability

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -14,6 +14,7 @@
     ClothingEyesHudSecurity: 2
     ClothingEyesEyepatchHudSecurity: 2
     ClothingBeltSecurityWebbing: 5
+    CombatKnife: 3
     Zipties: 12
     RiotShield: 2
     RiotLaserShield: 2

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -472,6 +472,7 @@
         - Sidearm
         - MagazinePistol
         - MagazineMagnum
+        - CombatKnife
       components:
         - Stunbaton
         - FlashOnTrigger

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -169,6 +169,7 @@
        - ShellTranquilizer
        - CartridgeLightRifle
        - CartridgeRifle
+       - CombatKnife
        - MagazineBoxPistol
        - MagazineBoxMagnum
        - MagazineBoxRifle
@@ -706,6 +707,7 @@
     runningState: icon
     staticRecipes:
       - ClothingEyesHudSecurity
+      - CombatKnife
       - Flash
       - Handcuffs
       - Zipties

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -363,6 +363,22 @@
   items:
     - ClothingBeltSecurityWebbingFilled
 
+# Equipment
+- type: loadout
+  id: LoadoutSecurityCombatKnife
+  category: Jobs
+  cost: 1
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Diona
+        - Harpy
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - CombatKnife
+
 # TODO: Make this replace the secoff handgun and make it cheaper
 # # Species
 # - type: loadout

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -30,7 +30,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitPrisonGuard
     back: ClothingBackpackSecurityFilled
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadPrisonGuard
     id: PrisonGuardPDA

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -31,6 +31,15 @@
     Plastic: 300
 
 - type: latheRecipe
+  id: CombatKnife
+  result: CombatKnife
+  category: Weapons
+  completetime: 2
+  materials:
+    Steel: 250
+    Plastic: 100
+    
+- type: latheRecipe
   id: WeaponLaserCarbine
   result: WeaponLaserCarbine
   category: Weapons


### PR DESCRIPTION
# Description

Added combat knives to the SecTech vendor and added the combat knife to the security techfab for a cost of 2.5 steel and 1 plastic.

With this change, Harpy and Diona Security players can now get a combat knife from the SecTech as they cannot spawn nor wear combat boots, which contains a combat knife.

Prison guards now start with combat boots with a combat knife, and a combat knife has been added to Loadouts for Felinid/Harpy security.

Cherry-picked from Space Wizards (https://github.com/space-wizards/space-station-14/pull/27224).

An equivalent to "Fix no combat knives in sec techfab" (https://github.com/space-wizards/space-station-14/pull/28086) has been added with 7809b504cc1c2f8f4e9db2e820d94f292e787115, which also adds the combat knife to emagged autolathes.


# Changelog

:cl: Skubman, Ghagliiarghii
- add: Added the combat knife to the SecTech, and the ability to manufacture combat knives in the SecLathe and emagged autolathes.
- add: Added a 1-point combat knife to Loadouts for Felinid/Harpy security jobs. 
- tweak: Made the security belt and security webbing able to hold combat knives.
- tweak: Prison Guards now start with combat boots with a combat knife. 