### PR TITLE
Fixes Failed to Cherry-Pick PR #25986: Return Detective to Security #145

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -17,6 +17,8 @@
   - Maintenance
   - Service
   - Detective
+  - External
+  - Cryogenics
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
Partial fix to #145, as the changes in inventory will need reflected in the Security Loadout system which will be in another PR.

Made so Detective has the same access as Security Officers.