### PR TITLE
Automatically Remove Loadouts Invalid For Species

### DIFF
--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -48,3 +48,6 @@ character-whitelist-requirement = You must {$inverted ->
     [true] not be
     *[other] be
 } whitelisted
+
+# Species
+species-cannot-equip = {$species} cannot equip {$item}

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
@@ -130,11 +130,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Captain

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
@@ -39,11 +39,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ChiefEngineer

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
@@ -61,11 +61,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ChiefMedicalOfficer

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
@@ -97,11 +97,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfPersonnel

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
@@ -168,11 +168,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
@@ -64,11 +64,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Quartermaster

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
@@ -50,11 +50,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - ResearchDirector

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -20,11 +20,6 @@
     - !type:CharacterJobRequirement
       jobs:
         - CargoTechnician
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsWinterCargo
 

--- a/Resources/Prototypes/Loadouts/Jobs/engineering.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/engineering.yml
@@ -4,10 +4,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer
@@ -53,10 +49,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer

--- a/Resources/Prototypes/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/medical.yml
@@ -47,10 +47,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -66,10 +62,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -85,10 +77,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -104,10 +92,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -123,10 +107,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -142,10 +122,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -161,10 +137,6 @@
   cost: 3
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -216,10 +188,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Paramedic
@@ -268,10 +236,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - MedicalDoctor
@@ -530,10 +494,6 @@
     - !type:CharacterJobRequirement
        jobs:
          - Chemist
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
   items:
     - ClothingUniformJumpsuitChemShirt
 
@@ -558,11 +518,6 @@
     - !type:CharacterJobRequirement
        jobs:
          - Chemist
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesEnclosedChem
 

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -19,10 +19,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Scientist

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -5,10 +5,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -23,10 +19,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -93,10 +85,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
@@ -121,10 +109,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -137,10 +121,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Warden
@@ -201,10 +181,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -220,10 +196,6 @@
   cost: 1
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective
@@ -252,11 +224,6 @@
   category: Jobs
   cost: 1
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Detective

--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -60,11 +60,6 @@
     - !type:CharacterJobRequirement
       jobs:
         - Clown
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsWinterClown
 
@@ -150,11 +145,6 @@
     - !type:CharacterJobRequirement
       jobs:
         - Mime
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsWinterMime
 
@@ -203,10 +193,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
      jobs:
         - Lawyer
@@ -231,10 +217,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -259,10 +241,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -287,10 +265,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Lawyer
@@ -328,10 +302,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Reporter

--- a/Resources/Prototypes/Loadouts/shoes.yml
+++ b/Resources/Prototypes/Loadouts/shoes.yml
@@ -4,12 +4,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorBlack
 
@@ -18,12 +12,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorBlue
 
@@ -32,12 +20,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorBrown
 
@@ -46,12 +28,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorGreen
 
@@ -60,12 +36,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorOrange
 
@@ -74,12 +44,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorPurple
 
@@ -88,12 +52,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorRed
 
@@ -102,12 +60,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorWhite
 
@@ -116,12 +68,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesColorYellow
 
@@ -130,12 +76,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesGeta
 
@@ -144,12 +84,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesTourist
 
@@ -159,12 +93,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsWork
 
@@ -173,12 +101,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsLaceup
 
@@ -187,12 +109,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsWinter
 
@@ -201,12 +117,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsCowboyBrown
 
@@ -215,12 +125,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsCowboyBlack
 
@@ -229,12 +133,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsCowboyWhite
 
@@ -243,12 +141,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsCowboyFancy
 
@@ -257,12 +149,6 @@
   category: Shoes
   cost: 2
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesBootsFishing
 
@@ -275,11 +161,6 @@
   items:
     - ClothingShoeSlippersDuck
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Clown
@@ -289,12 +170,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesLeather
 
@@ -303,12 +178,6 @@
   category: Shoes
   cost: 1
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesMiscWhite
 
@@ -317,12 +186,6 @@
   category: Shoes
   cost: 3
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingShoesHighheelBoots
 
@@ -332,12 +195,6 @@
   category: Shoes
   cost: 3
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingUnderSocksCoder
 
@@ -347,11 +204,5 @@
   category: Shoes
   cost: 3
   exclusive: true
-  requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Diona
-        - Harpy
   items:
     - ClothingUnderSocksBee

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -4,10 +4,6 @@
   cost: 2
   exclusive: true
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterJobRequirement
       jobs:
         - Passenger
@@ -24,10 +20,6 @@
   items:
     - ClothingUniformJumpsuitColorBlack
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -62,10 +54,6 @@
   items:
     - ClothingUniformJumpsuitColorBlue
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Medical
@@ -100,10 +88,6 @@
   items:
     - ClothingUniformJumpsuitColorGreen
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -136,10 +120,6 @@
   items:
     - ClothingUniformJumpsuitColorOrange
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -172,10 +152,6 @@
   items:
     - ClothingUniformJumpsuitColorPink
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -208,10 +184,6 @@
   items:
     - ClothingUniformJumpsuitColorRed
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -246,10 +218,6 @@
   items:
     - ClothingUniformJumpsuitColorWhite
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -286,10 +254,6 @@
   items:
     - ClothingUniformJumpsuitColorYellow
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -324,10 +288,6 @@
   items:
     - ClothingUniformJumpsuitColorDarkBlue
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -360,10 +320,6 @@
   items:
     - ClothingUniformJumpsuitColorTeal
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -396,10 +352,6 @@
   items:
     - ClothingUniformJumpsuitColorPurple
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -434,10 +386,6 @@
   items:
     - ClothingUniformJumpsuitColorDarkGreen
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -470,10 +418,6 @@
   items:
     - ClothingUniformJumpsuitColorLightBrown
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -506,10 +450,6 @@
   items:
     - ClothingUniformJumpsuitColorBrown
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -542,10 +482,6 @@
   items:
     - ClothingUniformJumpsuitColorMaroon
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        departments:
          - Civilian
@@ -578,10 +514,6 @@
   items:
     - ClothingUniformJumpsuitFlannel
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -609,10 +541,6 @@
   items:
     - ClothingUniformJumpsuitCasualPurple
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -641,10 +569,6 @@
   items:
     - ClothingUniformJumpsuitCasualRed
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -671,10 +595,6 @@
   items:
     - ClothingUniformJumpsuitTshirtJeans
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -689,10 +609,6 @@
   items:
     - ClothingUniformJumpsuitTshirtJeansGray
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -706,10 +622,6 @@
   items:
     - ClothingUniformJumpsuitTshirtJeansPeach
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -723,10 +635,6 @@
   items:
     - ClothingUniformJumpsuitJeansGreen
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -741,10 +649,6 @@
   items:
     - ClothingUniformJumpsuitJeansRed
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -758,10 +662,6 @@
   items:
     - ClothingUniformJumpsuitJeansBrown
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -776,10 +676,6 @@
   items:
     - ClothingUniformJumpsuitLostTourist
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -795,10 +691,6 @@
   items:
     - ClothingUniformJumpsuitHawaiBlack
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -813,10 +705,6 @@
   items:
     - ClothingUniformJumpsuitHawaiBlue
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -831,10 +719,6 @@
   items:
     - ClothingUniformJumpsuitHawaiRed
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -848,10 +732,6 @@
   items:
     - ClothingUniformJumpsuitHawaiYellow
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -880,10 +760,6 @@
   items:
     - ClothingUniformJumpsuitSober
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -979,10 +855,6 @@
   items:
     - ClothingUniformJumpsuitBartender
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1370,10 +1242,6 @@
   items:
     - ClothingUniformJumpsuitSuitBlack
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1387,10 +1255,6 @@
   items:
     - ClothingUniformJumpsuitSuitBlackAlt
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1404,10 +1268,6 @@
   items:
     - ClothingUniformJumpsuitSuitBlackMob
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1421,10 +1281,6 @@
   items:
     - ClothingUniformJumpsuitSuitBrown
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1439,10 +1295,6 @@
   items:
     - ClothingUniformJumpsuitSuitBrownAlt
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1456,10 +1308,6 @@
   items:
     - ClothingUniformJumpsuitSuitBrownMob
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1473,10 +1321,6 @@
   items:
     - ClothingUniformJumpsuitSuitWhite
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1491,10 +1335,6 @@
   items:
     - ClothingUniformJumpsuitSuitWhiteAlt
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:
@@ -1508,10 +1348,6 @@
   items:
     - ClothingUniformJumpsuitSuitWhiteMob
   requirements:
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
     - !type:CharacterDepartmentRequirement
        inverted: true
        departments:


### PR DESCRIPTION
# Description

This is a shitcode system that is meant to automatically remove any clothing item from the Loadouts menu that is impossible for a species to equip as a result of having whitelists or blacklists in their inventoryTemplate. For instance, species with the Digitigrade inventory template are now allowed to wear pants. If a Harpy opens the loadouts menu, they will find that the Shoes tab is empty(Harpies don't have a shoe slot), and that the Uniform tab contains only items with the Skirt tag. 

Please for the love of god don't merge this. It runs like ass. There are several improvements to be made. @DEATHB4DEFEAT that means I am openly inviting you to come improve this PR, because this is after all your system. 

# TODO

- [ ] Polish the shitcode until it doesn't stink anymore.

# Changelog

:cl:
- fix: Loadouts will no longer display items that would be impossible for your selected species to equip.
