### PR TITLE
Psionic Power Feedback Messages

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -285,7 +285,7 @@ namespace Content.Server.Abilities.Psionics
             if (proto.InitializationFeedback is null)
                 return;
 
-            var feedbackMessage = Loc.GetString($"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{proto.InitializationFeedback}[/color][/font]");
+            var feedbackMessage = $"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{Loc.GetString(proto.InitializationFeedback)}[/color][/font]";
             _chatManager.ChatMessageToOne(
                 proto.InitializationFeedbackChannel,
                 feedbackMessage,

--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -285,7 +285,9 @@ namespace Content.Server.Abilities.Psionics
             if (proto.InitializationFeedback is null)
                 return;
 
-            var feedbackMessage = $"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{Loc.GetString(proto.InitializationFeedback)}[/color][/font]";
+            if (!Loc.TryGetString(proto.InitializationFeedback, out var feedback))
+                return;
+            var feedbackMessage = $"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{feedback}[/color][/font]";
             _chatManager.ChatMessageToOne(
                 proto.InitializationFeedbackChannel,
                 feedbackMessage,

--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Actions;
-using Content.Shared.Chat;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;
 using Content.Shared.Random;
@@ -95,7 +94,7 @@ namespace Content.Server.Abilities.Psionics
                 _prototypeManager.TryIndex<PsionicPowerPrototype>(s, out var p) &&
                 psionic.ActivePowers.Contains(p));
 
-            if (newPool is null)
+            if (newPool.Count == 0)
                 return;
 
             var newProto = _random.Pick(newPool);
@@ -286,7 +285,7 @@ namespace Content.Server.Abilities.Psionics
             if (proto.InitializationFeedback is null)
                 return;
 
-            var feedbackMessage = $"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{proto.InitializationFeedback}[/color][/font]";
+            var feedbackMessage = Loc.GetString($"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{proto.InitializationFeedback}[/color][/font]");
             _chatManager.ChatMessageToOne(
                 proto.InitializationFeedbackChannel,
                 feedbackMessage,

--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Actions;
+using Content.Shared.Chat;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;
 using Content.Shared.Random;
@@ -10,6 +11,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Content.Shared.Psionics;
 using System.Linq;
+using Robust.Server.Player;
+using Content.Server.Chat.Managers;
 
 namespace Content.Server.Abilities.Psionics
 {
@@ -24,6 +27,8 @@ namespace Content.Server.Abilities.Psionics
         [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly SharedPopupSystem _popups = default!;
         [Dependency] private readonly ISerializationManager _serialization = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly IChatManager _chatManager = default!;
 
         private ProtoId<WeightedRandomPrototype> _pool = "RandomPsionicPowerPool";
         private const string GenericInitializationMessage = "generic-power-initialization-feedback";
@@ -38,9 +43,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Special use-case for a InnatePsionicPowers, which allows an entity to start with any number of Psionic Powers.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="comp"></param>
-        /// <param name="args"></param>
         private void InnatePowerStartup(EntityUid uid, InnatePsionicPowersComponent comp, ComponentStartup args)
         {
             // Any entity with InnatePowers should also be psionic, but in case they aren't already...
@@ -64,7 +66,6 @@ namespace Content.Server.Abilities.Psionics
         ///     The most shorthand route to creating a Psion. If an entity is not already psionic, it becomes one. This also adds a random new PsionicPower.
         ///     To create a "Latent Psychic"(Psion with no powers) just add or ensure the PsionicComponent normally.
         /// </summary>
-        /// <param name="uid"></param>
         public void AddPsionics(EntityUid uid)
         {
             if (Deleted(uid))
@@ -77,7 +78,6 @@ namespace Content.Server.Abilities.Psionics
         ///     Pretty straightforward, adds a random psionic power to a given Entity. If that Entity is not already Psychic, it will be made one.
         ///     If an entity already has all possible powers, this will not add any new ones.
         /// </summary>
-        /// <param name="uid"></param>
         public void AddRandomPsionicPower(EntityUid uid)
         {
             // We need to EnsureComp here to make sure that we aren't iterating over a component that:
@@ -110,11 +110,7 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Initializes a new Psionic Power on a given entity, assuming the entity does not already have said power initialized.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="proto"></param>
-        /// <param name="psionic"></param>
-        /// <param name="playPopup"></param>
-        public void InitializePsionicPower(EntityUid uid, PsionicPowerPrototype proto, PsionicComponent psionic, bool playPopup = true)
+        public void InitializePsionicPower(EntityUid uid, PsionicPowerPrototype proto, PsionicComponent psionic, bool playFeedback = true)
         {
             if (!_prototypeManager.HasIndex<PsionicPowerPrototype>(proto.ID)
                 || psionic.ActivePowers.Contains(proto))
@@ -126,31 +122,23 @@ namespace Content.Server.Abilities.Psionics
             AddPsionicPowerComponents(uid, proto);
             AddPsionicStatSources(proto, psionic);
             RefreshPsionicModifiers(uid, psionic);
-
-            if (playPopup)
-                _popups.PopupEntity(Loc.GetString(GenericInitializationMessage), uid, uid, PopupType.MediumCaution);
-            // TODO: Replace this with chat message: _popups.PopupEntity(proto.InitializationFeedback, uid, uid, PopupType.MediumCaution);
+            SendFeedbackMessage(uid, proto, playFeedback);
+            //SendFeedbackAudio(uid, proto, playPopup); // TODO: This one is coming next!
         }
 
         /// <summary>
         ///     Initializes a new Psionic Power on a given entity, assuming the entity does not already have said power initialized.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="proto"></param>
-        /// <param name="psionic"></param>
-        /// <param name="playPopup"></param>
-        public void InitializePsionicPower(EntityUid uid, PsionicPowerPrototype proto, bool playPopup = true)
+        public void InitializePsionicPower(EntityUid uid, PsionicPowerPrototype proto, bool playFeedback = true)
         {
             EnsureComp<PsionicComponent>(uid, out var psionic);
 
-            InitializePsionicPower(uid, proto, psionic, playPopup);
+            InitializePsionicPower(uid, proto, psionic, playFeedback);
         }
 
         /// <summary>
         ///     Updates a Psion's casting stats, call this anytime a system adds a new source of Amp or Damp.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="comp"></param>
         public void RefreshPsionicModifiers(EntityUid uid, PsionicComponent comp)
         {
             var ampModifier = 0f;
@@ -173,7 +161,6 @@ namespace Content.Server.Abilities.Psionics
         ///     Updates a Psion's casting stats, call this anytime a system adds a new source of Amp or Damp.
         ///     Variant function for systems that didn't already have the PsionicComponent.
         /// </summary>
-        /// <param name="uid"></param>
         public void RefreshPsionicModifiers(EntityUid uid)
         {
             if (!TryComp<PsionicComponent>(uid, out var comp))
@@ -186,7 +173,6 @@ namespace Content.Server.Abilities.Psionics
         ///     A more advanced form of removing powers. Mindbreaking not only removes all psionic powers,
         ///     it also disables the possibility of obtaining new ones.
         /// </summary>
-        /// <param name="uid"></param>
         public void MindBreak(EntityUid uid)
         {
             RemoveAllPsionicPowers(uid, true);
@@ -196,8 +182,6 @@ namespace Content.Server.Abilities.Psionics
         ///     Remove all Psionic powers, with accompanying actions, components, and casting stat sources, from a given Psion.
         ///     Optionally, the Psion can also be rendered permanently non-Psionic.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="mindbreak"></param>
         public void RemoveAllPsionicPowers(EntityUid uid, bool mindbreak = false)
         {
             if (!TryComp<PsionicComponent>(uid, out var psionic)
@@ -239,9 +223,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Add all actions associated with a specific Psionic Power
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="proto"></param>
-        /// <param name="psionic"></param>
         private void AddPsionicActions(EntityUid uid, PsionicPowerPrototype proto, PsionicComponent psionic)
         {
             foreach (var id in proto.Actions)
@@ -258,8 +239,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Add all components associated with a specific Psionic power.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="proto"></param>
         private void AddPsionicPowerComponents(EntityUid uid, PsionicPowerPrototype proto)
         {
             if (proto.Components is null)
@@ -279,8 +258,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Update the Amplification and Dampening sources of a Psion to include a new Power.
         /// </summary>
-        /// <param name="proto"></param>
-        /// <param name="psionic"></param>
         private void AddPsionicStatSources(PsionicPowerPrototype proto, PsionicComponent psionic)
         {
             if (proto.AmplificationModifier != 0)
@@ -291,10 +268,37 @@ namespace Content.Server.Abilities.Psionics
         }
 
         /// <summary>
+        ///     Displays a message to alert the player when they have obtained a new psionic power. These generally will not play for Innate powers.
+        ///     Chat messages of this nature should be written in the first-person.
+        ///     Popup feedback should be no more than a sentence, while the full Initialization Feedback can be as much as a paragraph of text.
+        /// </summary>
+        private void SendFeedbackMessage(EntityUid uid, PsionicPowerPrototype proto, bool playFeedback = true)
+        {
+            if (!playFeedback
+                || !_playerManager.TryGetSessionByEntity(uid, out var session)
+                || session is null)
+                return;
+
+            if (proto.InitializationPopup is null)
+                _popups.PopupEntity(Loc.GetString(GenericInitializationMessage), uid, uid, PopupType.MediumCaution);
+            else _popups.PopupEntity(Loc.GetString(proto.InitializationPopup), uid, uid, PopupType.MediumCaution);
+
+            if (proto.InitializationFeedback is null)
+                return;
+
+            var feedbackMessage = $"[font size={proto.InitializationFeedbackFontSize}][color={proto.InitializationFeedbackColor}]{proto.InitializationFeedback}[/color][/font]";
+            _chatManager.ChatMessageToOne(
+                proto.InitializationFeedbackChannel,
+                feedbackMessage,
+                feedbackMessage,
+                EntityUid.Invalid,
+                false,
+                session.Channel);
+        }
+
+        /// <summary>
         ///     Remove all Psychic Actions listed in an entity's Psionic Component. Unfortunately, removing actions associated with a specific Power Prototype is not supported.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="psionic"></param>
         private void RemovePsionicActions(EntityUid uid, PsionicComponent psionic)
         {
             if (psionic.Actions is null)
@@ -307,8 +311,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Remove all Components associated with a specific Psionic Power.
         /// </summary>
-        /// <param name="uid"></param>
-        /// <param name="proto"></param>
         private void RemovePsionicPowerComponents(EntityUid uid, PsionicPowerPrototype proto)
         {
             if (proto.Components is null)
@@ -327,8 +329,6 @@ namespace Content.Server.Abilities.Psionics
         /// <summary>
         ///     Remove all stat sources associated with a specific Psionic Power.
         /// </summary>
-        /// <param name="proto"></param>
-        /// <param name="psionic"></param>
         private void RemovePsionicStatSources(EntityUid uid, PsionicPowerPrototype proto, PsionicComponent psionic)
         {
             if (proto.AmplificationModifier != 0)

--- a/Content.Shared/Psionics/PsionicPowerPrototype.cs
+++ b/Content.Shared/Psionics/PsionicPowerPrototype.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Chat;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Psionics;
@@ -36,10 +37,37 @@ public sealed partial class PsionicPowerPrototype : IPrototype
     public ComponentRegistry Components = new();
 
     /// <summary>
-    ///     What message will play as a popup when the power is initialized.
+    ///     What message will be sent to the player as a Popup.
+    ///     If left blank, it will default to the Const "generic-power-initialization-feedback"
     /// </summary>
-    [DataField(required: true)]
-    public string InitializationFeedback = "psionic-power-initialization-default";
+    [DataField]
+    public string? InitializationPopup;
+
+    /// <summary>
+    ///     What message will be sent to the chat window when the power is initialized. Leave it blank to send no message.
+    ///     Initialization messages won't play for powers that are Innate, only powers obtained during the round.
+    ///     These should generally also be written in the first person, and can be far lengthier than popups.
+    /// </summary>
+    [DataField]
+    public string? InitializationFeedback;
+
+    /// <summary>
+    ///     What color will the initialization feedback display in the chat window with.
+    /// </summary>
+    [DataField]
+    public string InitializationFeedbackColor = "#8A00C2";
+
+    /// <summary>
+    ///     What font size will the initialization message use in chat.
+    /// </summary>
+    [DataField]
+    public int InitializationFeedbackFontSize = 12;
+
+    /// <summary>
+    ///     Which chat channel will the initialization message use.
+    /// </summary>
+    [DataField]
+    public ChatChannel InitializationFeedbackChannel = ChatChannel.Emotes;
 
     /// <summary>
     ///     What message will this power generate when scanned by a Metempsionic Focused Pulse.

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -18,7 +18,7 @@
     - ActionMassSleep
   components:
     - type: MassSleepPower
-  initializationFeedback: mass-sleep-power-initialization-feedback
+  # initializationFeedback: mass-sleep-power-initialization-feedback # I apologize, I don't feel like writing a paragraph of feedback for a power that's getting replaced with a new one.
   metapsionicFeedback: mass-sleep-power-metapsionic-feedback
   amplificationModifier: 0.5
   dampeningModifier: 0.5


### PR DESCRIPTION
# Description

This PR implements the previously planned feature whereby obtaining a Psionic Power plays some form of notification to alert the player that they have gained a new ability. Since some Psionics like Xenoglossy are purely passive, it's very important to give an indication to players what's going on. To that end, PsionicPowerPrototype has been expanded to include new datafields related to Initialization Feedback. There are now three kinds of feedback messages: Popup, Feedback, and Metapsionic.

All feedback will only play for powers obtained during the round, rather than for entities that innately start with powers.

- Popups will appear over your character's head as a small, brief message. These should be no more than a sentence at most.
- Feedback will appear in the Chat window as a message only visible to the Psion themself. These can be as much as a paragraph in length.
- Metapsionic messages are coming in their own separate PR: https://github.com/Simple-Station/Einstein-Engines/pull/774

In a separate PR, I also wish to add Audio feedback as well.

# Media

I apologize that the video has been bitcrunched to a point that the chat window can't be read.

https://github.com/user-attachments/assets/11e30e91-8fc6-48a2-b6a5-9ecf7127065e

# Changelog

:cl:
- add: Gaining a new Psionic Power can now display messages to alert the player, both as a short popup, and optionally a lengthier message sent to the user's Chat window. 