### PR TITLE
Remove Overlay Restrict From Vulps

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -62,9 +62,6 @@
       points: 1
       required: true
       defaultMarkings: [ VulpEar ]
-    Overlay:
-      points: 2
-      required: false
 
 - type: humanoidBaseSprite
   id: MobVulpkaninHead


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
As title, will allow players to put as many overlay markings as required for their vulps.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: TJohnson
- tweak: Removed overlay restriction for vulps, you can now have as many overlay markings as you want!
