### PR TITLE
Enhancement: Added Language and Healing Components to IPC Entities

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -102,7 +102,14 @@
 #     layoutId: IPC
   - type: EmitBuzzWhileDamaged
   - type: CanHostGuardian
-
+  - type: LanguageKnowledge
+    speaks:
+    - GalacticCommon
+    - RobotTalk
+    understands:
+    - GalacticCommon
+    - RobotTalk
+  - type: WeldingHealable
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description

This pull request introduces two new components to the IPC entities:

1. **LanguageKnowledge**: This component allows IPCs to speak and understand Galactic Common and RobotTalk. Previously, IPCs were limited to Universal language, which caused communication issues with the crew. With this addition, IPCs can now effectively communicate using the Galactic Common and RobotTalk languages.

2. **WeldingHealable**: This component enables IPCs to heal themselves using a welding tool. Given the nature of IPCs as robotic entities, this feature is essential for self-maintenance and ensures they can stay operational even after sustaining damage.

These changes aim to improve the functionality and immersion of IPCs within the game, allowing them to better integrate and interact with other entities while also providing them with the ability to self-repair.

---

# TODO

- [x] Add `LanguageKnowledge` component to IPC entities to support Galactic Common and RobotTalk.
- [x] Add `WeldingHealable` component to IPC entities for self-repair with welding tools.

# Changelog

:cl:
- add: Added the ability for IPCs to speak and understand Galactic Common and RobotTalk languages.
- add: Enabled IPCs to heal themselves using welding tools via the WeldingHealable component.
