### PR TITLE
Butlergone (Cherry-Pick From Delta-V)

### DIFF
--- a/Content.Server/DeltaV/NPC/Roboisseur/RoboisseurSystem.cs
+++ b/Content.Server/DeltaV/NPC/Roboisseur/RoboisseurSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Roboisseur.Roboisseur
                     }
                     else if (CheckTier(roboisseur.DesiredPrototype.ID, roboisseur) > 2)
                         message = Loc.GetString(_random.Pick(roboisseur.DemandMessagesTier2), ("item", roboisseur.DesiredPrototype.Name));
-                    _chat.TrySendInGameICMessage(roboisseur.Owner, message, InGameICChatType.Speak, false);
+                    _chat.TrySendInGameICMessage(roboisseur.Owner, message, InGameICChatType.Speak, true);
                 }
 
                 if (roboisseur.Accumulator >= roboisseur.ResetTime.TotalSeconds)
@@ -100,7 +100,7 @@ namespace Content.Server.Roboisseur.Roboisseur
             if (CheckTier(component.DesiredPrototype.ID, component) > 1)
                 message = Loc.GetString(_random.Pick(component.DemandMessagesTier2), ("item", component.DesiredPrototype.Name));
 
-            _chat.TrySendInGameICMessage(component.Owner, message, InGameICChatType.Speak, false);
+            _chat.TrySendInGameICMessage(component.Owner, message, InGameICChatType.Speak, true);
         }
 
         private void OnInteractUsing(EntityUid uid, RoboisseurComponent component, InteractUsingEvent args)

--- a/Resources/Prototypes/DeltaV/NPC/roboisseur.yml
+++ b/Resources/Prototypes/DeltaV/NPC/roboisseur.yml
@@ -4,12 +4,22 @@
   name: Mr. Butlertron
   description: It asks for food to deliver to exotic customers across the cosmos. Powered by the latest technology in bluespace food delivery.
   components:
+  - type: Anchorable
+  - type: Pullable
   - type: Sprite
     noRot: true
     drawdepth: Mobs
     sprite: DeltaV/Structures/Machines/roboisseur.rsi
     layers:
     - state: roboisseur-1
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: Roboisseur
   - type: Speech
     speechSounds: Pai


### PR DESCRIPTION
# Description
Cherry-picks https://github.com/DeltaV-Station/Delta-v/pull/1100 and https://github.com/DeltaV-Station/Delta-v/pull/1222.

Makes butlertron anchorable, pullable, and destructible, and disables logging of butlertron's messages.

Credit to adeinitas and NullWanderer.

# Note
This was cherry-picked without testing, someone needs to test it first.

# Changelog
:cl:
- add: Mr. Butlertron can now suffer for its crimes.
