### PR TITLE
Add Insulation to Robots

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -223,6 +223,7 @@
     understands:
     - GalacticCommon
     - RobotTalk
+  - type: PsionicInsulaion
 
 - type: entity
   id: BaseBorgChassisNT

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -223,7 +223,7 @@
     understands:
     - GalacticCommon
     - RobotTalk
-  - type: PsionicInsulaion
+  - type: PsionicInsulation
 
 - type: entity
   id: BaseBorgChassisNT

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -43,3 +43,4 @@
     damage:
       types:
         Blunt: 20
+  - type: PsionicInsulaion

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -43,4 +43,4 @@
     damage:
       types:
         Blunt: 20
-  - type: PsionicInsulaion
+  - type: PsionicInsulation

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -113,6 +113,7 @@
     understands:
     - GalacticCommon
     - RobotTalk
+  - type: PsionicInsulaion
 
 - type: entity
   parent: MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -113,7 +113,7 @@
     understands:
     - GalacticCommon
     - RobotTalk
-  - type: PsionicInsulaion
+  - type: PsionicInsulation
 
 - type: entity
   parent: MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -97,11 +97,9 @@
   - type: DeadStartupButton
     sound:
       path: /Audio/Effects/Silicon/startup.ogg
-# Erro de linter
-#   - type: Wires
-#     layoutId: IPC
   - type: EmitBuzzWhileDamaged
   - type: CanHostGuardian
+  - type: PsionicInsulation
 
 
 - type: entity


### PR DESCRIPTION
# Description

Soulless Robots didn't have PsionicInsulation, which meant they were eligible targets for powers such as Mindswap. This is a pretty simple fix. 

# Changelog
:cl:
- fix: Robots and other mechanical creatures are now correctly immune to non-physical psionic powers. 
