### PR TITLE
Maximize Default Description Limits

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -24,8 +24,8 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        public const int MaxNameLength = 32;
-        public const int MaxDescLength = 512;
+        public const int MaxNameLength = 48;
+        public const int MaxDescLength = 1024;
 
         private readonly Dictionary<string, JobPriority> _jobPriorities;
         private readonly List<string> _antagPreferences;


### PR DESCRIPTION
# Description

The current in game UI can reasonably support names up to 48 characters in length, as well as descriptions up to 1024 characters long. Any longer, and the UI requires a scroll bar. This change is present on Cosmatic Drift, which uses the same character UI we currently have. I've had many people requesting this change, and while I am aware that we wish to at some point update to a new character UI(such as Parkstation's UI), but a stopgap here is still nice, and it's just two Const variables.

# Media

![image](https://github.com/user-attachments/assets/d68c3e05-9659-464b-8fb1-8de7e41a674b)

# Changelog

:cl:
- tweak: Character names can now be up to 48 characters in length.
- tweak: Character descriptions can now be up to 1024 characters in length. This is the maximum size descriptions can be without the menu having a scroll bar. And while we'd like it to be bigger, we're going to want to get a new UI for this in the future!
