### PR TITLE
Action Blacklists

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -65,6 +65,7 @@ namespace Content.Client.Actions
                 return;
 
             component.Whitelist = state.Whitelist;
+            component.Blacklist = state.Blacklist;
             component.CanTargetSelf = state.CanTargetSelf;
             BaseHandleState<EntityTargetActionComponent>(uid, component, state);
         }

--- a/Content.Server/Abilities/Psionics/Abilities/DispelPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/DispelPowerSystem.cs
@@ -38,9 +38,6 @@ namespace Content.Server.Abilities.Psionics
 
         private void OnPowerUsed(DispelPowerActionEvent args)
         {
-            if (HasComp<PsionicInsulationComponent>(args.Target))
-                return;
-
             var ev = new DispelledEvent();
             RaiseLocalEvent(args.Target, ev, false);
 

--- a/Content.Server/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -41,9 +41,6 @@ namespace Content.Server.Abilities.Psionics
             if (!(TryComp<DamageableComponent>(args.Target, out var damageable) && damageable.DamageContainerID == "Biological"))
                 return;
 
-            if (HasComp<PsionicInsulationComponent>(args.Target))
-                return;
-
             Swap(args.Performer, args.Target);
 
             _psionics.LogPowerUsed(args.Performer, "mind swap");

--- a/Content.Server/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
@@ -22,9 +22,6 @@ namespace Content.Server.Abilities.Psionics
 
         private void OnPowerUsed(NoosphericZapPowerActionEvent args)
         {
-            if (HasComp<PsionicInsulationComponent>(args.Target))
-                return;
-
             _beam.TryCreateBeam(args.Performer, args.Target, "LightningNoospheric");
 
             _stunSystem.TryParalyze(args.Target, TimeSpan.FromSeconds(5), false);

--- a/Content.Shared/Actions/EntityTargetActionComponent.cs
+++ b/Content.Shared/Actions/EntityTargetActionComponent.cs
@@ -12,24 +12,27 @@ public sealed partial class EntityTargetActionComponent : BaseTargetActionCompon
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
-    [DataField("event")]
+    [DataField]
     [NonSerialized]
     public EntityTargetActionEvent? Event;
 
-    [DataField("whitelist")] public EntityWhitelist? Whitelist;
+    [DataField] public EntityWhitelist? Whitelist;
+    [DataField] public EntityWhitelist? Blacklist;
 
-    [DataField("canTargetSelf")] public bool CanTargetSelf = true;
+    [DataField] public bool CanTargetSelf = true;
 }
 
 [Serializable, NetSerializable]
 public sealed class EntityTargetActionComponentState : BaseActionComponentState
 {
     public EntityWhitelist? Whitelist;
+    public EntityWhitelist? Blacklist;
     public bool CanTargetSelf;
 
     public EntityTargetActionComponentState(EntityTargetActionComponent component, IEntityManager entManager) : base(component, entManager)
     {
         Whitelist = component.Whitelist;
+        Blacklist = component.Blacklist;
         CanTargetSelf = component.CanTargetSelf;
     }
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -453,6 +453,9 @@ public abstract class SharedActionsSystem : EntitySystem
         if (action.Whitelist != null && !action.Whitelist.IsValid(target, EntityManager))
             return false;
 
+        if (action.Blacklist != null && action.Blacklist.IsValid(target, EntityManager))
+            return false;
+
         if (action.CheckCanInteract && !_actionBlockerSystem.CanInteract(user, target))
             return false;
 

--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -11,6 +11,10 @@
     range: 6
     itemIconStyle: BigAction
     canTargetSelf: false
+    blacklist:
+      components:
+        - PsionicInsulation
+        - Mindbroken
     event: !type:DispelPowerActionEvent
 
 - type: entity
@@ -39,6 +43,10 @@
     checkCanAccess: false
     range: 8
     itemIconStyle: BigAction
+    blacklist:
+      components:
+        - PsionicInsulation
+        - Mindbroken
     event: !type:MindSwapPowerActionEvent
 
 - type: entity
@@ -64,6 +72,10 @@
     useDelay: 100
     range: 5
     itemIconStyle: BigAction
+    blacklist:
+      components:
+        - PsionicInsulation
+        - Mindbroken
     event: !type:NoosphericZapPowerActionEvent
 
 - type: entity


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/febab792-59ca-4938-8f84-e4a94f2a5b31)

I noticed that EntityTargetAction prototypes have a Whitelist field, but no Blacklist field. This turned out to be trivial to add, and now it's no longer necessary for Psionic powers to hardcode in C# that they can't affect anyone psionically insulated or Mindbroken. In total only 3 powers had this change, but new powers in the future that affect a target can now arbitrarily blacklist any component(Most likely, PsionicInsulation and Mindbroken. :))

All of this, just to remove 9 total lines of C# hardcoding. 

# Changelog

:cl:
- add: Actions no longer need to hardcode in target blacklists, and can now blacklist entities in YML. This is notably useful for Psionic powers, which all share a common feature that they can't target people with Psionic Insulation (Or have been Mindbroken). 
