### PR TITLE
New Trait: Blood Deficiency

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Traits.Assorted;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
@@ -11,7 +12,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Body.Components
 {
-    [RegisterComponent, Access(typeof(BloodstreamSystem), typeof(ReactionMixerSystem))]
+    [RegisterComponent, Access(typeof(BloodstreamSystem), typeof(ReactionMixerSystem), typeof(BloodDeficiencySystem))]
     public sealed partial class BloodstreamComponent : Component
     {
         public static string DefaultChemicalsSolutionName = "chemicals";
@@ -171,5 +172,17 @@ namespace Content.Server.Body.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public TimeSpan StatusTime;
+
+        /// <summary>
+        ///     If this is true, the entity will not passively regenerate blood,
+        ///     and instead will slowly lose blood.
+        /// </summary>
+        public bool HasBloodDeficiency = false;
+
+        /// <summary>
+        ///     How much reagent of blood should be removed with blood deficiency in each update interval?
+        /// </summary>
+        [DataField]
+        public FixedPoint2 BloodDeficiencyLossAmount;
     }
 }

--- a/Content.Server/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Server/Traits/BloodDeficiencyComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server.Traits.Assorted;
+
+/// <summary>
+///     This is used for the Blood Deficiency trait.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BloodDeficiencyComponent : Component
+{
+    // <summary>
+    //     How much reagent of blood should be removed in each update interval?
+    // </summary>
+    [DataField(required: true)]
+    public float BloodLossAmount;
+}

--- a/Content.Server/Traits/BloodDeficiencySystem.cs
+++ b/Content.Server/Traits/BloodDeficiencySystem.cs
@@ -1,0 +1,23 @@
+using Content.Server.Body.Systems;
+using Content.Server.Body.Components;
+using Content.Shared.Damage;
+
+namespace Content.Server.Traits.Assorted;
+
+public sealed class BloodDeficiencySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BloodDeficiencyComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, BloodDeficiencyComponent component, ComponentStartup args)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
+            return;
+
+        bloodstream.HasBloodDeficiency = true;
+        bloodstream.BloodDeficiencyLossAmount = component.BloodLossAmount;
+    }
+}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -23,6 +23,11 @@ trait-description-HeavyweightDrunk = Alcohol is afraid of you.
 trait-name-Muted = Muted
 trait-description-Muted = You can't speak
 
+trait-name-BloodDeficiency = Blood Deficiency
+trait-description-BloodDeficiency =
+    Your body loses more blood than it can replenish.
+    You lose blood over time, and when left untreated you will eventually die from blood loss.
+
 trait-name-Paracusia = Paracusia
 trait-description-Paracusia = You hear sounds that aren't really there
 

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -94,3 +94,17 @@
         - MedicalBorg
   components:
     - type: Snoring
+
+- type: trait
+  id: BloodDeficiency
+  category: Physical
+  points: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+  components:
+    - type: BloodDeficiency  # 0.07 = start taking bloodloss damage at around ~21.4 minutes,
+      bloodLossAmount: 0.07  # then become crit ~10 minutes later


### PR DESCRIPTION
# Description

**Blood Deficiency** is a +2 points negative Physical trait that makes you slowly lose blood over time. When left untreated you will die from blood loss. Inspired by the SS13 trait of the same name.

Slash/Piercing weapons and bleeding are much more lethal against you.

The moment you start taking **any** blood loss damage, you start dying because you can't regenerate blood. Even just two consecutive kitchen knife stabs will make you bleed enough to die slowly unless you immediately apply gauze.

Blood packs, iron pills (or copper for Arachnids), and gauze to stop bleeding will help you survive with this trait.

Here's how the timeline looks for untreated blood deficiency:
- ~0-21 minutes: losing blood slowly
- ~21-31 minutes: blood level below 90%, start taking bloodloss damage
- ~31-33 minutes: critical
- ~34 minutes: death

## Media

<details><summary>Expand</summary>

**Trait entry**

![image](https://github.com/user-attachments/assets/ea4a0c3c-7c05-45fc-8a32-48957701a246)

![image](https://github.com/user-attachments/assets/37398779-90a4-4f4f-a183-38d806184394)

As shown above, even just reducing the blood volume to less than 90% means you will die a slow and painful death.

</details>

</p>
</details>

# Changelog

:cl: Skubman
- add: Add the Blood Deficiency trait, a new negative trait that makes you slowly lose blood over time. You must routinely receive blood loss treatment to live, and even normally non-lethal bleeding can make you start dying slowly.