### PR TITLE
Minor Ifrit Health Rework

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -349,3 +349,14 @@
     Holy: 1.5
   flatReductions:
     Cold: 3
+
+- type: damageModifierSet
+  id: FireSpirit
+  coefficients:
+    Heat: 0.0
+    Cold: 0.5
+    Shock: 0.0
+    Blunt: 0.5
+    Slash: 0.5
+    Piercing: 0.5
+    Holy: 3.0

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -353,10 +353,9 @@
 - type: damageModifierSet
   id: FireSpirit
   coefficients:
-    Heat: 0.0
-    Cold: 0.5
-    Shock: 0.0
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
-    Holy: 3.0
+    Heat: 0
+    Cold: 1.2
+    Blunt: 0.6
+    Slash: 0.6
+    Piercing: 0.6
+    Holy: 1.5

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
@@ -1,4 +1,4 @@
-type: entity
+- type: entity
   parent: SimpleSpaceMobBase
   id: MobIfritFamiliar
   name: Ifrit

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
@@ -1,4 +1,4 @@
-- type: entity
+type: entity
   parent: SimpleSpaceMobBase
   id: MobIfritFamiliar
   name: Ifrit
@@ -62,7 +62,16 @@
   - type: Dispellable
   - type: Damageable
     damageContainer: CorporealSpirit
-    damageModifierSet: CorporealSpirit
+    damageModifierSet: FireSpirit
+  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
+    allowedStates:
+    - Alive
+    damageCap: 120
+    damage:
+      types:
+        Cold: -0.07
+      groups:
+        Brute: -0.07
   - type: Speech
     speechSounds: Bass
   - type: Puller
@@ -109,7 +118,7 @@
     requirements:
     - !type:DepartmentTimeRequirement
       department: Epistemics
-      time: 14400 # DeltaV - 4 hours
+      time: 14400 # 4 hours
 
 - type: entity
   parent: WelderExperimental


### PR DESCRIPTION
# Description
Closes #754

Ifrit is a fire spirit, he really shouldn't be taking 1.5x fire damage. This makes sense and should help with players accidentally killing themselves with the fire ball. 
For balance, the cold damage modifier was changed to 0.5x, unsure if it should be lower.

Minor passive regeneration has also been added, since there isn't another way to heal other than the Mystagogue sitting there hitting them with the book of mysteries.

# Changelog

:cl: 
- tweak: Ifrit has received some damage resistance changes