### PR TITLE
Various Floofstation Ports.

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -5178,3 +5178,21 @@ Entries:
       message: Dwarves receive the Liquor Lifeline trait for free.
   id: 6247
   time: '2024-08-10T20:59:22.0000000+00:00'
+- author: VMSolidus
+  changes:
+    - type: Add
+      message: >-
+        Being injured now lets you deal up to 20% more damage in melee combat to
+        simulate the adrenaline rush from taking a hit.
+    - type: Add
+      message: >-
+        Taking stamina damage now makes you deal less damage in melee. Up to 25%
+        less for Light Attacks, and 50% less for Power Attacks
+    - type: Add
+      message: >-
+        Wide Swing has been reworked as "Power Attack". Power attacks cost 20
+        stamina(by default) to perform, and their effects can differ from Light
+        attacks on a per-weapon basis. Individual weapons can also have
+        different stamina costs to power attack with.
+  id: 6248
+  time: '2024-08-10T21:30:42.0000000+00:00'

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -234,3 +234,36 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
+
+- type: entity #Fake goggles, the latest in anti-valid hunting technology
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesThermalBudget
+  name: red goggles
+  description: These don't have any real function, but they do look cool!
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Glasses/thermal.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Glasses/thermal.rsi
+
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesChemicalBudget
+  name: purple goggles
+  description: These don't have any real function, but they do look cool!
+  components:
+    - type: Sprite
+      sprite: Clothing/Eyes/Glasses/science.rsi
+    - type: Clothing
+      sprite: Clothing/Eyes/Glasses/science.rsi
+
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesMesonBudget
+  name: green goggles
+  description: These don't have any real function, but they do look cool!
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Glasses/meson.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Glasses/meson.rsi

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -76,6 +76,20 @@
     - ClothingOuterCoatLabSeniorResearcher
 
 - type: loadout
+  id: LoadoutScienceOuterExplorerLabcoat
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Scientist
+        - ResearchAssistant
+        - ResearchDirector
+  items:
+    - ClothingOuterExplorerCoat
+
+- type: loadout
   id: LoadoutScienceHatBeret
   category: Jobs
   cost: 1

--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -10,10 +10,6 @@
   category: Eyes
   cost: 1
   requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Nearsighted
   items:
     - ClothingEyesGlasses
 

--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -9,7 +9,6 @@
   id: LoadoutEyesGlasses
   category: Eyes
   cost: 1
-  requirements:
   items:
     - ClothingEyesGlasses
 

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -92,6 +92,54 @@
          - Security
 
 - type: loadout
+  id: LoadoutHeadHatCowboyBrown
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBrown
+
+- type: loadout
+  id: LoadoutHeadHatCowboyBlack
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBlack
+
+- type: loadout
+  id: LoadoutHeadHatCowboyGrey
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyGrey
+
+- type: loadout
+  id: LoadoutHeadHatCowboyRed
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyRed
+
+- type: loadout
+  id: LoadoutHeadHatCowboyWhite
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyWhite
+
+- type: loadout
+  id: LoadoutHeadHatCowboyBountyHunter
+  category: Head
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBountyHunter
+
+- type: loadout
   id: LoadoutHeadTinfoil
   category: Head
   cost: 3

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -155,6 +155,14 @@
   items:
     - ClothingHeadHatBellhop
 
+- type: loadout
+  id: LoadoutHeadFlower
+  category: Head
+  cost: 1
+  exclusive: true
+  items:
+    - ClothingHeadHatHairflower
+
 # Color Hats
 - type: loadout
   id: LoadoutHeadHatBluesoft

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -293,7 +293,6 @@
          - Security
          - Medical
          - Engineering
-         - Epistemics
     - !type:CharacterJobRequirement
        inverted: true
        jobs:


### PR DESCRIPTION
# Description

Various minor yaml and QOL ports from Floofstation.

Changelog entries go in order of author. I'm considering just copying over the changelog at some point.

# Changelog

:cl: AeraAuling, ShatteredSwords and Cynical24
- add: Added the Explorer's Labcoat and a Hairflower into Loadouts.
- fix: Fixed Epistemics being unable to take Survival Boxes
- fix: Fixed the NearSighted trait making you unable to take glasses in your loadout
- add: Added a variety of Cowboy Hats into loadouts.