### PR TITLE
Implement Mind Contests

### DIFF
--- a/Content.Shared/Contests/ContestsSystem.cs
+++ b/Content.Shared/Contests/ContestsSystem.cs
@@ -30,7 +30,6 @@ namespace Content.Shared.Contests
         /// <summary>
         ///     Outputs the ratio of mass between a performer and the average human mass
         /// </summary>
-        /// <param name="performerUid">Uid of Performer</param>
         public float MassContest(EntityUid performerUid, bool bypassClamp = false, float rangeFactor = 1f, float otherMass = AverageMass)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -48,8 +47,7 @@ namespace Content.Shared.Contests
 
         /// <inheritdoc cref="MassContest(EntityUid, bool, float, float)"/>
         /// <remarks>
-        ///     MaybeMassContest, in case your entity doesn'so be ready to meet god if you bypass the clamp.
-        /// </remarks> exist
+        ///     MaybeMassContest, in case your entity doesn't exist
         /// </remarks>
         public float MassContest(EntityUid? performerUid, bool bypassClamp = false, float rangeFactor = 1f, float otherMass = AverageMass)
         {
@@ -65,7 +63,6 @@ namespace Content.Shared.Contests
         ///     Outputs the ratio of mass between a performer and the average human mass
         ///     If a function already has the performer's physics component, this is faster
         /// </summary>
-        /// <param name="performerPhysics"></param>
         public float MassContest(PhysicsComponent performerPhysics, bool bypassClamp = false, float rangeFactor = 1f, float otherMass = AverageMass)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -84,8 +81,6 @@ namespace Content.Shared.Contests
         ///     Outputs the ratio of mass between a performer and a target, accepts either EntityUids or PhysicsComponents in any combination
         ///     If you have physics components already in your function, use <see cref="MassContest(PhysicsComponent, float)" /> instead
         /// </summary>
-        /// <param name="performerUid"></param>
-        /// <param name="targetUid"></param>
         public float MassContest(EntityUid performerUid, EntityUid targetUid, bool bypassClamp = false, float rangeFactor = 1f)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -240,9 +235,6 @@ namespace Content.Shared.Contests
         /// <remarks>
         ///     This can produce some truly astounding modifiers, so be ready to meet god if you bypass the clamp.
         /// </remarks>
-        /// <param name="performer"></param>
-        /// <param name="bypassClamp"></param>
-        /// <param name="rangeFactor"></param>
         public float MindContest(EntityUid performer, bool bypassClamp = false, float rangeFactor = 1f, float otherPsion = AveragePsionicPotential)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -270,10 +262,6 @@ namespace Content.Shared.Contests
         /// <remarks>
         ///     This can produce some truly astounding modifiers, so be ready to meet god if you bypass the clamp.
         /// </remarks>
-        /// <param name="performer"></param>
-        /// <param name="target"></param>
-        /// <param name="bypassClamp"></param>
-        /// <param name="rangeFactor"></param>
         public float MindContest(EntityUid performer, EntityUid target, bool bypassClamp = false, float rangeFactor = 1f)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -305,9 +293,6 @@ namespace Content.Shared.Contests
         /// <summary>
         ///     Outputs the ratio of an Entity's mood level and its Neutral Mood threshold.
         /// </summary>
-        /// <param name="performer"></param>
-        /// <param name="bypassClamp"></param>
-        /// <param name="rangeFactor"></param>
         public float MoodContest(EntityUid performer, bool bypassClamp = false, float rangeFactor = 1f)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
@@ -325,10 +310,6 @@ namespace Content.Shared.Contests
         /// <summary>
         ///     Outputs the ratio of mood level between two Entities.
         /// </summary>
-        /// <param name="performer"></param>
-        /// <param name="target"></param>
-        /// <param name="bypassClamp"></param>
-        /// <param name="rangeFactor"></param>
         public float MoodContest(EntityUid performer, EntityUid target, bool bypassClamp = false, float rangeFactor = 1f)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)

--- a/Content.Shared/Contests/ContestsSystem.cs
+++ b/Content.Shared/Contests/ContestsSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Abilities.Psionics;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -18,6 +19,12 @@ namespace Content.Shared.Contests
         ///     Defaulted to the average mass of an adult human
         /// </summary>
         private const float AverageMass = 71f;
+
+        /// <summary>
+        ///     The presumed average sum of a Psionic's Baseline Amplification and Baseline Dampening.
+        ///     Since Baseline casting stats are a random value between 0.4 and 1.2, this is defaulted to 0.8 + 0.8.
+        /// </summary>
+        private const float AveragePsionicPotential = 1.6f;
 
         #region Mass Contests
         /// <summary>
@@ -41,7 +48,8 @@ namespace Content.Shared.Contests
 
         /// <inheritdoc cref="MassContest(EntityUid, bool, float, float)"/>
         /// <remarks>
-        ///     MaybeMassContest, in case your entity doesn't exist
+        ///     MaybeMassContest, in case your entity doesn'so be ready to meet god if you bypass the clamp.
+        /// </remarks> exist
         /// </remarks>
         public float MassContest(EntityUid? performerUid, bool bypassClamp = false, float rangeFactor = 1f, float otherMass = AverageMass)
         {
@@ -225,29 +233,69 @@ namespace Content.Shared.Contests
         #region Mind Contests
 
         /// <summary>
-        ///     These cannot be implemented until AFTER the psychic refactor, but can still be factored into other systems before that point.
-        ///     Same rule here as other Contest functions, simply multiply or divide by the function.
+        ///     Returns the ratio of casting stats between a performer and the presumed average latent psionic.
+        ///     Uniquely among Contests, not being Psionic is not a failure condition, and is instead a variable.
+        ///     If you do not have a PsionicComponent, your combined casting stats are assumed to be 0.1f
         /// </summary>
+        /// <remarks>
+        ///     This can produce some truly astounding modifiers, so be ready to meet god if you bypass the clamp.
+        /// </remarks>
         /// <param name="performer"></param>
         /// <param name="bypassClamp"></param>
         /// <param name="rangeFactor"></param>
-        /// <returns></returns>
-        public float MindContest(EntityUid performer, bool bypassClamp = false, float rangeFactor = 1f)
+        public float MindContest(EntityUid performer, bool bypassClamp = false, float rangeFactor = 1f, float otherPsion = AveragePsionicPotential)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
                 || !_cfg.GetCVar(CCVars.DoMindContests))
                 return 1f;
 
-            return 1f;
+            var performerPotential = TryComp<PsionicComponent>(performer, out var performerPsionic)
+                ? performerPsionic.CurrentAmplification + performerPsionic.CurrentDampening
+                : 0.1f;
+
+            if (performerPotential == otherPsion)
+                return 1f;
+
+            return _cfg.GetCVar(CCVars.AllowClampOverride) && bypassClamp
+                ? performerPotential / otherPsion
+                : Math.Clamp(performerPotential / otherPsion,
+                    1 - _cfg.GetCVar(CCVars.MassContestsMaxPercentage) * rangeFactor,
+                    1 + _cfg.GetCVar(CCVars.MassContestsMaxPercentage) * rangeFactor);
         }
 
+        /// <summary>
+        ///     Returns the ratio of casting stats between a performer and a target.
+        ///     Like with single-Uid MindContests, if an entity does not possess a PsionicComponent, its casting stats are assumed to be 0.1f.
+        /// </summary>
+        /// <remarks>
+        ///     This can produce some truly astounding modifiers, so be ready to meet god if you bypass the clamp.
+        /// </remarks>
+        /// <param name="performer"></param>
+        /// <param name="target"></param>
+        /// <param name="bypassClamp"></param>
+        /// <param name="rangeFactor"></param>
         public float MindContest(EntityUid performer, EntityUid target, bool bypassClamp = false, float rangeFactor = 1f)
         {
             if (!_cfg.GetCVar(CCVars.DoContestsSystem)
                 || !_cfg.GetCVar(CCVars.DoMindContests))
                 return 1f;
 
-            return 1f;
+            var performerPotential = TryComp<PsionicComponent>(performer, out var performerPsionic)
+                ? performerPsionic.CurrentAmplification + performerPsionic.CurrentDampening
+                : 0.1f;
+
+            var targetPotential = TryComp<PsionicComponent>(target, out var targetPsionic)
+                ? targetPsionic.CurrentAmplification + targetPsionic.CurrentDampening
+                : 0.1f;
+
+            if (performerPotential == targetPotential)
+                return 1f;
+
+            return _cfg.GetCVar(CCVars.AllowClampOverride) && bypassClamp
+                ? performerPotential / targetPotential
+                : Math.Clamp(performerPotential / targetPotential,
+                    1 - _cfg.GetCVar(CCVars.MassContestsMaxPercentage) * rangeFactor,
+                    1 + _cfg.GetCVar(CCVars.MassContestsMaxPercentage) * rangeFactor);
         }
 
         #endregion


### PR DESCRIPTION
# Description

Now that the initial Psionic Refactor is out of the way, this is my first new standalone Psionics PR, filling in the MindContest function that was added over a month ago(but was set to always return 1f as a placeholder). 

Mind Contests are unique among the Contests System in that they do not treat the lack of a Psionic Component as a failure condition, and instead as a variable.

No changelog because MindContests are not currently used anywhere, all I'm doing is adding the actual function logic. 
