### PR TITLE
Fix Event Manager Allowing to Start Multiple Events of the Same Type in a Short Time Window

### DIFF
--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -43,7 +43,7 @@ public sealed class EventManagerSystem : EntitySystem
             return errStr;
         }
 
-        GameTicker.StartGameRule(randomEvent, out var ent);
+        var ent = GameTicker.AddGameRule(randomEvent);
         var str = Loc.GetString("station-event-system-run-event",("eventName", ToPrettyString(ent)));
         Log.Info(str);
         return str;
@@ -162,7 +162,7 @@ public sealed class EventManagerSystem : EntitySystem
 
     private bool CanRun(EntityPrototype prototype, StationEventComponent stationEvent, int playerCount, TimeSpan currentTime)
     {
-        if (GameTicker.IsGameRuleActive(prototype.ID))
+        if (GameTicker.IsGameRuleAdded(prototype.ID))
             return false;
 
         if (stationEvent.MaxOccurrences.HasValue && GetOccurrences(prototype) >= stationEvent.MaxOccurrences.Value)

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -43,7 +43,7 @@ public sealed class EventManagerSystem : EntitySystem
             return errStr;
         }
 
-        var ent = GameTicker.AddGameRule(randomEvent);
+        GameTicker.StartGameRule(randomEvent, out var ent);
         var str = Loc.GetString("station-event-system-run-event",("eventName", ToPrettyString(ent)));
         Log.Info(str);
         return str;


### PR DESCRIPTION
# Description
Makes it so that the event scheduler doesn't pick events that were already added (but not yet ended).

In order to fix this:

<details><p>

![image](https://github.com/user-attachments/assets/fd73dbce-7cbc-489b-8990-7ae791723351)

</p></details>