### PR TITLE
Increase Trait Limit From 5 To 10

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -361,7 +361,7 @@ namespace Content.Shared.CCVar
         ///     How many traits a character can have at most.
         /// </summary>
         public static readonly CVarDef<int> GameTraitsMax =
-            CVarDef.Create("game.traits_max", 5, CVar.REPLICATED);
+            CVarDef.Create("game.traits_max", 10, CVar.REPLICATED);
 
         /// <summary>
         ///     How many points a character should start with.


### PR DESCRIPTION
# Description

Given the big influx of new traits, a maximum of 5 traits can feel constricting, as often you'll have unspent points but not enough trait slots to buy more traits. This doubles the default trait limit from 5 to 10 to increase player choice and allow more unique trait setups.

Since the base trait points have not been increased, players will still need to take negative traits if they want to have more positive traits than before.

## Changelog

:cl: Skubman
- tweak: The maximum trait limit has increased from 5 traits to 10 traits.