### PR TITLE
Fix Overlays

### DIFF
--- a/Content.Client/Overlays/DogVisionOverlay.cs
+++ b/Content.Client/Overlays/DogVisionOverlay.cs
@@ -2,9 +2,9 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using Content.Shared.Abilities;
+using Content.Shared.Traits.Assorted.Components;
 
-namespace Content.Client.Nyanotrasen.Overlays;
+namespace Content.Client.Overlays;
 
 public sealed partial class DogVisionOverlay : Overlay
 {
@@ -23,22 +23,27 @@ public sealed partial class DogVisionOverlay : Overlay
         _dogVisionShader = _prototypeManager.Index<ShaderPrototype>("DogVision").Instance().Duplicate();
     }
 
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<DogVisionComponent>(player))
+            return false;
+
+        return base.BeforeDraw(in args);
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
-            return;
-        if (_playerManager.LocalPlayer?.ControlledEntity is not {Valid: true} player)
-            return;
-        if (!_entityManager.HasComponent<DogVisionComponent>(player))
+        if (ScreenTexture is null)
             return;
 
-        _dogVisionShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-
+        _dogVisionShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
         worldHandle.SetTransform(Matrix3.Identity);
         worldHandle.UseShader(_dogVisionShader);
         worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null);
     }
 }

--- a/Content.Client/Overlays/DogVisionSystem.cs
+++ b/Content.Client/Overlays/DogVisionSystem.cs
@@ -1,14 +1,16 @@
-using Content.Shared.Abilities;
+using Content.Shared.Traits.Assorted.Components;
 using Content.Shared.DeltaV.CCVars;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 
-namespace Content.Client.Nyanotrasen.Overlays;
+namespace Content.Client.Overlays;
 
 public sealed partial class DogVisionSystem : EntitySystem
 {
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
 
     private DogVisionOverlay _overlay = default!;
 
@@ -18,6 +20,8 @@ public sealed partial class DogVisionSystem : EntitySystem
 
         SubscribeLocalEvent<DogVisionComponent, ComponentInit>(OnDogVisionInit);
         SubscribeLocalEvent<DogVisionComponent, ComponentShutdown>(OnDogVisionShutdown);
+        SubscribeLocalEvent<DogVisionComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<DogVisionComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
         Subs.CVar(_cfg, DCCVars.NoVisionFilters, OnNoVisionFiltersChanged);
 
@@ -26,11 +30,28 @@ public sealed partial class DogVisionSystem : EntitySystem
 
     private void OnDogVisionInit(EntityUid uid, DogVisionComponent component, ComponentInit args)
     {
+        if (uid != _playerMan.LocalEntity)
+            return;
+
         if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
             _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnDogVisionShutdown(EntityUid uid, DogVisionComponent component, ComponentShutdown args)
+    {
+        if (uid != _playerMan.LocalEntity)
+            return;
+
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, DogVisionComponent component, LocalPlayerAttachedEvent args)
+    {
+        if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
+            _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, DogVisionComponent component, LocalPlayerDetachedEvent args)
     {
         _overlayMan.RemoveOverlay(_overlay);
     }

--- a/Content.Client/Overlays/SaturationScaleOverlay.cs
+++ b/Content.Client/Overlays/SaturationScaleOverlay.cs
@@ -1,12 +1,17 @@
 ﻿using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
+using Content.Shared.Mood;
+using Content.Shared.Overlays;
 
 namespace Content.Client.Overlays;
 
 public sealed class SaturationScaleOverlay : Overlay
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] IEntityManager _entityManager = default!;
 
     public override bool RequestScreenTexture => true;
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -18,20 +23,29 @@ public sealed class SaturationScaleOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
 
-        _shader = _prototypeManager.Index<ShaderPrototype>("SaturationScale").InstanceUnique();
+        _shader = _prototypeManager.Index<ShaderPrototype>("SaturationScale").Instance().Duplicate();
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<SaturationScaleOverlayComponent>(player))
+            return false;
+
+        return base.BeforeDraw(in args);
     }
 
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
+        if (ScreenTexture is null)
             return;
 
         _shader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
         _shader.SetParameter("saturation", Saturation);
 
         var handle = args.WorldHandle;
-
+        handle.SetTransform(Matrix3.Identity);
         handle.UseShader(_shader);
         handle.DrawRect(args.WorldBounds, Color.White);
         handle.UseShader(null);

--- a/Content.Client/Overlays/SaturationScaleSystem.cs
+++ b/Content.Client/Overlays/SaturationScaleSystem.cs
@@ -1,15 +1,15 @@
 ﻿using Content.Shared.GameTicking;
+using Content.Shared.Mood;
 using Content.Shared.Overlays;
 using Robust.Client.Graphics;
-using Robust.Client.Player;
 using Robust.Shared.Player;
 
 namespace Content.Client.Overlays;
 
 public sealed class SaturationScaleSystem : EntitySystem
 {
-    [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
 
     private SaturationScaleOverlay _overlay = default!;
 
@@ -47,7 +47,7 @@ public sealed class SaturationScaleSystem : EntitySystem
 
     private void OnShutdown(EntityUid uid, SaturationScaleOverlayComponent component, ComponentShutdown args)
     {
-        if (_player.LocalSession?.AttachedEntity != uid)
+        if (uid != _playerMan.LocalEntity)
             return;
 
         _overlayMan.RemoveOverlay(_overlay);
@@ -55,7 +55,7 @@ public sealed class SaturationScaleSystem : EntitySystem
 
     private void OnInit(EntityUid uid, SaturationScaleOverlayComponent component, ComponentInit args)
     {
-        if (_player.LocalSession?.AttachedEntity != uid)
+        if (uid != _playerMan.LocalEntity)
             return;
 
         _overlayMan.AddOverlay(_overlay);

--- a/Content.Client/Overlays/UltraVisionOverlay.cs
+++ b/Content.Client/Overlays/UltraVisionOverlay.cs
@@ -2,9 +2,9 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using Content.Shared.Abilities;
+using Content.Shared.Traits.Assorted.Components;
 
-namespace Content.Client.DeltaV.Overlays;
+namespace Content.Client.Overlays;
 
 public sealed partial class UltraVisionOverlay : Overlay
 {
@@ -23,22 +23,27 @@ public sealed partial class UltraVisionOverlay : Overlay
         _ultraVisionShader = _prototypeManager.Index<ShaderPrototype>("UltraVision").Instance().Duplicate();
     }
 
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<UltraVisionComponent>(player))
+            return false;
+
+        return base.BeforeDraw(in args);
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
-            return;
-        if (_playerManager.LocalPlayer?.ControlledEntity is not {Valid: true} player)
-            return;
-        if (!_entityManager.HasComponent<UltraVisionComponent>(player))
+        if (ScreenTexture is null)
             return;
 
-        _ultraVisionShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-
+        _ultraVisionShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
         worldHandle.SetTransform(Matrix3.Identity);
         worldHandle.UseShader(_ultraVisionShader);
         worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null);
     }
 }

--- a/Content.Client/Overlays/UltraVisionSystem.cs
+++ b/Content.Client/Overlays/UltraVisionSystem.cs
@@ -1,14 +1,16 @@
-using Content.Shared.Abilities;
+using Content.Shared.Traits.Assorted.Components;
 using Content.Shared.DeltaV.CCVars;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 
-namespace Content.Client.DeltaV.Overlays;
+namespace Content.Client.Overlays;
 
 public sealed partial class UltraVisionSystem : EntitySystem
 {
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
 
     private UltraVisionOverlay _overlay = default!;
 
@@ -18,6 +20,8 @@ public sealed partial class UltraVisionSystem : EntitySystem
 
         SubscribeLocalEvent<UltraVisionComponent, ComponentInit>(OnUltraVisionInit);
         SubscribeLocalEvent<UltraVisionComponent, ComponentShutdown>(OnUltraVisionShutdown);
+        SubscribeLocalEvent<UltraVisionComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<UltraVisionComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
         Subs.CVar(_cfg, DCCVars.NoVisionFilters, OnNoVisionFiltersChanged);
 
@@ -26,11 +30,28 @@ public sealed partial class UltraVisionSystem : EntitySystem
 
     private void OnUltraVisionInit(EntityUid uid, UltraVisionComponent component, ComponentInit args)
     {
+        if (uid != _playerMan.LocalEntity)
+            return;
+
         if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
             _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnUltraVisionShutdown(EntityUid uid, UltraVisionComponent component, ComponentShutdown args)
+    {
+        if (uid != _playerMan.LocalEntity)
+            return;
+
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, UltraVisionComponent component, LocalPlayerAttachedEvent args)
+    {
+        if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
+            _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, UltraVisionComponent component, LocalPlayerDetachedEvent args)
     {
         _overlayMan.RemoveOverlay(_overlay);
     }

--- a/Content.Shared/DeltaV/Abilities/UltraVisionComponent.cs
+++ b/Content.Shared/DeltaV/Abilities/UltraVisionComponent.cs
@@ -1,8 +1,0 @@
-using Robust.Shared.GameStates;
-namespace Content.Shared.Abilities;
-
-[RegisterComponent]
-[NetworkedComponent]
-
-public sealed partial class UltraVisionComponent : Component
-{}

--- a/Content.Shared/Nyanotrasen/Abilities/DogVisionComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/DogVisionComponent.cs
@@ -1,8 +1,0 @@
-using Robust.Shared.GameStates;
-namespace Content.Shared.Abilities;
-
-[RegisterComponent]
-[NetworkedComponent]
-
-public sealed partial class DogVisionComponent : Component
-{}

--- a/Content.Shared/Traits/Assorted/Components/DogVisionComponent.cs
+++ b/Content.Shared/Traits/Assorted/Components/DogVisionComponent.cs
@@ -1,0 +1,5 @@
+using Robust.Shared.GameStates;
+namespace Content.Shared.Traits.Assorted.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DogVisionComponent : Component { }

--- a/Content.Shared/Traits/Assorted/Components/UltraVisionComponent.cs
+++ b/Content.Shared/Traits/Assorted/Components/UltraVisionComponent.cs
@@ -1,0 +1,5 @@
+using Robust.Shared.GameStates;
+namespace Content.Shared.Traits.Assorted.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class UltraVisionComponent : Component { }


### PR DESCRIPTION
# Description

Overlays have a funny bug where the calls to update them are global. Meaning if any single person gets a bad enough mood to greyscale themselves, everyone globally gets greyscaled. This bug was also present on Dogvision and Ultravision, and had the same cause. Frontier luckily had a fix for those two, and the fix works here as well for the Mood Overlay. 

# Changelog

:cl:
- fix: Fixed an issue where Overlays(Dogvision, Ultravision, Mood) would apply globally to all entities when updating.
