### PR TITLE
Melee Pt2

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.Gameplay;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
@@ -226,7 +227,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
         // Server will validate it with InRangeUnobstructed.
         var entities = GetNetEntityList(ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user).ToList());
-        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, component.MaxTargets, entities.Count)), GetNetCoordinates(coordinates)));
+        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(component.MaxTargets, entities.Count)), GetNetCoordinates(coordinates)));
     }
 
     private void OnMeleeLunge(MeleeLungeEvent ev)

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.Gameplay;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
@@ -16,8 +17,6 @@ using Robust.Client.State;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Client.Weapons.Melee;
 
@@ -228,7 +227,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
         // Server will validate it with InRangeUnobstructed.
         var entities = GetNetEntityList(ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user).ToList());
-        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(MaxTargets, entities.Count)), GetNetCoordinates(coordinates)));
+        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(_config.GetCVar(CCVars.MaxMeleeTargets), entities.Count)), GetNetCoordinates(coordinates)));
     }
 
     private void OnMeleeLunge(MeleeLungeEvent ev)

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Client.Gameplay;
-using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
@@ -227,7 +226,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
         // Server will validate it with InRangeUnobstructed.
         var entities = GetNetEntityList(ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user).ToList());
-        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, Math.Min(_config.GetCVar(CCVars.MaxMeleeTargets), entities.Count)), GetNetCoordinates(coordinates)));
+        RaisePredictiveEvent(new HeavyAttackEvent(GetNetEntity(meleeUid), entities.GetRange(0, component.MaxTargets, entities.Count)), GetNetCoordinates(coordinates)));
     }
 
     private void OnMeleeLunge(MeleeLungeEvent ev)

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -251,7 +251,7 @@ public sealed class ExecutionSystem : EntitySystem
             return;
 
         _damageableSystem.TryChangeDamage(victim, melee.Damage * DamageModifier, true);
-        _audioSystem.PlayEntity(melee.HitSound, Filter.Pvs(weapon), weapon, true, AudioParams.Default);
+        _audioSystem.PlayEntity(melee.SoundHit, Filter.Pvs(weapon), weapon, true, AudioParams.Default);
 
         if (attacker == victim)
         {

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -57,6 +57,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             return;
 
         _damageExamine.AddDamageExamine(args.Message, damageSpec, Loc.GetString("damage-melee"));
+        _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
     }
 
     protected override bool ArcRaySuccessful(EntityUid targetUid, Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId,

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -57,7 +57,9 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             return;
 
         _damageExamine.AddDamageExamine(args.Message, damageSpec, Loc.GetString("damage-melee"));
-        _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
+
+        if (damageSpec * component.HeavyDamageBaseModifier != damageSpec)
+            _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
     }
 
     protected override bool ArcRaySuccessful(EntityUid targetUid, Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId,

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -132,7 +132,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (attemptEvent.Cancelled)
             return false;
 
-        var chance = CalculateDisarmChance(user, target, inTargetHand, combatMode) * _contests.MassContest(user, target);
+        var chance = CalculateDisarmChance(user, target, inTargetHand, combatMode);
 
         if (_random.Prob(chance))
         {
@@ -212,7 +212,11 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             chance += malus.Malus;
         }
 
-        return Math.Clamp(chance, 0f, 1f);
+        return Math.Clamp(chance
+                        * _contests.MassContest(disarmer, disarmed, false, 0.5f)
+                        * _contests.StaminaContest(disarmer, disarmed, false, 0.5f)
+                        * _contests.HealthContest(disarmer, disarmed, false, 0.5f),
+                        0f, 1f);
     }
 
     public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -143,7 +143,7 @@ namespace Content.Server.Zombies
             melee.AltDisarm = false;
             melee.Range = 1.2f;
             melee.Angle = 0.0f;
-            melee.HitSound = zombiecomp.BiteSound;
+            melee.SoundHit = zombiecomp.BiteSound;
 
             if (mobState.CurrentState == MobState.Alive)
             {

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2347,5 +2347,15 @@ namespace Content.Shared.CCVar
             CVarDef.Create("contests.max_percentage", 0.25f, CVar.REPLICATED | CVar.SERVER);
 
         #endregion
+
+        #region Melee System
+
+        /// <summary>
+        ///     The maximum number of entities that can be targeted by a power attack(right click) in melee.
+        /// </summary>
+        public static readonly CVarDef<int> MaxMeleeTargets =
+            CVarDef.Create("melee.max_targets", 5, CVar.REPLICATED);
+
+        #endregion
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2347,15 +2347,5 @@ namespace Content.Shared.CCVar
             CVarDef.Create("contests.max_percentage", 0.25f, CVar.REPLICATED | CVar.SERVER);
 
         #endregion
-
-        #region Melee System
-
-        /// <summary>
-        ///     The maximum number of entities that can be targeted by a power attack(right click) in melee.
-        /// </summary>
-        public static readonly CVarDef<int> MaxMeleeTargets =
-            CVarDef.Create("melee.max_targets", 5, CVar.REPLICATED);
-
-        #endregion
     }
 }

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -245,7 +245,8 @@ public sealed partial class StaminaSystem : EntitySystem
     public void TakeStaminaDamage(EntityUid uid, float value, StaminaComponent? component = null,
         EntityUid? source = null, EntityUid? with = null, bool visual = true, SoundSpecifier? sound = null)
     {
-        if (!Resolve(uid, ref component, false))
+        if (!Resolve(uid, ref component, false)
+            || value == 0)
             return;
 
         var ev = new BeforeStaminaDamageEvent(value);

--- a/Content.Shared/Weapons/Melee/MeleeSoundSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeSoundSystem.cs
@@ -20,7 +20,7 @@ public sealed class MeleeSoundSystem : EntitySystem
     /// </summary>
     public void PlaySwingSound(EntityUid userUid, EntityUid weaponUid, MeleeWeaponComponent weaponComponent)
     {
-        _audio.PlayPredicted(weaponComponent.SwingSound, weaponUid, userUid);
+        _audio.PlayPredicted(weaponComponent.SoundSwing, weaponUid, userUid);
     }
 
     /// <summary>
@@ -32,8 +32,8 @@ public sealed class MeleeSoundSystem : EntitySystem
     /// <param name="hitSoundOverride"> A sound can be supplied by the <see cref="MeleeHitEvent"/> itself to override everything else </param>
     public void PlayHitSound(EntityUid targetUid, EntityUid? userUid, string? damageType, SoundSpecifier? hitSoundOverride, MeleeWeaponComponent weaponComponent)
     {
-        var hitSound      = weaponComponent.HitSound;
-        var noDamageSound = weaponComponent.NoDamageSound;
+        var hitSound      = weaponComponent.SoundHit;
+        var noDamageSound = weaponComponent.SoundNoDamage;
 
         var playedSound = false;
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -130,6 +130,9 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField, AutoNetworkedField]
     public float HeavyStaminaCost = 20f;
 
+    [DataField, AutoNetworkedField]
+    public int MaxTargets = 5;
+
 
     // Sounds
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -56,7 +56,7 @@ public sealed partial class MeleeWeaponComponent : Component
     ///     When power attacking, the swing speed (in attacks per second) is multiplied by this amount
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HeavyRateModifier = 1f;
+    public float HeavyRateModifier = 0.8f;
     /// <summary>
     /// Are we currently holding down the mouse for an attack.
     /// Used so we can't just hold the mouse button and attack constantly.
@@ -103,7 +103,7 @@ public sealed partial class MeleeWeaponComponent : Component
     ///     Weapon damage is multiplied by this amount for heavy swings
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HeavyDamageBaseModifier = 1f;
+    public float HeavyDamageBaseModifier = 1.2f;
 
     /// <summary>
     /// Total width of the angle for wide attacks.

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -55,6 +55,11 @@ public sealed partial class MeleeWeaponComponent : Component
     public float AttackRate = 1f;
 
     /// <summary>
+    ///     When power attacking, the swing speed (in attacks per second) is multiplied by this amount
+    /// </summary>
+    [DataField]
+    public float HeavyRateModifier = 1f;
+    /// <summary>
     /// Are we currently holding down the mouse for an attack.
     /// Used so we can't just hold the mouse button and attack constantly.
     /// </summary>
@@ -76,7 +81,7 @@ public sealed partial class MeleeWeaponComponent : Component
 
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(0.5f);
+    public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(1f);
 
     /// <summary>
     /// Multiplies damage by this amount for single-target attacks.
@@ -90,6 +95,15 @@ public sealed partial class MeleeWeaponComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public float Range = 1.5f;
+
+    /// <summary>
+    ///     Attack range for heavy swings
+    /// </summary>
+    [DataField]
+    public float HeavyRangeModifier = 1f;
+
+    [DataField]
+    public float HeavyDamageBaseModifier = 1f;
 
     /// <summary>
     /// Total width of the angle for wide attacks.
@@ -112,6 +126,9 @@ public sealed partial class MeleeWeaponComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public bool SwingLeft;
+
+    [DataField]
+    public float HeavyStaminaCost = 20f;
 
 
     // Sounds

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -18,13 +18,12 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// Does this entity do a disarm on alt attack.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool AltDisarm = true;
 
     /// <summary>
     /// Should the melee weapon's damage stats be examinable.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public bool Hidden;
 
@@ -32,14 +31,13 @@ public sealed partial class MeleeWeaponComponent : Component
     /// Next time this component is allowed to light attack. Heavy attacks are wound up and never have a cooldown.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    [ViewVariables(VVAccess.ReadWrite)]
     [AutoPausedField]
     public TimeSpan NextAttack;
 
     /// <summary>
     /// Starts attack cooldown when equipped if true.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField]
+    [DataField]
     public bool ResetOnHandSelected = true;
 
     /*
@@ -51,83 +49,85 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// How many times we can attack per second.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float AttackRate = 1f;
 
     /// <summary>
     ///     When power attacking, the swing speed (in attacks per second) is multiplied by this amount
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float HeavyRateModifier = 1f;
     /// <summary>
     /// Are we currently holding down the mouse for an attack.
     /// Used so we can't just hold the mouse button and attack constantly.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [AutoNetworkedField]
     public bool Attacking = false;
 
     /// <summary>
     /// If true, attacks will be repeated automatically without requiring the mouse button to be lifted.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool AutoAttack;
 
     /// <summary>
     /// Base damage for this weapon. Can be modified via heavy damage or other means.
     /// </summary>
     [DataField(required: true)]
-    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [AutoNetworkedField]
     public DamageSpecifier Damage = default!;
 
-    [DataField]
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(1f);
 
     /// <summary>
     /// Multiplies damage by this amount for single-target attacks.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField]
+    [DataField, AutoNetworkedField]
     public FixedPoint2 ClickDamageModifier = FixedPoint2.New(1);
 
     // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>
     /// Nearest edge range to hit an entity.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float Range = 1.5f;
 
     /// <summary>
     ///     Attack range for heavy swings
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float HeavyRangeModifier = 1f;
 
-    [DataField]
+    /// <summary>
+    ///     Weapon damage is multiplied by this amount for heavy swings
+    /// </summary>
+    [DataField, AutoNetworkedField]
     public float HeavyDamageBaseModifier = 1f;
 
     /// <summary>
     /// Total width of the angle for wide attacks.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField]
+    [DataField, AutoNetworkedField]
     public Angle Angle = Angle.FromDegrees(60);
 
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntProtoId Animation = "WeaponArcPunch";
 
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntProtoId WideAnimation = "WeaponArcSlash";
 
     /// <summary>
     /// Rotation of the animation.
     /// 0 degrees means the top faces the attacker.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField]
+    [DataField, AutoNetworkedField]
     public Angle WideAnimationRotation = Angle.Zero;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField]
+    [DataField]
     public bool SwingLeft;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float HeavyStaminaCost = 20f;
 
 
@@ -136,9 +136,8 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// This gets played whenever a melee attack is done. This is predicted by the client.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("soundSwing"), AutoNetworkedField]
-    public SoundSpecifier SwingSound { get; set; } = new SoundPathSpecifier("/Audio/Weapons/punchmiss.ogg")
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier SoundSwing { get; set; } = new SoundPathSpecifier("/Audio/Weapons/punchmiss.ogg")
     {
         Params = AudioParams.Default.WithVolume(-3f).WithVariation(0.025f),
     };
@@ -147,16 +146,14 @@ public sealed partial class MeleeWeaponComponent : Component
     // then a player may doubt if the target actually took damage or not.
     // If overwatch and apex do this then we probably should too.
 
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("soundHit"), AutoNetworkedField]
-    public SoundSpecifier? HitSound;
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? SoundHit;
 
     /// <summary>
     /// Plays if no damage is done to the target entity.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("soundNoDamage"), AutoNetworkedField]
-    public SoundSpecifier NoDamageSound { get; set; } = new SoundCollectionSpecifier("WeakHit");
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier SoundNoDamage { get; set; } = new SoundCollectionSpecifier("WeakHit");
 }
 
 /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -51,7 +51,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
     [Dependency] private readonly ContestsSystem _contests = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] protected readonly IConfigurationManager _config = default!;
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Contests;
 using Content.Shared.Damage;
@@ -22,6 +23,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -49,13 +51,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
     [Dependency] private readonly ContestsSystem _contests = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
-
-    /// <summary>
-    /// Maximum amount of targets allowed for a wide-attack.
-    /// </summary>
-    public const int MaxTargets = 5;
 
     /// <summary>
     /// If an attack is released within this buffer it's assumed to be full damage.
@@ -577,11 +575,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return true;
         }
 
-        // Naughty input
-        if (entities.Count > MaxTargets)
-        {
-            entities.RemoveRange(MaxTargets, entities.Count - MaxTargets);
-        }
+        var maxTargets = _config.GetCVar(CCVars.MaxMeleeTargets);
+        if (entities.Count > maxTargets)
+            entities.RemoveRange(maxTargets, entities.Count - maxTargets);
 
         // Validate client
         for (var i = entities.Count - 1; i >= 0; i--)

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
-using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Contests;
 using Content.Shared.Damage;
@@ -23,7 +22,6 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -51,7 +49,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
     [Dependency] private readonly ContestsSystem _contests = default!;
-    [Dependency] protected readonly IConfigurationManager _config = default!;
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -575,7 +572,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return true;
         }
 
-        var maxTargets = _config.GetCVar(CCVars.MaxMeleeTargets);
+        var maxTargets = component.MaxTargets;
         if (entities.Count > maxTargets)
             entities.RemoveRange(maxTargets, entities.Count - maxTargets);
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -799,20 +799,20 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 meleeWeapon.Damage = itemToggleMelee.ActivatedDamage;
             }
 
-            meleeWeapon.HitSound = itemToggleMelee.ActivatedSoundOnHit;
+            meleeWeapon.SoundHit = itemToggleMelee.ActivatedSoundOnHit;
 
             if (itemToggleMelee.ActivatedSoundOnHitNoDamage != null)
             {
                 //Setting the deactivated sound on no damage hit to the weapon's regular value before changing it.
-                itemToggleMelee.DeactivatedSoundOnHitNoDamage ??= meleeWeapon.NoDamageSound;
-                meleeWeapon.NoDamageSound = itemToggleMelee.ActivatedSoundOnHitNoDamage;
+                itemToggleMelee.DeactivatedSoundOnHitNoDamage ??= meleeWeapon.SoundNoDamage;
+                meleeWeapon.SoundNoDamage = itemToggleMelee.ActivatedSoundOnHitNoDamage;
             }
 
             if (itemToggleMelee.ActivatedSoundOnSwing != null)
             {
                 //Setting the deactivated sound on no damage hit to the weapon's regular value before changing it.
-                itemToggleMelee.DeactivatedSoundOnSwing ??= meleeWeapon.SwingSound;
-                meleeWeapon.SwingSound = itemToggleMelee.ActivatedSoundOnSwing;
+                itemToggleMelee.DeactivatedSoundOnSwing ??= meleeWeapon.SoundSwing;
+                meleeWeapon.SoundSwing = itemToggleMelee.ActivatedSoundOnSwing;
             }
 
             if (itemToggleMelee.DeactivatedSecret)
@@ -823,13 +823,13 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             if (itemToggleMelee.DeactivatedDamage != null)
                 meleeWeapon.Damage = itemToggleMelee.DeactivatedDamage;
 
-            meleeWeapon.HitSound = itemToggleMelee.DeactivatedSoundOnHit;
+            meleeWeapon.SoundHit = itemToggleMelee.DeactivatedSoundOnHit;
 
             if (itemToggleMelee.DeactivatedSoundOnHitNoDamage != null)
-                meleeWeapon.NoDamageSound = itemToggleMelee.DeactivatedSoundOnHitNoDamage;
+                meleeWeapon.SoundNoDamage = itemToggleMelee.DeactivatedSoundOnHitNoDamage;
 
             if (itemToggleMelee.DeactivatedSoundOnSwing != null)
-                meleeWeapon.SwingSound = itemToggleMelee.DeactivatedSoundOnSwing;
+                meleeWeapon.SoundSwing = itemToggleMelee.DeactivatedSoundOnSwing;
 
             if (itemToggleMelee.DeactivatedSecret)
                 meleeWeapon.Hidden = true;

--- a/Resources/Locale/en-US/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/damage/damage-examine.ftl
@@ -5,6 +5,7 @@ damage-examinable-verb-message = Examine the damage values.
 damage-hitscan = hitscan
 damage-projectile = projectile
 damage-melee = melee
+damage-melee-heavy = power attack
 damage-throw = throw
 
 damage-examine = It does the following damage:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -47,6 +47,15 @@
   components:
   - type: Sprite
     state: icon
+  - type: MeleeWeapon
+    bluntStaminaDamageFactor: 2.0
+    damage:
+      types:
+        Blunt: 7.5
+    heavyRangeModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 25
   - type: DamageOnLand
     damage:
       types:
@@ -54,7 +63,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 4
+        Blunt: 5
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -14,6 +14,19 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi
     state: icon
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Nyanotrasen/Weapons/electricguitarhit.ogg
+    range: 1.85
+    damage:
+      types:
+        Blunt: 6
+        Shock: 1
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 75
   - type: Item
     size: Normal
     sprite: Objects/Fun/Instruments/eguitar.rsi
@@ -43,6 +56,19 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/bassguitar.rsi
     state: icon
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Nyanotrasen/Weapons/electricguitarhit.ogg
+    range: 1.85
+    damage:
+      types:
+        Blunt: 6
+        Shock: 1
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 75
   - type: Item
     size: Normal
     sprite: Objects/Fun/Instruments/bassguitar.rsi
@@ -71,6 +97,27 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/rockguitar.rsi
     state: icon
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Nyanotrasen/Weapons/electricguitarhit.ogg
+    range: 1.85
+    attackRate: 1.25
+    wideAnimationRotation: 45
+    damage:
+      types:
+        Blunt: 6
+        Shock: 1
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 15
+    angle: 160
+  - type: Wieldable
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 2
+        Shock: 1
   - type: Item
     size: Normal
     sprite: Objects/Fun/Instruments/rockguitar.rsi
@@ -82,18 +129,6 @@
   - type: Tag
     tags:
     - StringInstrument
-  - type: MeleeWeapon
-    wideAnimationRotation: 45
-    damage:
-      types:
-        Blunt: 6
-        Slash: 2
-  - type: Wieldable
-  - type: IncreaseDamageOnWield #they don't call it an axe for nothing
-    damage:
-      types:
-        Blunt: 4
-        Slash: 2
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -145,14 +180,20 @@
       types:
         Blunt: 20
   - type: MeleeWeapon
+    range: 1.5
     wideAnimationRotation: 45
     damage:
       types:
-        Blunt: 5
+        Blunt: 7
+    bluntStaminaDamageFactor: 2
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 75
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 15
+        Blunt: 2
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -186,10 +227,15 @@
   - type: MeleeWeapon
     soundHit:
       path: /Audio/SimpleStation14/Weapons/Melee/banjohit.ogg
+    range: 1.5
     damage:
       types:
         Blunt: 7
-    bluntStaminaDamageFactor: 1.5
+    bluntStaminaDamageFactor: 2
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 75
 
 - type: entity
   parent: BaseHandheldInstrument

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -628,6 +628,16 @@
   - type: Sprite
     sprite: Objects/Fun/ducky.rsi
     state: icon
+  - type: MeleeWeapon
+    attackRate: 1.5
+    range: 1.3
+    damage:
+      types:
+        Blunt: 0.1
+    heavyDamageBaseModifier: 2
+    heavyStaminaCost: 5
+    maxTargets: 8
+    angle: 25
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/ducky.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -9,6 +9,18 @@
   - type: Storage
     grid:
     - 0,0,5,3
+  - type: MeleeWeapon
+    bluntStaminaDamageFactor: 3.0
+    attackRate: 0.9
+    range: 1.75
+    damage:
+      types:
+        Blunt: 3.5
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 0.8
+    heavyDamageBaseModifier: 2
+    heavyStaminaCost: 5
+    maxTargets: 8
   - type: Tag
     tags:
     - Briefcase

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -7,9 +7,16 @@
   - type: Sharp
   - type: MeleeWeapon
     attackRate: 1.5
+    range: 1.3
     damage:
       types:
-        Slash: 5
+        Slash: 4
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 0.8
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 3
+    angle: 75
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -38,9 +38,16 @@
     hasSafety: true
   - type: MeleeWeapon
     wideAnimationRotation: 180
+    attackRate: 0.8
+    bluntStaminaDamageFactor: 2.5
+    range: 1.75
     damage:
       types:
-        Blunt: 10
+        Blunt: 8
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 2
+    heavyStaminaCost: 15
+    maxTargets: 8
     soundHit:
       path: /Audio/Weapons/smash.ogg
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -45,8 +45,12 @@
   - type: MeleeWeapon # Nyanotrasen - Bibles do Holy damage
     damage:
       types:
-        Blunt: 3
-        Holy: 10
+        Blunt: 4
+        Holy: 20
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 5
+    maxTargets: 3
   - type: Tag
     tags:
     - Book

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -16,7 +16,14 @@
     swingLeft: true
     damage:
       types:
-        Slash: 6
+        Slash: 3.5
+        Blunt: 3
+    heavyRateModifier: 1
+    heavyRangeModifier: 1
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 5
+    angle: 100
   - type: Item
     sprite: Objects/Tools/Hydroponics/hoe.rsi
 
@@ -34,9 +41,16 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: 90
+    attackRate: 0.8
     damage:
       types:
-        Slash: 7
+        Pierce: 7
+    heavyRateModifier: 0.9
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
   - type: Item
     sprite: Objects/Tools/Hydroponics/clippers.rsi
     storedRotation: -90
@@ -53,9 +67,16 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: 135
+    range: 1.85
     damage:
       types:
-        Slash: 10
+        Slash: 7
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 120
   - type: Item
     size: Normal
   - type: Clothing
@@ -81,10 +102,13 @@
   - type: MeleeWeapon
     wideAnimationRotation: 135
     swingLeft: true
+    attackRate: 1.25
+    range: 1.25
     damage:
       types:
-        Slash: 8
-        Piercing: 2
+        Slash: 10
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
   - type: Item
     sprite: Objects/Tools/Hydroponics/hatchet.rsi
 
@@ -104,14 +128,19 @@
     wideAnimationRotation: 45
     damage:
       types:
-        Blunt: 8
-        Piercing: 2 # I guess you can stab it into them?
+        Blunt: 6
+        Slash: 2 # I guess you can stab it into them?
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    angle: 80
     soundHit:
       collection: MetalThud
   - type: Item
     sprite: Objects/Tools/Hydroponics/spade.rsi
   - type: Shovel
-    speedModifier: 0.75 # slower at digging than a full-sized shovel
+    speedModifier: 0.85 # slower at digging than a full-sized shovel
 
 - type: entity
   name: plant bag

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -8,9 +8,17 @@
     sprite: Objects/Specific/Janitorial/mop.rsi
     state: mop
   - type: MeleeWeapon
+    range: 1.85
     damage:
       types:
-        Blunt: 10
+        Blunt: 2
+    bluntStaminaDamageFactor: 3
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.25
+    heavyStaminaCost: 10
+    maxTargets: 2
+    angle: 180
     soundHit:
       collection: MetalThud
   - type: Spillable
@@ -48,9 +56,17 @@
       sprite: Objects/Specific/Janitorial/advmop.rsi
       state: advmop
     - type: MeleeWeapon
+      range: 1.85
       damage:
         types:
-          Blunt: 10
+          Blunt: 2
+      bluntStaminaDamageFactor: 3
+      heavyRateModifier: 0.8
+      heavyRangeModifier: 1.25
+      heavyDamageBaseModifier: 1.25
+      heavyStaminaCost: 10
+      maxTargets: 2
+      angle: 180
       soundHit:
          collection: MetalThud
     - type: Spillable

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -50,9 +50,15 @@
     - 0,0,1,0
     - 1,1,1,1
   - type: MeleeWeapon
+    attackRate: 0.75
+    range: 1.3
     damage:
       types:
-        Piercing: 10
+        Piercing: 8
+      heavyDamageBaseModifier: 1.5
+      heavyStaminaCost: 5
+      maxTargets: 1
+      angle: 20
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: StaticPrice
@@ -80,10 +86,16 @@
   - type: MeleeWeapon
     wideAnimationRotation: 90
     swingLeft: true
-    attackRate: 1.5
+    attackRate: 1.25
+    range: 1.25
     damage:
       types:
-        Slash: 8
+        Slash: 7.5
+      heavyRateModifier: 0.8
+      heavyDamageBaseModifier: 1.25
+      heavyStaminaCost: 5
+      maxTargets: 1
+      angle: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
 
@@ -111,7 +123,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 12
+        Slash: 8
 
 - type: entity
   name: laser scalpel
@@ -121,6 +133,11 @@
   components:
   - type: Sprite
     state: laser
+  - type: MeleeWeapon
+    damage:
+      types:
+        Slash: 6.5
+        Heat: 1
   - type: Item
     heldPrefix: laser
 
@@ -179,7 +196,19 @@
     qualities:
       - Sawing
     speed: 1.0
-# No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.
+  - type: MeleeWeapon
+    attackRate: 0.75
+    range: 1.35
+    damage:
+      types:
+        Blunt: 2.5
+        Slash: 6.5
+      heavyRateModifier: 0.8
+      heavyDamageBaseModifier: 1.0
+      heavyStaminaCost: 20
+      maxTargets: 8
+      angle: 20
+# ~~No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.~~ No, I'm going to saw through your bones.
 
 - type: entity
   name: choppa
@@ -192,9 +221,17 @@
   - type: Item
     heldPrefix: improv
   - type: MeleeWeapon
+    attackRate: 0.85
     damage:
-      groups:
-        Brute: 10
+      types:
+        Blunt: 3
+        Slash: 7
+      bluntStaminaDamageFactor: 3
+      heavyRateModifier: 0.8
+      heavyDamageBaseModifier: 1.0
+      heavyStaminaCost: 20
+      maxTargets: 8
+      angle: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tool
@@ -214,9 +251,18 @@
     heldPrefix: electric
     storedRotation: 90
   - type: MeleeWeapon
+    attackRate: 1.15
+    range: 1.4
+    bluntStaminaDamageFactor: 3.0
     damage:
-      groups:
-        Brute: 15
+      types:
+        Blunt: 4.5
+        Slash: 5.5
+    heavyRateModifier: 0.5
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 15
+    maxTargets: 8
+    angle: 360
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
@@ -236,10 +282,18 @@
     heldPrefix: advanced
     storedRotation: 90
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.25
+    range: 1.4
+    bluntStaminaDamageFactor: 5.0
     damage:
-      groups:
-        Brute: 15
+      types:
+        Blunt: 4.5
+        Slash: 7.5
+    heavyRateModifier: 0.5
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 15
+    maxTargets: 8
+    angle: 360
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -55,10 +55,10 @@
     damage:
       types:
         Piercing: 8
-      heavyDamageBaseModifier: 1.5
-      heavyStaminaCost: 5
-      maxTargets: 1
-      angle: 20
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: StaticPrice
@@ -91,11 +91,11 @@
     damage:
       types:
         Slash: 7.5
-      heavyRateModifier: 0.8
-      heavyDamageBaseModifier: 1.25
-      heavyStaminaCost: 5
-      maxTargets: 1
-      angle: 20
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.25
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
 
@@ -203,11 +203,11 @@
       types:
         Blunt: 2.5
         Slash: 6.5
-      heavyRateModifier: 0.8
-      heavyDamageBaseModifier: 1.0
-      heavyStaminaCost: 20
-      maxTargets: 8
-      angle: 20
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 20
+    maxTargets: 8
+    angle: 20
 # ~~No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.~~ No, I'm going to saw through your bones.
 
 - type: entity
@@ -226,12 +226,12 @@
       types:
         Blunt: 3
         Slash: 7
-      bluntStaminaDamageFactor: 3
-      heavyRateModifier: 0.8
-      heavyDamageBaseModifier: 1.0
-      heavyStaminaCost: 20
-      maxTargets: 8
-      angle: 20
+    bluntStaminaDamageFactor: 3
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 20
+    maxTargets: 8
+    angle: 20
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -54,6 +54,14 @@
         shader: unshaded
         visible: false
         map: [ "light" ]
+  - type: MeleeWeapon
+    attackRate: 0.8
+    bluntStaminaDamageFactor: 1.5
+    damage:
+      types:
+        Blunt: 6
+    soundHit:
+      collection: MetalThud
   - type: Item
     sprite: Objects/Tools/flashlight.rsi
     storedRotation: -90
@@ -108,9 +116,15 @@
         map: [ "light" ]
   - type: MeleeWeapon
     wideAnimationRotation: 90
+    attackRate: 0.8
     damage:
       types:
-        Blunt: 10
+        Blunt: 6.5
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.9
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       collection: MetalThud
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -34,9 +34,16 @@
   - type: MeleeWeapon
     wideAnimationRotation: 45
     attackRate: 0.8
+    range: 1.75
     damage:
       types:
-        Blunt: 10
+        Blunt: 8
+    bluntStaminaDamageFactor: 2.5
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 15
+    maxTargets: 1
+    angle: 140
   - type: PhysicalComposition
     materialComposition:
       Steel: 185

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -44,9 +44,18 @@
         changeSound: /Audio/Items/change_jaws.ogg
   - type: MeleeWeapon
     wideAnimationRotation: 90
+    attackRate: 0.75
+    range: 1.75
     damage:
       types:
         Blunt: 10
+        Slash: 2
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 10
+    maxTargets: 1
+    angle: 20
     soundHit:
       collection: MetalThud
 
@@ -87,4 +96,5 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 14
+        Blunt: 12
+        Slash: 2

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -21,9 +21,15 @@
   - type: Item
     size: Ginormous
   - type: MeleeWeapon
+    attackRate: 0.9
+    range: 1.75
     damage:
       types:
-        Blunt: 12
+        Blunt: 9
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.8
+    heavyStaminaCost: 10
+    angle: 80.5
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
   - type: Tag
@@ -134,7 +140,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 20
+        Blunt: 11.5
 
 - type: entity
   name: golden toolbox
@@ -147,6 +153,10 @@
     state: icon
   - type: Item
     sprite: Objects/Tools/Toolboxes/toolbox_gold.rsi
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 12
 
 - type: entity
   id: ToolboxThief

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -23,10 +23,16 @@
     - state: cutters-cutty-thingy
   - type: MeleeWeapon
     wideAnimationRotation: -90
+    attackRate: 0.9
+    range: 1.6
     damage:
       types:
-        Piercing: 2
-    attackRate: 2 #open and close that shit on their arm like hell! because you sure aren't doing any damage with this
+        Blunt: 6.5
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 4
+    angle: 60
     soundHit:
       path: "/Audio/Items/wirecutter.ogg"
   - type: Tool
@@ -75,10 +81,15 @@
     storedRotation: -90
   - type: MeleeWeapon
     wideAnimationRotation: -90
-    attackRate: 1
+    attackRate: 1.35
     damage:
       types:
         Piercing: 6
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
   - type: Tool
@@ -122,10 +133,16 @@
       state: storage
   - type: MeleeWeapon
     wideAnimationRotation: 135
-    attackRate: 1.5
+    attackRate: 0.9
+    range: 1.6
     damage:
       types:
-        Blunt: 4.5
+        Blunt: 6.5
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.75
+    heavyStaminaCost: 5
+    angle: 100
     soundHit:
       collection: MetalThud
   - type: Tool
@@ -166,9 +183,12 @@
       state: storage
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 1.25
     damage:
       types:
-        Blunt: 8
+        Blunt: 6
+    bluntStaminaDamageFactor: 2
+    heavyStaminaCost: 5
     soundHit:
       collection: MetalThud
   - type: Tool
@@ -220,6 +240,16 @@
     - state: icon
     - state: green-unlit
       shader: unshaded
+  - type: MeleeWeapon
+    attackRate: 0.75
+    damage:
+      types:
+        Shock: 2
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
   - type: Item
     size: Small
   - type: Clothing
@@ -359,10 +389,16 @@
     price: 100
   - type: MeleeWeapon
     wideAnimationRotation: -90
-    attackRate: 1.5
+    attackRate: 0.9
+    range: 1.4
     damage:
       types:
-        Piercing: 10
+        Piercing: 8
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
 
@@ -568,9 +604,16 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: 45
+    attackRate: 0.8
+    range: 2.0
     damage:
       types:
-        Blunt: 14
+        Blunt: 8
+    bluntStaminaDamageFactor: 1.5
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 10
+    angle: 100
     soundHit:
       collection: MetalThud
   - type: Item
@@ -610,9 +653,16 @@
     - Belt
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 0.9
     damage:
       types:
         Blunt: 7
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.5
+    heavyStaminaCost: 5
+    maxTargets: 1
+    angle: 20
     soundHit:
       collection: MetalThud
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -55,7 +55,7 @@
       collection: MetalThud
     activatedDamage:
         types:
-            Heat: 8
+            Heat: 7
   - type: ItemToggleSize
     activatedSize: Large
   - type: ItemToggleHot
@@ -75,7 +75,7 @@
     wideAnimationRotation: -90
     damage:
       types:
-        Blunt: 5 #i mean... i GUESS you could use it like that
+        Blunt: 6 #i mean... i GUESS you could use it like that
     soundHit:
       collection: MetalThud
   - type: RefillableSolution

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -9,17 +9,24 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    range: 1.6
     damage:
       types:
-        Blunt: 10
+        Blunt: 7.5
         Structural: 5
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.5
+    heavyDamageBaseModifier: 1.75
+    heavyStaminaCost: 15
+    maxTargets: 2
+    angle: 120
     soundHit:
       collection: MetalThud
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 5
+        Blunt: 4
         Structural: 10
   - type: Item
     size: Normal

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -15,7 +15,6 @@
     state: icon
   - type: MeleeWeapon
     autoAttack: true
-    angle: 0
     wideAnimationRotation: -135
     attackRate: 4
     damage:
@@ -23,6 +22,11 @@
         Slash: 2
         Blunt: 2
         Structural: 4
+    heavyRateModifier: 0.5
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 15
+    maxTargets: 20
+    angle: 160
     soundHit:
       path: /Audio/Weapons/chainsaw.ogg
       params:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -10,10 +10,14 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 1.25
+    range: 1.4
     damage:
       types:
-        Slash: 12
+        Slash: 8
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
   - type: Item
     size: Normal
   - type: Clothing
@@ -35,9 +39,14 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 0.75
+    range: 1.75
     damage:
       types:
-        Slash: 16
+        Slash: 12
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    maxTargets: 6
+    angle: 90
   - type: Item
     size: Normal
   - type: Clothing
@@ -62,19 +71,24 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 0.75
+    range: 1.75
     damage:
       types:
-        Blunt: 10
-        Slash: 10
+        Blunt: 2
+        Slash: 13
         Structural: 5
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 100
     soundHit:
       collection: MetalThud
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 5
-        Slash: 5
+        Blunt: 2
+        Slash: 3
         Structural: 10
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -35,8 +35,8 @@
         variation: 0.125
     activatedDamage:
         types:
-            Slash: 15
-            Heat: 15
+            Slash: 8
+            Heat: 10
             Structural: 20
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword.rsi
@@ -49,7 +49,7 @@
         map: [ "blade" ]
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1
+    attackRate: 1.25
     damage:
       types:
         Blunt: 4.5
@@ -106,8 +106,8 @@
         variation: 0.250
     activatedDamage:
         types:
-            Slash: 10
-            Heat: 10
+            Slash: 4
+            Heat: 8
     deactivatedSecret: true
   - type: ItemToggleActiveSound
     activeSound:
@@ -245,8 +245,8 @@
         variation: 0.250
     activatedDamage:
         types:
-            Slash: 12
-            Heat: 12
+            Slash: 8
+            Heat: 13
             Structural: 15
   - type: ItemToggleActiveSound
     activeSound:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -18,16 +18,20 @@
     damage:
       types:
         # axes are kinda like sharp hammers, you know?
-        Blunt: 5
-        Slash: 10
+        Blunt: 4
+        Slash: 6
         Structural: 10
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 10
+    angle: 100
     soundHit:
       collection: MetalThud
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 10
+        Blunt: 2
+        Slash: 5
         Structural: 40
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -12,9 +12,16 @@
       - Knife
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 1.25
+    range: 1.4
     damage:
       types:
-        Slash: 10
+        Slash: 8
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 3
+    angle: 40
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Sprite
@@ -60,10 +67,11 @@
     state: butch
   - type: MeleeWeapon
     wideAnimationRotation: -115
-    attackRate: 1.5
+    attackRate: 1
     damage:
       types:
-        Slash: 13
+        Slash: 8
+        Blunt: 1
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -87,15 +95,16 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.5
+    range: 1.4
     damage:
       types:
-        Slash: 12
+        Slash: 9
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 10
+        Slash: 9
   - type: Item
     sprite: Objects/Weapons/Melee/combat_knife.rsi
   - type: DisarmMalus
@@ -110,6 +119,13 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/survival_knife.rsi
     state: icon
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: 1.25
+    range: 1.5
+    damage:
+      types:
+        Slash: 8
   - type: Item
     sprite: Objects/Weapons/Melee/survival_knife.rsi
 
@@ -124,9 +140,10 @@
     state: icon
   - type: MeleeWeapon
     attackRate: 1.0
+    range: 1.75
     damage:
       types:
-        Slash: 15
+        Slash: 10
   - type: Item
     sprite: Objects/Weapons/Melee/kukri_knife.rsi
 
@@ -186,7 +203,8 @@
     sprite: Objects/Weapons/Melee/shiv.rsi
     state: icon
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.75
+    range: 0.75
     damage:
       types:
         Slash: 5.5
@@ -205,7 +223,6 @@
     graph: ReinforcedShiv
     node: icon
   - type: MeleeWeapon
-    attackRate: 1.5
     damage:
       types:
         Slash: 7 #each "tier" grants an additional 2 damage
@@ -224,10 +241,9 @@
     graph: PlasmaShiv
     node: icon
   - type: MeleeWeapon
-    attackRate: 1.5
     damage:
       types:
-        Slash: 9
+        Slash: 8.5
   - type: Item
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
   - type: Sprite
@@ -243,10 +259,9 @@
     graph: UraniumShiv
     node: icon
   - type: MeleeWeapon
-    attackRate: 1.5
     damage:
       types:
-        Slash: 7
+        Slash: 6.5
         Radiation: 4
   - type: Item
     sprite: Objects/Weapons/Melee/uranium_shiv.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -43,12 +43,18 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 0.75
+    range: 1.75
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 10
-        Slash: 5
+        Blunt: 8
+        Slash: 4
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 120
     soundHit:
       collection: MetalThud
   - type: Wieldable
@@ -79,10 +85,16 @@
   - type: MeleeWeapon
     autoAttack: true
     wideAnimationRotation: -135
-    attackRate: 2
+    attackRate: 1.25
+    range: 1.4
     damage:
       types:
-        Slash: 15
+        Slash: 9
+    heavyRateModifier: 0.9
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 2
+    angle: 20
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -68,6 +68,7 @@
       groups:
         Brute: 9
         Slash: 6
+      types:
         Structural: 12
     bluntStaminaDamageFactor: 4.0
     heavyRateModifier: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -20,8 +20,7 @@
         volume: -3
     damage:
       groups:
-        Brute: 5
-        Piercing: 3
+        Brute: 7
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
     heavyStaminaCost: 5
@@ -66,8 +65,7 @@
     range: 1.4
     damage:
       groups:
-        Brute: 9
-        Slash: 6
+        Brute: 10
       types:
         Structural: 12
     bluntStaminaDamageFactor: 4.0

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -11,7 +11,8 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
-    attackRate: 0.7
+    attackRate: 0.75
+    range: 1.75
     wideAnimationRotation: -135
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -20,11 +21,17 @@
     damage:
       groups:
         Brute: 5
+        Piercing: 3
+    bluntStaminaDamageFactor: 2.0
+    heavyDamageBaseModifier: 1.75
+    heavyStaminaCost: 5
+    maxTargets: 2
+    angle: 60
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       groups:
-        Brute: 10
+        Brute: 5
       types:
         Structural: 30
   - type: Item
@@ -52,16 +59,24 @@
     state: handdrill
   - type: MeleeWeapon
     autoAttack: true
-    angle: 0
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-    attackRate: 3.5
+    attackRate: 0.5
+    range: 1.4
     damage:
       groups:
-        Brute: 3
-      types:
+        Brute: 9
+        Slash: 6
         Structural: 12
+    bluntStaminaDamageFactor: 4.0
+    heavyRateModifier: 1
+    heavyRangeModifier: 2
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 10
+    maxTargets: 3
+    angle: 20
+
   - type: ReverseEngineering # Nyano
     difficulty: 2
     recipes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -19,7 +19,7 @@
       params:
         volume: -3
     damage:
-      groups:
+      types:
         Blunt: 6
         Pierce: 3
     bluntStaminaDamageFactor: 2.0
@@ -30,9 +30,8 @@
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
-      groups:
-        Blunt: 5
       types:
+        Blunt: 5
         Structural: 30
   - type: Item
     size: Normal
@@ -65,10 +64,9 @@
     attackRate: 0.5
     range: 1.4
     damage:
-      groups:
+      types:
         Blunt: 9
         Slash: 3
-      types:
         Structural: 12
     bluntStaminaDamageFactor: 4.0
     heavyRateModifier: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -20,7 +20,8 @@
         volume: -3
     damage:
       groups:
-        Brute: 7
+        Blunt: 6
+        Pierce: 3
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
     heavyStaminaCost: 5
@@ -30,7 +31,7 @@
   - type: IncreaseDamageOnWield
     damage:
       groups:
-        Brute: 5
+        Blunt: 5
       types:
         Structural: 30
   - type: Item
@@ -65,7 +66,8 @@
     range: 1.4
     damage:
       groups:
-        Brute: 10
+        Blunt: 9
+        Slash: 3
       types:
         Structural: 12
     bluntStaminaDamageFactor: 4.0

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -9,10 +9,18 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 0.8
+    range: 1.75
     damage:
       types:
-        Blunt: 10
+        Blunt: 6
         Structural: 10
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.75
+    heavyStaminaCost: 15
+    maxTargets: 10
+    angle: 120
     soundHit:
       collection: MetalThud
   - type: Wieldable

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -35,17 +35,24 @@
       visible: false
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    range: 1.75
     damage:
       types:
-        Piercing: 12
-    angle: 0
+        Piercing: 7
+        Slash: 1
+    heavyRateModifier: 0.75
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.0
+    heavyStaminaCost: 5
+    maxTargets: 3
+    angle: 20
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 15
+        Piercing: 10
   - type: Item
     size: Ginormous
   - type: Clothing
@@ -75,7 +82,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Piercing: 4
+        Piercing: 3
+        Slash: 3
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -124,11 +132,12 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 15
+        Piercing: 8.5
+        Slash: 1
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 18
+        Piercing: 12
   - type: Construction
     graph: SpearReinforced
 
@@ -144,11 +153,12 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 18
+        Piercing: 9.5
+        Slash: 1.5
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 21
+        Piercing: 14
   - type: Construction
     graph: SpearPlasma
 
@@ -164,13 +174,13 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 10
+        Piercing: 8
         Radiation: 8
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 12
-        Radiation: 9
+        Piercing: 8
+        Radiation: 8
   - type: Construction
     graph: SpearUranium
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -30,16 +30,23 @@
     energyPerUse: 70
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 0.8
+    range: 1.4
     damage:
       types:
-        Blunt: 9
+        Blunt: 7.5
+    bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 5
+    maxTargets: 3
     angle: 60
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit
-    damage: 20
+    damage: 22
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 20
+    damage: 22
     sound: /Audio/Weapons/egloves.ogg
   - type: Battery
     maxCharge: 360

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -10,12 +10,19 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 1.25
+    range: 1.75
     soundHit:
       path: /Audio/SimpleStation14/Weapons/Melee/rapierhit.ogg
     damage:
       types:
         Slash: 17 #cmon, it has to be at least BETTER than the rest.
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 5
+    maxTargets: 7
+    angle: 80
   - type: Reflect
     enabled: true
     reflectProb: .5
@@ -43,11 +50,18 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 1.5
     soundHit:
       path: /Audio/SimpleStation14/Weapons/Melee/rapierhit.ogg
     damage:
       types:
-        Slash: 15
+        Slash: 12
+    heavyRateModifier: 0.5
+    heavyRangeModifier: 3 #Superior Japanese folded steel
+    heavyDamageBaseModifier: 1.25
+    heavyStaminaCost: 10
+    maxTargets: 1
+    angle: 20
   - type: Item
     size: Normal
     sprite: DeltaV/Objects/Weapons/Melee/katana.rsi #DeltaV
@@ -66,7 +80,7 @@
     wideAnimationRotation: -60
     damage:
       types:
-        Slash: 30
+        Slash: 25
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/energykatana.rsi
@@ -99,9 +113,15 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 0.8
     damage:
       types:
         Slash: 15
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1.25
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    angle: 80
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -121,10 +141,19 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 0.75
+    attackRate: 0.65
+    range: 1.85
     damage:
       types:
-        Slash: 20
+        Slash: 19
+        Blunt: 1
+    bluntStaminaDamageFactor: 25.0
+    heavyRateModifier: 0.5
+    heavyRangeModifier: 1
+    heavyDamageBaseModifier: 1
+    heavyStaminaCost: 20
+    maxTargets: 10
+    angle: 200
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -150,9 +179,16 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 1.25
     damage:
       types:
-        Slash: 16
+        Slash: 12
+    heavyRateModifier: 0.8
+    heavyRangeModifier: 1.2
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
+    maxTargets: 3
+    angle: 40
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
@@ -12,16 +12,23 @@
     sprite: Objects/Weapons/Melee/white_cane.rsi
   - type: MeleeWeapon
     wideAnimationRotation: 45
+    attackRate: 0.9
+    range: 1.6
     damage:
       types:
-        Blunt: 5
-  - type: StaminaDamageOnHit
-    damage: 5
+        Blunt: 6
+    bluntStaminaDamageFactor: 2.5
+    heavyRateModifier: 0.5
+    heavyRangeModifier: 1.75
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 0
+    maxTargets: 1
+    angle: 20
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 3
+        Blunt: 2
   - type: UseDelay
     delay: 1
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -104,7 +104,7 @@
     soundHit:
       collection: MetalThud
     bluntStaminaDamageFactor: 2
-    heavyRateModifier: 0.8
+    heavyRateModifier: 1
     heavyDamageBaseModifier: 1.2
     heavyStaminaCost: 10
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -35,6 +35,10 @@
       types:
         Blunt: 7
     bluntStaminaDamageFactor: 2.0
+    heavyRateModifier: 0.75
+    heavyDamageBaseModifier: 1.75
+    heavyStaminaCost: 5
+    maxTargets: 3
     angle: 60
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
@@ -93,12 +97,16 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 0.8
     damage:
       types:
-        Blunt: 20
+        Blunt: 15
     soundHit:
       collection: MetalThud
-    bluntStaminaDamageFactor: 1.5
+    bluntStaminaDamageFactor: 2
+    heavyRateModifier: 0.8
+    heavyDamageBaseModifier: 1.2
+    heavyStaminaCost: 10
   - type: Item
     size: Normal
   - type: Clothing


### PR DESCRIPTION
# PT2 of Melee Weapons The Numbers Don't Lie

This is part 2 of the ongoing work of Solid and myself going through and touching up the melee combat in the game. In this part I rebalance all of the melee weapons to generally do less damage, more stamina damage, and be more unique in regards to slight range changes, attack speed adjustments, along with every weapon getting slightly adjusted heavy swing changes ranging from attack rates, damage, range, angle, and how many targets you can hit.

Majority of weapons will hit the standard amount of targets of 5(the old norm), but a few are lowered to be single target hits. These are usually tightened in the angle that they attack in(old angle range was 60). Similarly all melee weapons have individual stamina costs on their heavy swings, most of these are in the range of 5 or 10, and following this PR the new standard should be 10 as the outliers that would abuse this have been addressed in this PR.

---

# Changelog

Normally I would do a changelog but this took awhile and I forgo. 

:cl: ODJ
- tweak: Melee Weapons now feel different across the board, from the Wrench to the Chainsaw, try out their normal swings and their heavy attacks!
