### PR TITLE
Useful Items In Loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/service.yml
@@ -92,6 +92,17 @@
   items:
     - BedsheetClown
 
+- type: loadout
+  id: LoadoutServiceClownCowToolboxFilled
+  category: Jobs
+  cost: 3
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Clown
+  items:
+    - CowToolboxFilled
+
 # Mime
 - type: loadout
   id: LoadoutServiceMimeOuterWinter

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -76,6 +76,21 @@
   items:
     - SmokingPipeFilledTobacco
 
+- type: loadout
+  id: LoadoutItemBlunt
+  category: Items
+  cost: 2
+  items:
+    - Blunt
+
+- type: loadout
+  id: LoadoutItemJoint
+  category: Items
+  cost: 2
+  items:
+    - Joint
+
+
 # Instruments
 - type: loadout
   id: LoadoutItemMicrophoneInstrument
@@ -278,6 +293,13 @@
   cost: 3
   items:
     - LunchboxGenericFilledRandom
+
+- type: loadout
+  id: LoadoutItemDrinkMREFlask
+  category: Items
+  cost: 2
+  items:
+    - DrinkMREFlask
 
 # Survival boxes
 - type: loadout
@@ -540,3 +562,38 @@
   cost: 3
   items:
     - HandLabeler
+
+- type: loadout
+  id: LoadoutItemHandheldStationMap
+  category: Items
+  cost: 2
+  items:
+    - HandheldStationMap
+
+- type: loadout
+  id: LoadoutItemLantern
+  category: Items
+  cost: 2
+  items:
+    - Lantern
+
+- type: loadout
+  id: LoadoutItemDrinkShinyFlask
+  category: Items
+  cost: 1
+  items:
+    - DrinkShinyFlask
+
+- type: loadout
+  id: LoadoutItemDrinkLithiumFlask
+  category: Items
+  cost: 1
+  items:
+    - DrinkLithiumFlask
+
+- type: loadout
+  id: LoadoutItemDrinkVacuumFlask
+  category: Items
+  cost: 1
+  items:
+    - DrinkVacuumFlask


### PR DESCRIPTION

# Description



This PR adds the Blunt and Joint in the Smokeables category, the Station Map, Lantern, MRE Flask, and undepartmentalized flasks in the misc category, and it adds Cow Tools for the clown in the Jobs category for 3 points.

---

# Changelog


:cl:
- add: Several useful items have been added to loadouts
- add: Cowtools are selectable for clown in the "Jobs" category of loadouts
