### PR TITLE
Increase Trait Point Granularity

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -367,7 +367,7 @@ namespace Content.Shared.CCVar
         ///     How many points a character should start with.
         /// </summary>
         public static readonly CVarDef<int> GameTraitsDefaultPoints =
-            CVarDef.Create("game.traits_default_points", 5, CVar.REPLICATED);
+            CVarDef.Create("game.traits_default_points", 10, CVar.REPLICATED);
 
 
         /// <summary>
@@ -2299,7 +2299,7 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<float> StationGoalsChance =
             CVarDef.Create("game.station_goals_chance", 0.1f, CVar.SERVERONLY);
-            
+
 
         #region CPR System
         /// <summary>
@@ -2346,7 +2346,7 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<float> CPRAirlossReductionMultiplier =
             CVarDef.Create("cpr.airloss_reduction_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
-            
+
         #endregion
 
         #region Contests System

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Blindness
   category: Visual
-  points: 2
+  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -14,7 +14,7 @@
 - type: trait
   id: Narcolepsy
   category: Mental
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -33,14 +33,14 @@
 - type: trait
   id: Pacifist
   category: Mental
-  points: 3
+  points: 6
   components:
     - type: Pacified
 
 - type: trait
   id: Paracusia
   category: Auditory
-  points: 1
+  points: 2
   components:
     - type: Paracusia
       minTimeBetweenIncidents: 0.1
@@ -52,7 +52,7 @@
 - type: trait
   id: Muted
   category: Speech
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -65,7 +65,7 @@
 - type: trait
   id: Uncloneable
   category: Physical
-  points: 2
+  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -110,7 +110,7 @@
 - type: trait
   id: Sluggish
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -133,7 +133,7 @@
 - type: trait
   id: SnailPaced
   category: Physical
-  points: 2
+  points: 4
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -156,7 +156,7 @@
 - type: trait
   id: BloodDeficiency
   category: Physical
-  points: 2
+  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -174,7 +174,7 @@
 - type: trait
   id: Hemophilia
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -40,7 +40,7 @@
 - type: trait
   id: ForeignerLight
   category: Mental
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -54,7 +54,7 @@
 - type: trait
   id: Foreigner
   category: Mental
-  points: 2
+  points: 4
   requirements: # TODO: Add a requirement to know at least 1 non-gc language
     - !type:CharacterTraitRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -7,7 +7,7 @@
 - type: trait
   id: Accentless
   category: Speech
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -42,7 +42,7 @@
 - type: trait
   id: Saturnine
   category: Mental
-  points: 3
+  points: 6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -60,7 +60,7 @@
 - type: trait
   id: Sanguine
   category: Mental
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: WillToLive
   category: Physical
-  points: -2
+  points: -4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -23,7 +23,7 @@
 - type: trait
   id: WillToDie
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -45,7 +45,7 @@
 - type: trait
   id: Tenacity
   category: Physical
-  points: -2
+  points: -4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -67,7 +67,7 @@
 - type: trait
   id: GlassJaw
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -89,7 +89,7 @@
 - type: trait
   id: Vigor
   category: Physical
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -112,7 +112,7 @@
 - type: trait
   id: Lethargy
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -134,7 +134,7 @@
 - type: trait
   id: HighAdrenaline
   category: Physical
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -157,7 +157,7 @@
 - type: trait
   id: AdrenalDysfunction
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -179,7 +179,7 @@
 - type: trait
   id: Masochism
   category: Physical
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -198,7 +198,7 @@
 - type: trait
   id: LowPainTolerance
   category: Physical
-  points: 1
+  points: 2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -216,7 +216,7 @@
 - type: trait
   id: MartialArtist
   category: Physical
-  points: -2
+  points: -4
   requirements:
   - !type:CharacterJobRequirement
     inverted: true

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: CPRTraining
   category: Mental
-  points: -2
+  points: -4
   components:
     - type: CPRTraining
   requirements:
@@ -18,7 +18,7 @@
 - type: trait
   id: SelfAware
   category: Mental
-  points: -2
+  points: -4
   components:
     - type: SelfAware
       analyzableTypes:
@@ -36,7 +36,7 @@
 - type: trait
   id: HeavyweightDrunk
   category: Physical
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -60,7 +60,7 @@
 - type: trait
   id: LiquorLifeline
   category: Physical
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -85,7 +85,7 @@
 - type: trait
   id: Thieving
   category: Physical
-  points: -4
+  points: -8
   components:
     - type: Thieving
       ignoreStripHidden: true
@@ -101,7 +101,7 @@
 - type: trait
   id: SignLanguage
   category: Visual
-  points: -1
+  points: -2
   components:
     - type: LanguageKnowledgeModifier
       speaks:
@@ -112,7 +112,7 @@
 - type: trait
   id: Voracious
   category: Physical
-  points: -1
+  points: -2
   components:
     - type: ConsumeDelayModifier
       foodDelayMultiplier: 0.5
@@ -127,7 +127,7 @@
 - type: trait
   id: ParkourTraining
   category: Physical
-  points: -3
+  points: -6
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -148,7 +148,7 @@
 - type: trait
   id: LightStep
   category: Auditory
-  points: -1
+  points: -2
   components:
     - type: FootstepVolumeModifier
       sprintVolumeModifier: -10
@@ -162,7 +162,7 @@
 - type: trait
   id: Singer
   category: Auditory
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true
@@ -175,7 +175,7 @@
 - type: trait
   id: LatentPsychic
   category: Mental
-  points: -3
+  points: -6
   components:
     - type: Psionic
   requirements:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Swashbuckler
   category: Physical
-  points: -1
+  points: -2
   components:
   - type: OniDamageModifier
     modifiers:
@@ -22,7 +22,7 @@
 - type: trait
   id: Spearmaster
   category: Physical
-  points: -1
+  points: -2
   components:
   - type: OniDamageModifier
     modifiers:
@@ -43,7 +43,7 @@
 - type: trait
   id: WeaponsGeneralist
   category: Physical
-  points: -1
+  points: -2
   components:
   - type: OniDamageModifier
     modifiers:


### PR DESCRIPTION
# Description

Since we now have a LOT of Traits, and soon to be another fresh batch of Traits coming in now that they've been refactored to offer even more options, it's come up that Traits are kinda hard to balance with the current combination of point costs and allotted starting points. To help alleviate this problem, I've both doubled the point values of every trait in the game, as well as doubled the default allotted starting points. There is now more room to balance trait costs against each other.

I have not however actually made use of the new range of point costs yet, and would like to consult with other contributors and maintainers on which traits need to be adjusted. 

# TODO

- [ ] Go over trait point costs again to address balance.
- [ ] Do this again in 6 months when we have 200 traits.

# Changelog

:cl:
- tweak: Trait points have been made more granular by both doubling the available number of trait points, and increasing the base cost of all pre-existing traits.
