### PR TITLE
Vulpkanin Update

### DIFF
--- a/Content.Server/Flash/DamagedByFlashingSystem.cs
+++ b/Content.Server/Flash/DamagedByFlashingSystem.cs
@@ -15,8 +15,5 @@ public sealed class DamagedByFlashingSystem : EntitySystem
     private void OnFlashAttempt(Entity<DamagedByFlashingComponent> ent, ref FlashAttemptEvent args)
     {
         _damageable.TryChangeDamage(ent, ent.Comp.FlashDamage);
-
-        //To Do: It would be more logical if different flashes had different power,
-        //and the damage would be inflicted depending on the strength of the flash.
     }
 }

--- a/Content.Shared/Flash/FlashableComponent.cs
+++ b/Content.Shared/Flash/FlashableComponent.cs
@@ -10,6 +10,18 @@ namespace Content.Shared.Flash
         public float Duration;
         public TimeSpan LastFlash;
 
+        // <summary>
+        //   Chance to get EyeDamage on flash
+        // </summary>
+        [DataField("eyeDamageChance")]
+        public float EyeDamageChance = 0f;
+
+        // <summary>
+        //   How many EyeDamage when flashed? (If EyeDamageChance check passed)
+        // </summary>
+        [DataField("eyeDamage")]
+        public int EyeDamage = 0;
+
         [DataField]
         public CollisionGroup CollisionGroup = CollisionGroup.Opaque;
 
@@ -21,11 +33,15 @@ namespace Content.Shared.Flash
     {
         public float Duration { get; }
         public TimeSpan Time { get; }
+        public float EyeDamageChance { get; }
+        public int EyeDamage { get; }
 
-        public FlashableComponentState(float duration, TimeSpan time)
+        public FlashableComponentState(float duration, TimeSpan time, float eyeDamageChance, int eyeDamage)
         {
             Duration = duration;
             Time = time;
+            EyeDamageChance = eyeDamageChance;
+            EyeDamage = eyeDamage;
         }
     }
 

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Flash
 
         private static void OnFlashableGetState(EntityUid uid, FlashableComponent component, ref ComponentGetState args)
         {
-            args.State = new FlashableComponentState(component.Duration, component.LastFlash);
+            args.State = new FlashableComponentState(component.Duration, component.LastFlash, component.EyeDamageChance, component.EyeDamage);
         }
     }
 }

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -97,6 +97,11 @@
       Female: FemaleVulpkanin
       Unsexed: MaleVulpkanin
   - type: DogVision
+  # - type: DarkVision
+  # - type: ScentTracker
+  - type: Flashable
+    eyeDamageChance: 0.3
+    eyeDamage: 1
   - type: Wagging
   - type: LanguageKnowledge
     speaks:


### PR DESCRIPTION
![WarningTrystan](https://github.com/user-attachments/assets/958f868b-11b9-48f0-80ab-13d9ff243f06)
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR is the rework regarding the unique feature for vulpkanins, this is mostly due to the "FORCED" Issue by VM: https://github.com/Simple-Station/Einstein-Engines/issues/711

This PR will mostly add the new features that will mostly make Vulpkanins unique.

For Vulpkanin Stats changed please check this PR: https://github.com/Simple-Station/Einstein-Engines/pull/713

This is a WIP if you need access to edit this PR, please DM me on discord.

Currently planned:
- Flash Damge: Flashable has 2 new variables "EyeDamageChance" (Float) and "EyeDamage" (int), those are default to 0 but if changed could give a chance from 0 to 1 to give EyeDamage from the EyeDamage Value, this is not fixed to vulpkanin and can be added to anything with the "Flashable" Component.
- DarkVision: DarkVision goal will be to make that in the dark you will not be compleatly blind but being able to see, this feature will be mostly intresting for Vulpkanin as a unique part of them but also, Xenos, ect... and we could add variable to it to make it more modular.
- ScentTracker: ScentTracker should a way for vulpkanins or anything wih the component to track a scent, highlighting anyone/anything with that scent, could be washed with a soap or wash yourself to change/remove your scent.
Or we could do ScentTracker a sort of simillar thing as the FingerPrints but more simple and not as detailed to not just replace detective, a way that you can check all the scent of an object that give you a random scent string and you have to sniff the right person to compair it yourself, (Better note that every scent), should still be able to clean scent with a soap on an object or person.

Its one of both and would need discussion on how to aproch this.
- Vulpkanins Screams: I have 5 Fox Screams that need to be edited and need to be added in-game for vulpkanins with a lisence, just need to have the time to do it and this PR seem the perfect place for it.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Flash Damage
- [ ] ScentTracker System
- [ ] DarkVision
- [ ] Vulpkanin Screams

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

N/A

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: FoxxoTrystan
- add: Vulpkanin can now track Scents on objects and peoples.
- tweak: Vulpkanins eyes are sensetive, please dont flash them with lights as this could damage them.
- add: Vulpkanins can now see better in the dark!
- add: Vulpkanins now has their own screams!
