### PR TITLE
Stamina Damage Resistance Real

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
@@ -14,7 +14,7 @@ public sealed partial class BoxingSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BoxerComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<BoxerComponent, MeleeHitEvent>(OnMeleeHit);
-        SubscribeLocalEvent<BoxingGlovesComponent, StaminaMeleeHitEvent>(OnStamHit);
+        SubscribeLocalEvent<BoxingGlovesComponent, TakeStaminaDamageEvent>(OnStamHit);
     }
 
     private void OnInit(EntityUid uid, BoxerComponent component, ComponentInit args)
@@ -27,7 +27,7 @@ public sealed partial class BoxingSystem : EntitySystem
         args.ModifiersList.Add(component.UnarmedModifiers);
     }
 
-    private void OnStamHit(EntityUid uid, BoxingGlovesComponent component, StaminaMeleeHitEvent args)
+    private void OnStamHit(EntityUid uid, BoxingGlovesComponent component, TakeStaminaDamageEvent args)
     {
         if (!_containerSystem.TryGetContainingContainer(uid, out var equipee))
             return;

--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Abilities.Oni
             SubscribeLocalEvent<OniComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
             SubscribeLocalEvent<OniComponent, MeleeHitEvent>(OnOniMeleeHit);
             SubscribeLocalEvent<HeldByOniComponent, MeleeHitEvent>(OnHeldMeleeHit);
-            SubscribeLocalEvent<HeldByOniComponent, StaminaMeleeHitEvent>(OnStamHit);
+            SubscribeLocalEvent<HeldByOniComponent, TakeStaminaDamageEvent>(OnStamHit);
         }
 
         private void OnEntInserted(EntityUid uid, OniComponent component, EntInsertedIntoContainerMessage args)
@@ -68,7 +68,7 @@ namespace Content.Server.Abilities.Oni
             args.ModifiersList.Add(oni.MeleeModifiers);
         }
 
-        private void OnStamHit(EntityUid uid, HeldByOniComponent component, StaminaMeleeHitEvent args)
+        private void OnStamHit(EntityUid uid, HeldByOniComponent component, TakeStaminaDamageEvent args)
         {
             if (!TryComp<OniComponent>(component.Holder, out var oni))
                 return;

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -113,11 +113,9 @@ namespace Content.Server.Psionics
         private void OnStamHit(EntityUid uid, AntiPsionicWeaponComponent component, TakeStaminaDamageEvent args)
         {
             var bonus = false;
-            foreach (var stam in args.HitList)
-            {
-                if (HasComp<PsionicComponent>(stam.Entity))
-                    bonus = true;
-            }
+
+            if (HasComp<PsionicComponent>(args.Target))
+                bonus = true;
 
             if (!bonus)
                 return;

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Psionics
             base.Initialize();
             SubscribeLocalEvent<PotentialPsionicComponent, MapInitEvent>(OnStartup);
             SubscribeLocalEvent<AntiPsionicWeaponComponent, MeleeHitEvent>(OnMeleeHit);
-            SubscribeLocalEvent<AntiPsionicWeaponComponent, StaminaMeleeHitEvent>(OnStamHit);
+            SubscribeLocalEvent<AntiPsionicWeaponComponent, TakeStaminaDamageEvent>(OnStamHit);
 
             SubscribeLocalEvent<PsionicComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<PsionicComponent, ComponentRemove>(OnRemove);
@@ -110,7 +110,7 @@ namespace Content.Server.Psionics
             _npcFactonSystem.RemoveFaction(uid, "PsionicInterloper");
         }
 
-        private void OnStamHit(EntityUid uid, AntiPsionicWeaponComponent component, StaminaMeleeHitEvent args)
+        private void OnStamHit(EntityUid uid, AntiPsionicWeaponComponent component, TakeStaminaDamageEvent args)
         {
             var bonus = false;
             foreach (var stam in args.HitList)

--- a/Content.Shared/Damage/Events/TakeStaminaDamageEvent.cs
+++ b/Content.Shared/Damage/Events/TakeStaminaDamageEvent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Damage.Events;
 /// </summary>
 public sealed class TakeStaminaDamageEvent : HandledEntityEventArgs, IInventoryRelayEvent
 {
-    public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
+    public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
 
     /// <summary>
     /// List of hit stamina components.

--- a/Content.Shared/Damage/Events/TakeStaminaDamageEvent.cs
+++ b/Content.Shared/Damage/Events/TakeStaminaDamageEvent.cs
@@ -1,5 +1,5 @@
 using Content.Shared.Damage.Components;
-using Robust.Shared.Collections;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Damage.Events;
 
@@ -7,12 +7,14 @@ namespace Content.Shared.Damage.Events;
 /// The components in the list are going to be hit,
 /// give opportunities to change the damage or other stuff.
 /// </summary>
-public sealed class StaminaMeleeHitEvent : HandledEntityEventArgs
+public sealed class TakeStaminaDamageEvent : HandledEntityEventArgs, IInventoryRelayEvent
 {
+    public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
+
     /// <summary>
     /// List of hit stamina components.
     /// </summary>
-    public List<(EntityUid Entity, StaminaComponent Component)> HitList;
+    public EntityUid Target;
 
     /// <summary>
     /// The multiplier. Generally, try to use *= or /= instead of overwriting.
@@ -24,8 +26,8 @@ public sealed class StaminaMeleeHitEvent : HandledEntityEventArgs
     /// </summary>
     public float FlatModifier = 0;
 
-    public StaminaMeleeHitEvent(List<(EntityUid Entity, StaminaComponent Component)> hitList)
+    public TakeStaminaDamageEvent(EntityUid target)
     {
-        HitList = hitList;
+        Target = target;
     }
 }

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class StaminaSystem : EntitySystem
 
         foreach (var (ent, comp) in toHit)
         {
-            var hitEvent = new TakeStaminaDamageEvent((ent, comp));
+            var hitEvent = new TakeStaminaDamageEvent(ent);
             RaiseLocalEvent(uid, hitEvent);
 
             if (hitEvent.Handled)
@@ -212,7 +212,7 @@ public sealed partial class StaminaSystem : EntitySystem
         if (ev.Cancelled)
             return;
 
-        var hitEvent = new TakeStaminaDamageEvent((target, stamComp));
+        var hitEvent = new TakeStaminaDamageEvent(target);
         RaiseLocalEvent(target, hitEvent);
 
         if (hitEvent.Handled)

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -212,7 +212,6 @@ public sealed partial class StaminaSystem : EntitySystem
         if (ev.Cancelled)
             return;
 
-        // goobstation
         var hitEvent = new TakeStaminaDamageEvent((target, stamComp));
         RaiseLocalEvent(target, hitEvent);
 

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Chemistry;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Events;
 using Content.Shared.Electrocution;
 using Content.Shared.Explosion;
 using Content.Shared.Eye.Blinding.Systems;
@@ -20,6 +21,7 @@ public partial class InventorySystem
     public void InitializeRelay()
     {
         SubscribeLocalEvent<InventoryComponent, DamageModifyEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, TakeStaminaDamageEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, ElectrocutionAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SlipAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshMovementSpeedModifiersEvent>(RelayInventoryEvent);

--- a/Content.Shared/Stunnable/StaminaDamageResistanceComponent.cs
+++ b/Content.Shared/Stunnable/StaminaDamageResistanceComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Stunnable;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StaminaDamageResistanceComponent : Component
+{
+    /// <summary>
+    ///     1 - no reduction, 0 - full reduction
+    /// </summary>
+    [DataField] public float Coefficient = 1;
+}

--- a/Content.Shared/Stunnable/StaminaDamageResistanceSystem.cs
+++ b/Content.Shared/Stunnable/StaminaDamageResistanceSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Damage.Events;
+using Content.Shared.Examine;
+using Content.Shared.Inventory;
+
+namespace Content.Shared.Stunnable;
+
+public sealed partial class StaminaDamageResistanceSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StaminaDamageResistanceComponent, InventoryRelayedEvent<TakeStaminaDamageEvent>>(OnStaminaMeleeHit);
+        SubscribeLocalEvent<StaminaDamageResistanceComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private void OnStaminaMeleeHit(Entity<StaminaDamageResistanceComponent> ent, ref InventoryRelayedEvent<TakeStaminaDamageEvent> args)
+    {
+        args.Args.Multiplier *= ent.Comp.Coefficient;
+    }
+    private void OnExamine(Entity<StaminaDamageResistanceComponent> ent, ref ExaminedEvent args)
+    {
+        var percentage = (1 - ent.Comp.Coefficient) * 100;
+        args.PushMarkup(Loc.GetString("armor-examine-stamina", ("num", percentage)));
+    }
+}

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -17,3 +17,4 @@ armor-damage-type-cold = Cold
 armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
+armor-examine-stamina = Reduces your stamina damage by [color=cyan]{$num}%[/color].

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -141,6 +141,8 @@
   - type: Clothing
     equipDelay: 2.5 # Hardsuits are heavy and take a while to put on/off.
     unequipDelay: 2.5
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -100,6 +100,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 #Spationaut Hardsuit
 - type: entity
@@ -221,6 +223,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 #Brigmedic Hardsuit
 - type: entity
@@ -248,6 +252,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 #Warden's Hardsuit
 - type: entity
@@ -278,6 +284,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
+  - type: StaminaDamageResistance
+    coefficient: 0.65 # 35%
 
 #Captain's Hardsuit
 - type: entity
@@ -310,6 +318,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Chief Engineer's Hardsuit
 - type: entity
@@ -345,6 +355,8 @@
   - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
+  - type: StaminaDamageResistance
+    coefficient: 0.65 # 35%
 
 #Chief Medical Officer's Hardsuit
 - type: entity
@@ -412,6 +424,8 @@
     price: 750
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitRd
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25% as in "shock resistance" :trollface:
 
 #Head of Security's Hardsuit
 - type: entity
@@ -443,6 +457,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Luxury Mining Hardsuit
 - type: entity
@@ -520,6 +536,8 @@
     - Hardsuit
     - WhitelistChameleon
     - HidesHarpyWings
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 # Syndicate Medic Hardsuit
 - type: entity
@@ -539,6 +557,8 @@
     - Hardsuit
     - WhitelistChameleon
     - HidesHarpyWings
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -575,6 +595,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -607,6 +629,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -639,6 +663,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Wizard Hardsuit
 - type: entity
@@ -671,6 +697,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Ling Space Suit
 - type: entity
@@ -766,6 +794,8 @@
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
   - type: StaticPrice
     price: 0
+  - type: StaminaDamageResistance
+    coefficient: 0.75 # 25%
 
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
@@ -781,6 +811,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -795,6 +827,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTChaplain
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #ERT Engineer Hardsuit
 - type: entity
@@ -809,6 +843,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTEngineer
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #ERT Medic Hardsuit
 - type: entity
@@ -823,6 +859,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTMedical
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #ERT Security Hardsuit
 - type: entity
@@ -841,6 +879,8 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #ERT Janitor Hardsuit
 - type: entity
@@ -855,6 +895,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertjanitor.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTJanitor
+  - type: StaminaDamageResistance
+    coefficient: 0.5 # 50%
 
 #Deathsquad
 - type: entity
@@ -889,6 +931,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
+  - type: StaminaDamageResistance
+    coefficient: 0.1 # 90%
 
 #CBURN Hardsuit
 - type: entity


### PR DESCRIPTION
# Description
Added stamina damage resistance, acts the same way as armor does.
Call this shock resistance if you wish :trollface:
Just attach StaminaDamageResistance component to an entity with a set multiplier and have fun.

Made all hardsuits 25% stun resistant by default.
With some variety, e.g. nukie, ERT, captain, HoS suits are 50%, DS are 90%, etc. etc.

This will not remove stuneta but it will make it more difficult to stamcrit a traitor or such.

Some armor/batong ratios that you need to hit before the target is stamcritted:
0% - 3 batong hits
25% - 4 batong hits
50% - 6 batong hits
75% - 12 batong hits
90% - 28 batong hits :trollface:
100% - 
![image](https://github.com/user-attachments/assets/da147676-520b-4e3c-b027-ef9dc6a7394b)


# Changelog

:cl:
- add: Added different stamina damage resistance to hardsuits.