### PR TITLE
Revert "Refactor Ramping Event Scheduler (#592)"

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -4,10 +4,16 @@
 public sealed partial class RampingStationEventSchedulerComponent : Component
 {
     /// <summary>
-    ///     Multiplies the End Time of the Ramping Event curve. Lower this number for shorter, hectic shifts, increase this number for longer shifts.
+    ///     The maximum number by which the event rate will be multiplied when shift time reaches the end time.
     /// </summary>
     [DataField]
-    public float ShiftChaosModifier = 1f;
+    public float ChaosModifier = 3f;
+
+    /// <summary>
+    ///     The minimum number by which the event rate will be multiplied when the shift has just begun.
+    /// </summary>
+    [DataField]
+    public float StartingChaosRatio = 0.1f;
 
     /// <summary>
     ///     The number by which all event delays will be multiplied. Unlike chaos, remains constant throughout the shift.
@@ -15,39 +21,21 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     [DataField]
     public float EventDelayModifier = 1f;
 
-
     /// <summary>
-    ///     Shift Length(in Minutes) is directly reduced by this value.
+    ///     The number by which average expected shift length is multiplied. Higher values lead to slower chaos growth.
     /// </summary>
-    [DataField]
-    public float ShiftLengthOffset = 0f;
-
-    /// <summary>
-    ///     Minimum time between events is decreased by this value.
-    /// </summary>
-    [DataField]
-    public float MinimumEventTimeOffset = 0f;
-
-    /// <summary>
-    ///     Maximum time between events is decreased by this value.
-    /// </summary>
-
-    [DataField]
-    public float MaximumEventTimeOffset = 0f;
-
-    [DataField]
-    public bool IgnoreMinimumTimes = false;
+    public float ShiftLengthModifier = 1f;
 
     // Everything below is overridden in the RampingStationEventSchedulerSystem based on CVars
-    [DataField]
+    [DataField("endTime"), ViewVariables(VVAccess.ReadWrite)]
     public float EndTime;
 
-    [DataField]
+    [DataField("maxChaos"), ViewVariables(VVAccess.ReadWrite)]
     public float MaxChaos;
 
-    [DataField]
+    [DataField("startingChaos"), ViewVariables(VVAccess.ReadWrite)]
     public float StartingChaos;
 
-    [DataField]
+    [DataField("timeUntilNextEvent"), ViewVariables(VVAccess.ReadWrite)]
     public float TimeUntilNextEvent;
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -119,7 +119,7 @@ namespace Content.Shared.CCVar
         ///     Max chaos chosen for a round will deviate from this
         /// </summary>
         public static readonly CVarDef<float>
-            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 0.8f, CVar.ARCHIVE | CVar.SERVERONLY);
+            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /*
          * Game
@@ -186,29 +186,16 @@ namespace Content.Shared.CCVar
             GameEventsBasicMaximumTime = CVarDef.Create("game.events_basic_maximum_time", 1500, CVar.SERVERONLY);
 
         /// <summary>
-        ///     Minimum time between Ramping station events in minutes
+        ///     Minimum time between Ramping station events in seconds
         /// </summary>
-        public static readonly CVarDef<float> // 8 Minutes
-            GameEventsRampingMinimumTime = CVarDef.Create("game.events_ramping_minimum_time", 8f, CVar.SERVERONLY);
+        public static readonly CVarDef<int> // 4 Minutes
+            GameEventsRampingMinimumTime = CVarDef.Create("game.events_ramping_minimum_time", 240, CVar.SERVERONLY);
 
         /// <summary>
-        ///     After the shift's desired "Endpoint" is reached, the minimum time between events is RampingMinimumTime - Offset.
+        ///     Maximum time between Ramping station events in seconds
         /// </summary>
-
-        public static readonly CVarDef<float>
-            GameEventsRampingMinimumTimeOffset = CVarDef.Create("game.events_ramping_minimum_time_offset", 6f, CVar.SERVERONLY);
-
-        /// <summary>
-        ///     Maximum time between Ramping station events in minutes
-        /// </summary>
-        public static readonly CVarDef<float> // 16 Minutes
-            GameEventsRampingMaximumTime = CVarDef.Create("game.events_ramping_maximum_time", 16f, CVar.SERVERONLY);
-
-        /// <summary>
-        ///     After the shift's desired "Endpoint" is reached, the maximum time between events is RampingMaximumTime - Offset.
-        /// </summary>
-        public static readonly CVarDef<float>
-            GameEventsRampingMaximumTimeOffset = CVarDef.Create("game.events_ramping_maximum_time_offset", 10f, CVar.SERVERONLY);
+        public static readonly CVarDef<int> // 12 Minutes
+            GameEventsRampingMaximumTime = CVarDef.Create("game.events_ramping_maximum_time", 720, CVar.SERVERONLY);
 
         /// <summary>
         ///

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
@@ -3,6 +3,3 @@ survival-description = No internal threats, but how long can the station survive
 
 hellshift-title = Hellshift
 hellshift-description = The station rolled a "one" in a luck check. Can the crew make it to the end?
-
-longsurvival-title = Long Survival
-longsurvival-description = Survival, but two hours longer. Event growth is stretched over a vastly greater length of time.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -133,20 +133,14 @@
   - type: RampingStationEventScheduler
 
 - type: entity
-  id: LongSurvivalStationEventScheduler
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: RampingStationEventScheduler
-    shiftLengthOffset: -120
-
-- type: entity
   id: HellshiftStationEventScheduler
   parent: BaseGameRule
   noSpawn: true
   components:
   - type: RampingStationEventScheduler
-    shiftChaosModifier: 4 #30 minute HELL SHIFT
+    chaosModifier: 4 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
+    startingChaosRatio: 0.025 # Starts as slow as survival, but quickly ramps up
+    shiftLengthModifier: 2.5
 
 # variation passes
 - type: entity

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -21,17 +21,6 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
-  id: SurvivalLonger
-  alias:
-    - longsurvival
-  showInVote: true
-  name: longsurvival-title
-  description: longsurvival-description
-  rules:
-    - LongSurvivalStationEventScheduler
-    - BasicRoundstartVariation
-
-- type: gamePreset
   id: AllAtOnce
   name: all-at-once-title
   description: all-at-once-description


### PR DESCRIPTION
# Description
This reverts commit 910b4c3c4e83e07fe2e22687e74c940604e97eb1.

The PR was never tested properly, and after it was merged on deep station, a lot of significant issues have been uncovered, including station events appearing every 6-12 seconds regardless of the gamemode, some RampingStationEventScheduler component fields being unused, some CVars having misleading usages, some CVars being unused, and more.

The PR needs to be re-done and tested thoroughly before it can be merged.

:cl:
- fix: Reverted the station event scheduler rework due to it absolutely breaking the game.