### PR TITLE
New Trait: Hemophilia

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Body.Components
 {
-    [RegisterComponent, Access(typeof(BloodstreamSystem), typeof(ReactionMixerSystem), typeof(BloodDeficiencySystem))]
+    [RegisterComponent, Access(typeof(BloodstreamSystem), typeof(ReactionMixerSystem), typeof(BloodDeficiencySystem), typeof(HemophiliaSystem))]
     public sealed partial class BloodstreamComponent : Component
     {
         public static string DefaultChemicalsSolutionName = "chemicals";

--- a/Content.Server/Traits/HemophiliaComponent.cs
+++ b/Content.Server/Traits/HemophiliaComponent.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Damage;
+namespace Content.Server.Traits.Assorted;
+
+/// <summary>
+///   This is used for the Hemophilia trait.
+/// </summary>
+[RegisterComponent]
+public sealed partial class HemophiliaComponent : Component
+{
+    // <summary>
+    //   What the BleedReductionAmount should be multiplied by.
+    // </summary>
+    [DataField(required: true)]
+    public float BleedReductionModifier = 1f;
+
+    /// <summary>
+    ///   The damage increase from this trait.
+    /// </summary>
+    [DataField(required: true)]
+    public DamageModifierSet DamageModifiers = default!;
+}

--- a/Content.Server/Traits/HemophiliaSystem.cs
+++ b/Content.Server/Traits/HemophiliaSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.Body.Systems;
+using Content.Server.Body.Components;
+using Content.Shared.Damage;
+
+namespace Content.Server.Traits.Assorted;
+
+public sealed class HemophiliaSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<HemophiliaComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<HemophiliaComponent, DamageModifyEvent>(OnDamageModify);
+    }
+
+    private void OnStartup(EntityUid uid, HemophiliaComponent component, ComponentStartup args)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
+            return;
+
+        bloodstream.BleedReductionAmount *= component.BleedReductionModifier;
+    }
+
+    private void OnDamageModify(EntityUid uid, HemophiliaComponent component, DamageModifyEvent args)
+    {
+        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, component.DamageModifiers);
+    }
+}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -28,6 +28,11 @@ trait-description-BloodDeficiency =
     Your body loses more blood than it can replenish.
     You lose blood over time, and when left untreated you will eventually die from blood loss.
 
+trait-name-Hemophilia = Hemophilia
+trait-description-Hemophilia =
+    Your body's ability to form blood clots is impaired.
+    You bleed twice as long, and you have easy bruising, taking 10% more Blunt damage.
+
 trait-name-Paracusia = Paracusia
 trait-description-Paracusia = You hear sounds that aren't really there
 

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -108,3 +108,20 @@
   components:
     - type: BloodDeficiency  # 0.07 = start taking bloodloss damage at around ~21.4 minutes,
       bloodLossAmount: 0.07  # then become crit ~10 minutes later
+
+- type: trait
+  id: Hemophilia
+  category: Physical
+  points: 1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+  components:
+    - type: Hemophilia
+      bleedReductionModifier: 0.5
+      damageModifiers:
+        coefficients:
+          Blunt: 1.1


### PR DESCRIPTION
# Description

**Hemophilia** is a +1 point negative Physical trait that makes you more susceptible to bleeding. You bleed twice as long, and you take 10% more Blunt damage.

## Media

<details><summary>Expand</summary>

![image](https://github.com/user-attachments/assets/ceb0e91e-73c8-4986-a566-40fb9cd0d32b)

</details>

---

# Changelog

:cl: Skubman
- add: Add the Hemophilia trait, a new negative trait for 1 point that makes you bleed twice as long and makes you take 10% more Blunt damage.
