### PR TITLE
Traits Refactor

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -140,8 +140,7 @@ namespace Content.Server.Abilities.Psionics
         /// <param name="playPopup"></param>
         public void InitializePsionicPower(EntityUid uid, PsionicPowerPrototype proto, bool playPopup = true)
         {
-            if (!TryComp<PsionicComponent>(uid, out var psionic))
-                return;
+            EnsureComp<PsionicComponent>(uid, out var psionic);
 
             InitializePsionicPower(uid, proto, psionic, playPopup);
         }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -49,10 +49,20 @@ public sealed class TraitSystem : EntitySystem
                 out _))
                 continue;
 
-            AddTraitComponents(args.Mob, traitPrototype);
-            AddTraitActions(args.Mob, traitPrototype);
-            AddTraitPsionics(args.Mob, traitPrototype);
+            AddTrait(args.Mob, traitPrototype);
         }
+    }
+
+    /// <summary>
+    ///     Adds a single Trait Prototype to an Entity.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="traitPrototype"></param>
+    public void AddTrait(EntityUid uid, TraitPrototype traitPrototype)
+    {
+        AddTraitComponents(uid, traitPrototype);
+        AddTraitActions(uid, traitPrototype);
+        AddTraitPsionics(uid, traitPrototype);
     }
 
     /// <summary>
@@ -60,7 +70,7 @@ public sealed class TraitSystem : EntitySystem
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="traitPrototype"></param>
-    private void AddTraitComponents(EntityUid uid, TraitPrototype traitPrototype)
+    public void AddTraitComponents(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.Components is null)
             return;
@@ -82,7 +92,7 @@ public sealed class TraitSystem : EntitySystem
     /// <param name="uid"></param>
     /// <param name="proto"></param>
     /// <param name="psionic"></param>
-    private void AddTraitActions(EntityUid uid, TraitPrototype traitPrototype)
+    public void AddTraitActions(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.Actions is null)
             return;
@@ -103,7 +113,7 @@ public sealed class TraitSystem : EntitySystem
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="traitPrototype"></param>
-    private void AddTraitPsionics(EntityUid uid, TraitPrototype traitPrototype)
+    public void AddTraitPsionics(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.PsionicPowers is null)
             return;

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -56,8 +56,6 @@ public sealed class TraitSystem : EntitySystem
     /// <summary>
     ///     Adds a single Trait Prototype to an Entity.
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="traitPrototype"></param>
     public void AddTrait(EntityUid uid, TraitPrototype traitPrototype)
     {
         AddTraitComponents(uid, traitPrototype);
@@ -68,8 +66,6 @@ public sealed class TraitSystem : EntitySystem
     /// <summary>
     ///     Adds all Components included with a Trait.
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="traitPrototype"></param>
     public void AddTraitComponents(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.Components is null)
@@ -89,9 +85,6 @@ public sealed class TraitSystem : EntitySystem
     /// <summary>
     ///     Add all actions associated with a specific Trait
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="proto"></param>
-    /// <param name="psionic"></param>
     public void AddTraitActions(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.Actions is null)
@@ -111,8 +104,6 @@ public sealed class TraitSystem : EntitySystem
     ///     If a trait includes any Psionic Powers, this enters the powers into PsionicSystem to be initialized.
     ///     If the lack of logic here seems startling, it's okay. All of the logic necessary for adding Psionics is handled by InitializePsionicPower.
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="traitPrototype"></param>
     public void AddTraitPsionics(EntityUid uid, TraitPrototype traitPrototype)
     {
         if (traitPrototype.PsionicPowers is null)

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -49,14 +49,9 @@ public sealed class TraitSystem : EntitySystem
                 out _))
                 continue;
 
-            if (traitPrototype.Components is not null)
-                AddTraitComponents(args.Mob, traitPrototype);
-
-            if (traitPrototype.Actions is not null)
-                AddTraitActions(args.Mob, traitPrototype);
-
-            if (traitPrototype.PsionicPowers is not null)
-                AddTraitPsionics(args.Mob, traitPrototype);
+            AddTraitComponents(args.Mob, traitPrototype);
+            AddTraitActions(args.Mob, traitPrototype);
+            AddTraitPsionics(args.Mob, traitPrototype);
         }
     }
 
@@ -67,6 +62,9 @@ public sealed class TraitSystem : EntitySystem
     /// <param name="traitPrototype"></param>
     private void AddTraitComponents(EntityUid uid, TraitPrototype traitPrototype)
     {
+        if (traitPrototype.Components is null)
+            return;
+
         foreach (var entry in traitPrototype.Components.Values)
         {
             if (HasComp(uid, entry.Component.GetType()))
@@ -86,6 +84,9 @@ public sealed class TraitSystem : EntitySystem
     /// <param name="psionic"></param>
     private void AddTraitActions(EntityUid uid, TraitPrototype traitPrototype)
     {
+        if (traitPrototype.Actions is null)
+            return;
+
         foreach (var id in traitPrototype.Actions)
         {
             EntityUid? actionId = null;
@@ -98,11 +99,15 @@ public sealed class TraitSystem : EntitySystem
 
     /// <summary>
     ///     If a trait includes any Psionic Powers, this enters the powers into PsionicSystem to be initialized.
+    ///     If the lack of logic here seems startling, it's okay. All of the logic necessary for adding Psionics is handled by InitializePsionicPower.
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="traitPrototype"></param>
     private void AddTraitPsionics(EntityUid uid, TraitPrototype traitPrototype)
     {
+        if (traitPrototype.PsionicPowers is null)
+            return;
+
         foreach (var powerProto in traitPrototype.PsionicPowers)
             _psionicAbilities.InitializePsionicPower(uid, powerProto, false);
     }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -1,16 +1,15 @@
 using System.Linq;
+using Content.Shared.Actions;
 using Content.Server.GameTicking;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.Customization.Systems;
-using Content.Shared.Hands.Components;
-using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Players;
 using Content.Shared.Roles;
 using Content.Shared.Traits;
-using Pidgin.Configuration;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
+using Content.Server.Abilities.Psionics;
 
 namespace Content.Server.Traits;
 
@@ -18,10 +17,11 @@ public sealed class TraitSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly ISerializationManager _serialization = default!;
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly CharacterRequirementsSystem _characterRequirements = default!;
     [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
     [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly PsionicAbilitiesSystem _psionicAbilities = default!;
 
     public override void Initialize()
     {
@@ -49,16 +49,61 @@ public sealed class TraitSystem : EntitySystem
                 out _))
                 continue;
 
-            // Add all components required by the prototype
-            foreach (var entry in traitPrototype.Components.Values)
-            {
-                if (HasComp(args.Mob, entry.Component.GetType()))
-                    continue;
+            if (traitPrototype.Components is not null)
+                AddTraitComponents(args.Mob, traitPrototype);
 
-                var comp = (Component) _serialization.CreateCopy(entry.Component, notNullableOverride: true);
-                comp.Owner = args.Mob;
-                EntityManager.AddComponent(args.Mob, comp);
+            if (traitPrototype.Actions is not null)
+                AddTraitActions(args.Mob, traitPrototype);
+
+            if (traitPrototype.PsionicPowers is not null)
+                AddTraitPsionics(args.Mob, traitPrototype);
+        }
+    }
+
+    /// <summary>
+    ///     Adds all Components included with a Trait.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="traitPrototype"></param>
+    private void AddTraitComponents(EntityUid uid, TraitPrototype traitPrototype)
+    {
+        foreach (var entry in traitPrototype.Components.Values)
+        {
+            if (HasComp(uid, entry.Component.GetType()))
+                continue;
+
+            var comp = (Component) _serialization.CreateCopy(entry.Component, notNullableOverride: true);
+            comp.Owner = uid;
+            EntityManager.AddComponent(uid, comp);
+        }
+    }
+
+    /// <summary>
+    ///     Add all actions associated with a specific Trait
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="proto"></param>
+    /// <param name="psionic"></param>
+    private void AddTraitActions(EntityUid uid, TraitPrototype traitPrototype)
+    {
+        foreach (var id in traitPrototype.Actions)
+        {
+            EntityUid? actionId = null;
+            if (_actions.AddAction(uid, ref actionId, id))
+            {
+                _actions.StartUseDelay(actionId);
             }
         }
+    }
+
+    /// <summary>
+    ///     If a trait includes any Psionic Powers, this enters the powers into PsionicSystem to be initialized.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="traitPrototype"></param>
+    private void AddTraitPsionics(EntityUid uid, TraitPrototype traitPrototype)
+    {
+        foreach (var powerProto in traitPrototype.PsionicPowers)
+            _psionicAbilities.InitializePsionicPower(uid, powerProto, false);
     }
 }

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -35,17 +35,17 @@ public sealed partial class TraitPrototype : IPrototype
     ///     The components that get added to the player when they pick this trait.
     /// </summary>
     [DataField]
-    public ComponentRegistry Components { get; private set; } = default!;
+    public ComponentRegistry? Components { get; private set; } = default!;
 
     /// <summary>
     ///     The list of each Action that this trait adds in the form of ActionId and ActionEntity
     /// </summary>
     [DataField]
-    public List<EntProtoId> Actions { get; private set; } = default!;
+    public List<EntProtoId>? Actions { get; private set; } = default!;
 
     /// <summary>
     ///     The list of all Psionic Powers that this trait adds. If this list is not empty, the trait will also Ensure that a player is Psionic.
     /// </summary>
     [DataField]
-    public List<PsionicPowerPrototype> PsionicPowers { get; private set; } = default!;
+    public List<PsionicPowerPrototype>? PsionicPowers { get; private set; } = default!;
 }

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -1,5 +1,5 @@
 using Content.Shared.Customization.Systems;
-using Content.Shared.Whitelist;
+using Content.Shared.Psionics;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Traits;
@@ -34,6 +34,18 @@ public sealed partial class TraitPrototype : IPrototype
     /// <summary>
     ///     The components that get added to the player when they pick this trait.
     /// </summary>
-    [DataField(required: true)]
+    [DataField]
     public ComponentRegistry Components { get; private set; } = default!;
+
+    /// <summary>
+    ///     The list of each Action that this trait adds in the form of ActionId and ActionEntity
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> Actions { get; private set; } = default!;
+
+    /// <summary>
+    ///     The list of all Psionic Powers that this trait adds. If this list is not empty, the trait will also Ensure that a player is Psionic.
+    /// </summary>
+    [DataField]
+    public List<PsionicPowerPrototype> PsionicPowers { get; private set; } = default!;
 }


### PR DESCRIPTION
# Description

I decided traits weren't flexible enough, so I refactored them to also optionally add Actions(Activatable Abilities), and PsionicPowers(Going through the PsionicAbilitiesSystem). Neither of these have any current implementations, I'll leave that to other people. Trait Components are by extension no longer a hard requirement, although if you add a blank trait that adds nothing, you have only yourself to blame. But doing so won't crash the game or throw an error anyway.

# Changelog

:cl:
- add: Traits can now add Active Abilities to a character.
- add: Traits can now add Psionic Powers to a character.
