### PR TITLE
New Trait: Sluggish / Snail-Paced

### DIFF
--- a/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
+++ b/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server.Traits.Assorted;
+
+/// <summary>
+///  This component is used for traits that modify movement speed.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TraitSpeedModifierComponent : Component
+{
+    [DataField("walkModifier", required: true)]
+    public float WalkModifier = 1.0f;
+
+    [DataField("sprintModifier", required: true)]
+    public float SprintModifier = 1.0f;
+}

--- a/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
+++ b/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Traits.Assorted;
 [RegisterComponent]
 public sealed partial class TraitSpeedModifierComponent : Component
 {
-    [DataField("walkModifier", required: true)]
+    [DataField(required: true)]
     public float WalkModifier = 1.0f;
 
     [DataField("sprintModifier", required: true)]

--- a/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
+++ b/Content.Server/Traits/Assorted/TraitSpeedModifierComponent.cs
@@ -9,6 +9,6 @@ public sealed partial class TraitSpeedModifierComponent : Component
     [DataField(required: true)]
     public float WalkModifier = 1.0f;
 
-    [DataField("sprintModifier", required: true)]
+    [DataField(required: true)]
     public float SprintModifier = 1.0f;
 }

--- a/Content.Server/Traits/Assorted/TraitSpeedModifierSystem.cs
+++ b/Content.Server/Traits/Assorted/TraitSpeedModifierSystem.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Movement.Systems;
+using Content.Server.Traits.Assorted;
+
+namespace Content.Shared.Traits.Assorted;
+
+public sealed class TraitSpeedModifierSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TraitSpeedModifierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeed);
+    }
+
+    private void OnRefreshMovementSpeed(EntityUid uid, TraitSpeedModifierComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+    }
+}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -94,6 +94,11 @@ trait-description-Sluggish =
     You navigate the world slower than others, perhaps due to a medical condition, inactivity, or age.
     You move slower, and it takes longer for you to climb, lie down and get up.
 
+trait-name-SnailPaced = Snail-Paced
+trait-description-SnailPaced =
+    You walk at a snail's pace, perhaps due to a medical condition, mobility impairment, or age.
+    You move substantially slower, and it takes far more longer for you to climb, lie down and get up.
+
 trait-name-LightStep = Light Step
 trait-description-LightStep =
     You move with a gentle step, making your footsteps quieter.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -89,6 +89,11 @@ trait-description-ParkourTraining =
     Whether as a hobby, lifestyle, or professional training, you are trained in the discipline of parkour.
     You're faster with climbing, crawling, lying down, and getting up.
 
+trait-name-Sluggish = Sluggish
+trait-description-Sluggish =
+    You navigate the world slower than others, perhaps due to a medical condition, inactivity, or age.
+    You move slower, and it takes longer for you to climb, lie down and get up.
+
 trait-name-LightStep = Light Step
 trait-description-LightStep =
     You move with a gentle step, making your footsteps quieter.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -97,7 +97,7 @@ trait-description-Sluggish =
 trait-name-SnailPaced = Snail-Paced
 trait-description-SnailPaced =
     You walk at a snail's pace, perhaps due to a medical condition, mobility impairment, or age.
-    You move substantially slower, and it takes far more longer for you to climb, lie down and get up.
+    You move substantially slower, and it takes far longer for you to climb, lie down and get up.
 
 trait-name-LightStep = Light Step
 trait-description-LightStep =

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -96,6 +96,44 @@
     - type: Snoring
 
 - type: trait
+  id: Sluggish
+  category: Physical
+  points: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - ParkourTraining
+        - SnailPaced
+  components:
+    - type: TraitSpeedModifier
+      sprintModifier: 0.85
+      walkModifier: 0.85
+    - type: ClimbDelayModifier
+      climbDelayMultiplier: 1.35
+    - type: LayingDownModifier
+      layingDownCooldownMultiplier: 1.2
+
+- type: trait
+  id: SnailPaced
+  category: Physical
+  points: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - ParkourTraining
+        - Sluggish
+  components:
+    - type: TraitSpeedModifier
+      sprintModifier: 0.7
+      walkModifier: 0.7
+    - type: ClimbDelayModifier
+      climbDelayMultiplier: 1.66
+    - type: LayingDownModifier
+      layingDownCooldownMultiplier: 1.6
+
+- type: trait
   id: BloodDeficiency
   category: Physical
   points: 2

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -1,4 +1,4 @@
-- type: trait
+﻿- type: trait
   id: LightweightDrunk
   category: Physical
   requirements:
@@ -57,41 +57,3 @@
   components:
     - type: ForeignerTrait
       baseTranslator: TranslatorForeigner
-
-- type: trait
-  id: Sluggish
-  category: Physical
-  points: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - ParkourTraining
-        - SnailPaced
-  components:
-    - type: TraitSpeedModifier
-      sprintModifier: 0.85
-      walkModifier: 0.85
-    - type: ClimbDelayModifier
-      climbDelayMultiplier: 1.35
-    - type: LayingDownModifier
-      layingDownCooldownMultiplier: 1.2
-
-- type: trait
-  id: SnailPaced
-  category: Physical
-  points: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - ParkourTraining
-        - Sluggish
-  components:
-    - type: TraitSpeedModifier
-      sprintModifier: 0.7
-      walkModifier: 0.7
-    - type: ClimbDelayModifier
-      climbDelayMultiplier: 1.66
-    - type: LayingDownModifier
-      layingDownCooldownMultiplier: 1.6

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -1,4 +1,4 @@
-﻿- type: trait
+- type: trait
   id: LightweightDrunk
   category: Physical
   requirements:
@@ -57,3 +57,21 @@
   components:
     - type: ForeignerTrait
       baseTranslator: TranslatorForeigner
+
+- type: trait
+  id: Sluggish
+  category: Physical
+  points: 1
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - ParkourTraining
+  components:
+    - type: TraitSpeedModifier
+      sprintModifier: 0.85
+      walkModifier: 0.85
+    - type: ClimbDelayModifier
+      climbDelayMultiplier: 1.35
+    - type: LayingDownModifier
+      layingDownCooldownMultiplier: 1.2

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -67,6 +67,7 @@
       inverted: true
       traits:
         - ParkourTraining
+        - SnailPaced
   components:
     - type: TraitSpeedModifier
       sprintModifier: 0.85
@@ -75,3 +76,22 @@
       climbDelayMultiplier: 1.35
     - type: LayingDownModifier
       layingDownCooldownMultiplier: 1.2
+
+- type: trait
+  id: SnailPaced
+  category: Physical
+  points: 2
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - ParkourTraining
+        - Sluggish
+  components:
+    - type: TraitSpeedModifier
+      sprintModifier: 0.7
+      walkModifier: 0.7
+    - type: ClimbDelayModifier
+      climbDelayMultiplier: 1.66
+    - type: LayingDownModifier
+      layingDownCooldownMultiplier: 1.6

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -96,6 +96,7 @@
       inverted: true
       traits:
         - Sluggish
+        - SnailPaced
   components:
     - type: ClimbDelayModifier
       climbDelayMultiplier: 0.70

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -91,6 +91,11 @@
   id: ParkourTraining
   category: Physical
   points: -3
+  requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Sluggish
   components:
     - type: ClimbDelayModifier
       climbDelayMultiplier: 0.70


### PR DESCRIPTION
# Description

This PR adds two new negative traits that decrease your movement speed: **Sluggish** and **Snail-Paced**.

- Sluggish (+1 points)
  - 15% slower movement speed
  - 35% slower climbing speed (for standard tables, from 1.5s to ~2.02 seconds)
  - Cooldown on laying down/standing up increased from 2.5 seconds to 3 seconds
- Snail-Paced (+2 points)
  - 30% slower movement speed
  - 66% slower climbing speed (for standard tables, from 1.5s to ~2.48 seconds)
  - Cooldown on laying down/standing up increased from 2.5 seconds to 4 seconds

## Media

<details><summary>Expand</summary>

**Trait entry**

![image](https://github.com/user-attachments/assets/cb483536-ec3e-4c28-a4b4-c431bb1b669e)

![image](https://github.com/user-attachments/assets/a251844e-7058-4d4b-b21d-a5637c39489f)

</details>

# Changelog

:cl: Skubman
- add: Add two new negative traits: Sluggish (+1) and Snail-Paced (+2) that make you move slower, and climb tables slower.