### PR TITLE
Rename Mantis

### DIFF
--- a/Resources/Locale/en-US/deltav/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/deltav/prototypes/access/accesses.ftl
@@ -1,5 +1,5 @@
 id-card-access-level-orders = Orders
-id-card-access-level-mantis = Psionic Mantis
+id-card-access-level-mantis = Mantis
 id-card-access-level-chief-justice = Chief Justice
 id-card-access-level-prosecutor = Prosecutor
 id-card-access-level-justice = Justice

--- a/Resources/Locale/en-US/nyanotrasen/job/job-names.ftl
+++ b/Resources/Locale/en-US/nyanotrasen/job/job-names.ftl
@@ -3,8 +3,8 @@ job-name-guard = Prison Guard
 job-name-mail-carrier = Courier
 job-name-martialartist =  Martial Artist
 job-name-prisoner = Prisoner
-job-name-mantis = Psionic Mantis
+job-name-mantis = Mantis
 
 # Role timers
 JobMailCarrier = Courier
-JobForensicMantis = Psionic Mantis
+JobForensicMantis = Mantis

--- a/Resources/Locale/en-US/psionics/stamp-component.ftl
+++ b/Resources/Locale/en-US/psionics/stamp-component.ftl
@@ -1,1 +1,1 @@
-stamp-component-stamped-name-mantis = Psionic Mantis
+stamp-component-stamped-name-mantis = Mantis

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -34,7 +34,7 @@
   - Atmospherics
   - Mail # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
   - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
-  - Mantis # DeltaV - Psionic Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
+  - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
   - Paramedic # DeltaV - Add Paramedic access
   - Psychologist # DeltaV - Add Psychologist access
   - Boxer # DeltaV - Add Boxer access

--- a/Resources/Prototypes/Access/research.yml
+++ b/Resources/Prototypes/Access/research.yml
@@ -11,4 +11,4 @@
   tags:
   - ResearchDirector
   - Research
-  - Mantis # DeltaV - Psionic Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
+  - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Belt/belts.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ClothingBeltStorageBase
   id: ClothingBeltMantis
-  name: psionic mantis' belt # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' belt
   description: Perfect for storing all of your equipment.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -124,7 +124,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatFezMantis
-  name: psionic mantis' fez # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' fez
   description: A fine red fez with a gold tassel.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingOuterCoatMantis
-  name: psionic mantis' jacket # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' jacket
   description: Modeled after an ancient infantry uniform, this jacket may guard you against the unknown in your journey for the truth.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -47,7 +47,7 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterCoatMantis
-  name: psionic mantis' winter coat # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' winter coat
   description: Solve cold cases in style.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Shoes/boots.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ClothingShoesBaseButcherable
   id: ClothingShoesBootsMantis
-  name: psionic mantis' boots # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' boots
   description: Soft, comfortable, and good for rough terrain.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -72,7 +72,7 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitMantis
-  name: psionic mantis' uniform # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' uniform
   description: Modeled after an ancient infantry uniform, this uniform has superior mobility for tense situations.
   components:
   - type: Sprite
@@ -83,7 +83,7 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformSkirtMantis
-  name: psionic mantis' jumpskirt # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' jumpskirt
   description: Adapted from an ancient infantry uniform, this jumpskirt has superior mobility for tense situations.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
@@ -65,7 +65,7 @@
 - type: entity
   id: SpawnPointForensicMantis
   parent: SpawnPointJobBase
-  name: psionic mantis # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis
   components:
   - type: SpawnPoint
     job_id: ForensicMantis

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -82,7 +82,7 @@
 - type: entity
   parent: IDCardStandard
   id: ForensicMantisIDCard
-  name: psionic mantis ID card # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis ID card
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -99,7 +99,7 @@
 - type: entity
   parent: BasePDA
   id: ForensicMantisPDA
-  name: psionic mantis PDA # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis PDA
   description: Smells like illegal substances.
   components:
   - type: Pda

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/paper.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: psionic mantis' seal # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' seal
   parent: RubberStampBase
   id: RubberStampMantis
   suffix: DO NOT MAP

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -2,7 +2,7 @@
   id: LockerForensicMantis
   parent: LockerDetective
   suffix: Empty
-  name: psionic mantis' cabinet # DeltaV - Rename Forensic Mantis to Psionic Mantis
+  name: mantis' cabinet
   description: You'll never know what's inside until you collapse the quantum superposition of all possible mysteries.
   components:
   # Because it holds a traitor objective, StrongMetallic,

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -18,7 +18,7 @@
   access:
   - Research
   - Maintenance
-  - Mantis # DeltaV - Psionic Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
+  - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -21,7 +21,7 @@
   - Command
   - Maintenance
   - ResearchDirector
-  - Mantis # DeltaV - Psionic Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
+  - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
   - Chapel # DeltaV - Chaplain is in Epistemics
   - Cryogenics
   special: # Nyanotrasen - Mystagogue can use the Bible

--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -92,7 +92,7 @@ Players that are revived by using a defibrillator CAN recall what killed them an
 
 [color=#a4885c]11.[/color] Psionics
     - Players that have psionic powers are allowed to use them at-will to accomplish their roleplay goals. It should be noted that in-character consequences can happen as a result of their use, including being stripped of psionic powers or even death.
-    - As a psionic mantis, it is not your goal to hunt down psionics. Do not mindbreak others against their will solely because they have psionic powers.
+    - As a mantis, it is not your goal to hunt down psionics. Do not mindbreak others against their will solely because they have psionic powers.
 
 [color=#a4885c]12.[/color] Don't rush for or prepare equipment unrelated to your job for no purpose other than to have it "just in case" (referred to as "Powergaming").
     - A medical doctor does not need insulated gloves, and the Head of Personnel does not need to give themselves armory access so they can go grab a gun. Have an actual reason for needing these things.


### PR DESCRIPTION
"Mantis" was going to be the original name, but the doubling as detective lead me to needing to add the qualifier "forensic" to make that part clearer. The "Mantis" was already there to imply the psionic part.

For "psionic mantis" defenders, I propose an alternative renaming scheme:
Mystagogue -> Psionic Mystagogue
Mantis -> Psionic Mantis
Cyborg -> Robotic Cyborg
Chaplain -> Religious Chaplain

Players either already know what a mantis is, or they've got little enough playtime that there's still some intrigue left in the setting and it's something they can learn by observation. Weird names are mostly restricted to one dept here and a tinge harder time understanding it is what I'd call "Mystery" rather than something that's undesirable here. The mechanic the mantis interacts with - psionics - is also somewhat hidden and esoteric.

# Media
![image](https://github.com/user-attachments/assets/8706c0cd-97a3-4ed6-a0e4-e23012a461a7)

![image](https://github.com/user-attachments/assets/7e6296fb-52ca-4d4e-b40d-2e166520d4b5)


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Rane
- tweak: Renamed "Psionic Mantis" to "Mantis", as it was originally going to be called. 