### PR TITLE
Fix RGB Moths

### DIFF
--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#ffda93"
   markingLimits: MobMothMarkingLimits
   dollPrototype: MobMothDummy
-  skinColoration: TintedHuesSkin # DeltaV - No rgb moths, literally 1849
+  skinColoration: Hues
   maleFirstNames: names_moth_first_male
   femaleFirstNames: names_moth_first_female
   lastNames: names_moth_last


### PR DESCRIPTION
# Description

Magic single line Yml Fix obtained by digging through DeltaV's Blame 
**GO!**

# Changelog

:cl:
- tweak: Moths can now be colorful again.