### PR TITLE
Remove Hugging Interaction Popup From Humanoids

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -77,12 +77,6 @@ comp-window-knock = *knock knock*
 
 fence-rattle-success = *rattle*
 
-## Hugging players
-
-hugging-success-generic = You hug {THE($target)}.
-hugging-success-generic-others = { CAPITALIZE(THE($user)) } hugs {THE($target)}.
-hugging-success-generic-target = { CAPITALIZE(THE($user)) } hugs you.
-
 ## Other
 
 petting-success-tesla = You pet {THE($target)}, violating the laws of nature and physics.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
@@ -5,11 +5,6 @@
   id: MobVulpkanin
   components:
     - type: CombatMode
-    - type: InteractionPopup
-      successChance: 1
-      interactSuccessString: hugging-success-generic
-      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-      messagePerceivedByOthers: hugging-success-generic-others
     - type: MindContainer
       showExamineInfo: true
     - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachne.yml
@@ -5,11 +5,6 @@
   id: MobArachne
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/harpy.yml
@@ -5,11 +5,6 @@
   id: MobHarpy
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -3,12 +3,7 @@
   parent: BaseMobSkeletonPerson
   id: MobSkeletonPerson
   components:
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
-  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic. 
+  - type: PotentialPsionic #Nyano - Summary: makes potentially psionic.
 
 - type: entity
   name: skeleton pirate

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -180,11 +180,6 @@
   - type: Dna
   - type: MindContainer
     showExamineInfo: true
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
@@ -5,11 +5,6 @@
   id: MobOni
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -5,11 +5,6 @@
   id: MobFelinid
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Reasoning:
1) Hugging your coworkers isn't necessarily always inappropriate, but it's something that should take a bit more intention than it does now.
2) Event subs in this game right now still have no good method of handling multiple subscriptions to the same event. The hugging event is occupying 2 pieces of prime real estate - the empty hand interaction, which is the most common, and the humanoid interaction, which is the most common and most important. And for what? Spamming popups and chat for something that could just be an emote.
3) Because of the above, it's too easy to accidentally hug people while doing something else - the lack of intersectionality makes people just ignore hugging because they assume it means nothing and was not intentional. This does not lead to good roleplay outcomes.
4) I left the petting stuff on animals because that's much more common and appropriate and you're less likely to be trying to do other complex interactions with them. Also, since they're usually NPCs, it doesn't matter if they get desensitized to the interaction as meaningless, or at least it's out of scope.

# Changelog

:cl: Rane
- remove: Removed the spammable hugging on click. Consider using emotes for this instead.
