### PR TITLE
Missing Psychic Trait Strings

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -196,3 +196,8 @@ trait-description-WeaponsGeneralist =
 
 trait-name-Singer = Singer
 trait-description-Singer = You are naturally capable of singing simple melodies with your voice.
+
+trait-name-LatentPsychic = Latent Psychic
+trait-description-LatentPsychic = Your mind and soul are open to the noosphere, allowing for use of Telepathy.
+                                  Thus, you are eligible for potentially receiving psychic powers.
+                                  It is possible that you may be hunted by otherworldly forces, so consider keeping your powers a secret.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -198,6 +198,7 @@ trait-name-Singer = Singer
 trait-description-Singer = You are naturally capable of singing simple melodies with your voice.
 
 trait-name-LatentPsychic = Latent Psychic
-trait-description-LatentPsychic = Your mind and soul are open to the noosphere, allowing for use of Telepathy.
-                                  Thus, you are eligible for potentially receiving psychic powers.
-                                  It is possible that you may be hunted by otherworldly forces, so consider keeping your powers a secret.
+trait-description-LatentPsychic =
+    Your mind and soul are open to the noosphere, allowing for use of Telepathy.
+    Thus, you are eligible for potentially receiving psychic powers.
+    It is possible that you may be hunted by otherworldly forces, so consider keeping your powers a secret.


### PR DESCRIPTION
# Description

I accidentally deleted these at some point, so here they are again.

![image](https://github.com/user-attachments/assets/c6216f11-f2bc-48a6-86ae-739de0cfe1df)

No changelog because I don't want to publicly admit the error. :)