### PR TITLE
Zombie Improvements Take 2

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -224,13 +224,11 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var zombers = GetEntityQuery<ZombieComponent>();
         while (players.MoveNext(out var uid, out _, out _, out var mob, out var xform))
         {
-            if (!_mobState.IsAlive(uid, mob))
-                continue;
-
-            if (zombers.HasComponent(uid))
-                continue;
-
-            if (!includeOffStation && !stationGrids.Contains(xform.GridUid ?? EntityUid.Invalid))
+            if (!_mobState.IsAlive(uid, mob)
+                || HasComp<PendingZombieComponent>(uid) //Do not include infected players in the "Healthy players" list.
+                || HasComp<ZombifyOnDeathComponent>(uid)
+                || zombers.HasComponent(uid)
+                || !includeOffStation && !stationGrids.Contains(xform.GridUid ?? EntityUid.Invalid))
                 continue;
 
             healthy.Add(uid);

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -43,6 +43,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly AnnouncerSystem _announcer = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
 
     public override void Initialize()
     {
@@ -89,7 +90,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
                     ("username", player.Value)));
             }
 
-            var healthy = GetHealthyHumans();
+            var healthy = GetHealthyHumans(true);
             // Gets a bunch of the living players and displays them if they're under a threshold.
             // InitialInfected is used for the threshold because it scales with the player count well.
             if (healthy.Count <= 0 || healthy.Count > 2 * zombie.InitialInfectedNames.Count)
@@ -185,7 +186,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     /// <param name="includeOffStation">Include healthy players that are not on the station grid</param>
     /// <param name="includeDead">Should dead zombies be included in the count</param>
     /// <returns></returns>
-    private float GetInfectedFraction(bool includeOffStation = true, bool includeDead = false)
+    private float GetInfectedFraction(bool includeOffStation = false, bool includeDead = true)
     {
         var players = GetHealthyHumans(includeOffStation);
         var zombieCount = 0;
@@ -205,14 +206,14 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     /// Flying off via a shuttle disqualifies you.
     /// </summary>
     /// <returns></returns>
-    private List<EntityUid> GetHealthyHumans(bool includeOffStation = true)
+    private List<EntityUid> GetHealthyHumans(bool includeOffStation = false)
     {
         var healthy = new List<EntityUid>();
 
         var stationGrids = new HashSet<EntityUid>();
         if (!includeOffStation)
         {
-            foreach (var station in _station.GetStationsSet())
+            foreach (var station in _gameTicker.GetSpawnableStations())
             {
                 if (TryComp<StationDataComponent>(station, out var data) && _station.GetLargestGrid(data) is { } grid)
                     stationGrids.Add(grid);


### PR DESCRIPTION
# Description

Problem: "Players like to stall zombie rounds"
Solution: Fix the Anti-Stall mechanic.

The set of functions for handling the automatic shuttle call now correctly only checks "The" station, rather than any grid containing a StationDataComponent. By using the less permissive _gameTicker.GetSpawnableStations(); function, the zombie gamerule no longer includes stations such as Centcomm, Planet Expeditions, some salvage wrecks, certain space ships, the Syndicate Listening Outpost, and Nukie World. Additionally, the check for "Healthy" humans no longer considers anyone infected with the zombie virus to be a "Healthy" human, ensuring that someone with a 200u jug of Bicaridine can no longer contribute to round stalling. Finally, dead (player)zombies are now by default checked for the purpose of calling the evac shuttle. The reason being for this assumption, is that dead zombies are still players removed from the round. If a majority of players are removed from the round(or fucked off to space), the shuttle should be called.

# Changelog

:cl:
- fix: Zombie events have had their Anti-Stalling mechanic improved. Dead (Player) Zombies, Infected Players, and Initial Infected are all counted as zombies for the purpose of determine if the shuttle should be called. Additionally, any player who leaves the station is no longer counted as a healthy crewman for the automatic shuttle call.
