### PR TITLE
Ramping Event Time Missing Parentheses

### DIFF
--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -31,10 +31,10 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
         var shiftLength = Math.Max(1, _cfg.GetCVar(CCVars.EventsRampingAverageEndTime) - component.ShiftLengthOffset);
         return 2 * endTime
             / (1
-            	+ MathF.Exp(_cfg.GetCVar(CCVars.EventsRampingAverageChaos)
+            	+ MathF.Pow(2, _cfg.GetCVar(CCVars.EventsRampingAverageChaos)
 	            * component.ShiftChaosModifier
-	            / shiftLength
-	            * endTime
+	            / (shiftLength
+	            * endTime)
 	            * (float) _gameTicker.RoundDuration().TotalSeconds
 	            / 60))
                 	+ (startTime - endTime);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -112,14 +112,14 @@ namespace Content.Shared.CCVar
         ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
         /// </summary>
         public static readonly CVarDef<float>
-            EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 40f, CVar.ARCHIVE | CVar.SERVERONLY);
+            EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 120f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /// <summary>
         ///     Average ending chaos modifier for the ramping event scheduler.
         ///     Max chaos chosen for a round will deviate from this
         /// </summary>
         public static readonly CVarDef<float>
-            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 0.8f, CVar.ARCHIVE | CVar.SERVERONLY);
+            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 0.3f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /*
          * Game
@@ -189,26 +189,26 @@ namespace Content.Shared.CCVar
         ///     Minimum time between Ramping station events in minutes
         /// </summary>
         public static readonly CVarDef<float> // 8 Minutes
-            GameEventsRampingMinimumTime = CVarDef.Create("game.events_ramping_minimum_time", 8f, CVar.SERVERONLY);
+            GameEventsRampingMinimumTime = CVarDef.Create("game.events_ramping_minimum_time", 16f, CVar.SERVERONLY);
 
         /// <summary>
         ///     After the shift's desired "Endpoint" is reached, the minimum time between events is RampingMinimumTime - Offset.
         /// </summary>
 
         public static readonly CVarDef<float>
-            GameEventsRampingMinimumTimeOffset = CVarDef.Create("game.events_ramping_minimum_time_offset", 6f, CVar.SERVERONLY);
+            GameEventsRampingMinimumTimeOffset = CVarDef.Create("game.events_ramping_minimum_time_offset", 8f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Maximum time between Ramping station events in minutes
         /// </summary>
         public static readonly CVarDef<float> // 16 Minutes
-            GameEventsRampingMaximumTime = CVarDef.Create("game.events_ramping_maximum_time", 16f, CVar.SERVERONLY);
+            GameEventsRampingMaximumTime = CVarDef.Create("game.events_ramping_maximum_time", 24f, CVar.SERVERONLY);
 
         /// <summary>
         ///     After the shift's desired "Endpoint" is reached, the maximum time between events is RampingMaximumTime - Offset.
         /// </summary>
         public static readonly CVarDef<float>
-            GameEventsRampingMaximumTimeOffset = CVarDef.Create("game.events_ramping_maximum_time_offset", 10f, CVar.SERVERONLY);
+            GameEventsRampingMaximumTimeOffset = CVarDef.Create("game.events_ramping_maximum_time_offset", 12f, CVar.SERVERONLY);
 
         /// <summary>
         ///

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -188,7 +188,7 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Minimum time between Ramping station events in minutes
         /// </summary>
-        public static readonly CVarDef<float> // 8 Minutes
+        public static readonly CVarDef<float> // 16 Minutes
             GameEventsRampingMinimumTime = CVarDef.Create("game.events_ramping_minimum_time", 16f, CVar.SERVERONLY);
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Maximum time between Ramping station events in minutes
         /// </summary>
-        public static readonly CVarDef<float> // 16 Minutes
+        public static readonly CVarDef<float> // 24 Minutes
             GameEventsRampingMaximumTime = CVarDef.Create("game.events_ramping_maximum_time", 24f, CVar.SERVERONLY);
 
         /// <summary>

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -131,6 +131,7 @@
   noSpawn: true
   components:
   - type: RampingStationEventScheduler
+    shiftChaosModifier: 0.3
 
 - type: entity
   id: LongSurvivalStationEventScheduler
@@ -139,6 +140,7 @@
   components:
   - type: RampingStationEventScheduler
     shiftLengthOffset: -120
+    shiftChaosModifier: 0.2
 
 - type: entity
   id: HellshiftStationEventScheduler
@@ -146,7 +148,8 @@
   noSpawn: true
   components:
   - type: RampingStationEventScheduler
-    shiftChaosModifier: 4 #30 minute HELL SHIFT
+    shiftChaosModifier: 0.4
+    shiftLengthOffset: 60
 
 # variation passes
 - type: entity


### PR DESCRIPTION
# Description

RampingEventTimeEquation was missing a parentheses. I also replaced the e curve with 2 to make it just a bit smoother. Haven't tested this yet.
I also added actual use of the yaml datafields to the survival variants(None of them used them).

# TODO

- [ ] Test it ingame.