### PR TITLE
Remove the Stupid Station Records Check From News

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -141,9 +141,6 @@ public sealed class NewsSystem : SharedNewsSystem
         if (msg.Session.AttachedEntity is not { } author)
             return;
 
-        if (!_accessReader.FindStationRecordKeys(author, out _))
-            return;
-
         string? authorName = null;
         if (_idCardSystem.TryFindIdCard(author, out var idCard))
             authorName = idCard.Comp.FullName;


### PR DESCRIPTION
# Description
It was never used but caused annoyance all the time: the listening post could never use the news console and ghosts/centcom officials/skeletons could never publish news because of it.

(This was not tested, I recommend either waiting til I test it or making someone else test it before merging)

# Changelog
:cl:
- fix: You no longer need to have a station record to publish news.
