### PR TITLE
Fix No Blood Regeneration

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -177,6 +177,7 @@ namespace Content.Server.Body.Components
         ///     If this is true, the entity will not passively regenerate blood,
         ///     and instead will slowly lose blood.
         /// </summary>
+        [DataField]
         public bool HasBloodDeficiency = false;
 
         /// <summary>

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -120,12 +120,15 @@ public sealed class BloodstreamSystem : EntitySystem
 
             // Removes blood for Blood Deficiency constantly.
             if (bloodstream.HasBloodDeficiency)
+            {
                 if (!_mobStateSystem.IsDead(uid))
                     RemoveBlood(uid, bloodstream.BloodDeficiencyLossAmount, bloodstream);
+            }
             // Adds blood to their blood level if it is below the maximum.
-            else if (bloodSolution.Volume < bloodSolution.MaxVolume)
-                if (!_mobStateSystem.IsDead(uid))
-                    TryModifyBloodLevel(uid, bloodstream.BloodRefreshAmount, bloodstream);
+            else if (bloodSolution.Volume < bloodSolution.MaxVolume && !_mobStateSystem.IsDead(uid))
+            {
+                TryModifyBloodLevel(uid, bloodstream.BloodRefreshAmount, bloodstream);
+            }
 
             // Removes blood from the bloodstream based on bleed amount (bleed rate)
             // as well as stop their bleeding to a certain extent.


### PR DESCRIPTION
# Description

Being a little too clever with omitting braces in complicated if statement chains in #686 caused blood regeneration for entities without Blood Deficiency to stop working altogether. I added some braces and now blood regeneration works again.

I also added `DataField` to `HasBloodDeficiency` because I forgot to add that.

# Changelog

:cl: Skubman
- fix: Passive blood regeneration now works again.
