### PR TITLE
Psionic Powers Add Components With Arguments.

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
+using Robust.Shared.Serialization.Manager;
 using Content.Shared.Psionics;
 using System.Linq;
 
@@ -23,6 +23,7 @@ namespace Content.Server.Abilities.Psionics
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly SharedPopupSystem _popups = default!;
+        [Dependency] private readonly ISerializationManager _serialization = default!;
 
         private ProtoId<WeightedRandomPrototype> _pool = "RandomPsionicPowerPool";
         private const string GenericInitializationMessage = "generic-power-initialization-feedback";
@@ -265,13 +266,14 @@ namespace Content.Server.Abilities.Psionics
             if (proto.Components is null)
                 return;
 
-            foreach (var comp in proto.Components)
+            foreach (var entry in proto.Components.Values)
             {
-                var powerComp = (Component) _componentFactory.GetComponent(comp.Key);
-                if (EntityManager.HasComponent(uid, powerComp.GetType()))
+                if (HasComp(uid, entry.Component.GetType()))
                     continue;
 
-                AddComp(uid, powerComp);
+                var comp = (Component) _serialization.CreateCopy(entry.Component, notNullableOverride: true);
+                comp.Owner = uid;
+                EntityManager.AddComponent(uid, comp);
             }
         }
 


### PR DESCRIPTION
# Description

While coding another Psionic Power feature, I discovered that the current implementation of iterating over components does not carry over arguments for the components. So I copied over the method used by Traits exactly-as-is, and just changed the names of the variables to accommodate the PsionicSystem.

# Changelog

:cl:
- add: PsionicPowers that add a Component now also allow for adding a Component with Arguments. This works exactly like the trait system's implementation of components.
