### PR TITLE
Rebalance Radiation Shielding

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -108,7 +108,7 @@
   - type: Airtight
     noAirWhenFullyAirBlocked: false
   - type: RadiationBlocker
-    resistance: 3
+    resistance: 5
   - type: Occluder
   - type: Damageable
     damageContainer: StructuralInorganic
@@ -116,7 +116,7 @@
   - type: RCDDeconstructable
     cost: 6
     delay: 8
-    fx: EffectRCDDeconstruct8    
+    fx: EffectRCDDeconstruct8
   - type: Destructible
     thresholds:
     - trigger:
@@ -151,7 +151,7 @@
   - type: BlockWeather
   placement:
     mode: SnapgridCenter
- 
+
 - type: entity
   id: AirlockRCDResistant
   parent: Airlock
@@ -196,7 +196,7 @@
   - type: PaintableAirlock
     group: Glass
   - type: RadiationBlocker
-    resistance: 2
+    resistance: 1
   - type: Tag
     tags:
       - GlassAirlock

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -98,6 +98,7 @@
       noAirWhenFullyAirBlocked: true
     - type: RadiationBlocker
       enabled: false
+      resistance: 1
     - type: Occluder
       enabled: false
     - type: WallMount

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -24,7 +24,7 @@
   - type: Occluder
   - type: Appearance
   - type: RadiationBlocker
-    resistance: 8
+    resistance: 10
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StrongMetallic

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -60,7 +60,7 @@
       type: WiresBoundUserInterface
   - type: Airtight
   - type: RadiationBlocker
-    resistance: 2
+    resistance: 1
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StrongMetallic
@@ -126,7 +126,7 @@
   id: ShuttersRadiation
   parent: BaseShutter
   name: radiation shutters
-  description: Why did they make these shutters radioactive?
+  description: A relatively fragile set of shutters, made of radiation blocking lead plates.
   components:
   - type: Sprite
     sprite: Structures/Doors/Shutters/shutters_radiation.rsi
@@ -140,7 +140,15 @@
     containers:
     - board
   - type: RadiationBlocker
-    resistance: 4
+    resistance: 10
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
 
 - type: entity
   id: ShuttersRadiationOpen

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -66,7 +66,7 @@
     damageContainer: Inorganic
     damageModifierSet: Glass
   - type: ExaminableDamage
-    messages: WindowMessages   
+    messages: WindowMessages
   - type: RCDDeconstructable
     cost: 8
     delay: 8
@@ -252,7 +252,7 @@
   - type: StaticPrice
     price: 170
   - type: RadiationBlocker
-    resistance: 2
+    resistance: 4
 
 - type: entity
   id: BaseSecurePlasmaWindoor
@@ -307,7 +307,7 @@
   - type: StaticPrice
     price: 312
   - type: RadiationBlocker
-    resistance: 4
+    resistance: 6
 
 #Uranium Windoors
 - type: entity
@@ -362,7 +362,7 @@
   - type: StaticPrice
     price: 180
   - type: RadiationBlocker
-    resistance: 3
+    resistance: 5
 
 - type: entity
   id: BaseSecureUraniumWindoor
@@ -417,4 +417,4 @@
   - type: StaticPrice
     price: 462
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 8

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -48,7 +48,7 @@
   - type: StaticPrice #was DynamicPrice
     price: 75
   - type: RadiationBlocker
-    resistance: 2
+    resistance: 1
   - type: BlockWeather
 
 - type: entity
@@ -399,7 +399,7 @@
     key: walls
     base: plasma
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 7
 
 - type: entity
   parent: BaseWall
@@ -570,7 +570,7 @@
   - type: StaticPrice
     price: 150
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 8
 
 - type: entity
   parent: WallReinforced
@@ -977,7 +977,7 @@
     key: walls
     base: uranium
   - type: RadiationBlocker
-    resistance: 6
+    resistance: 10
 
 - type: entity
   parent: BaseWall

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -51,7 +51,7 @@
   - type: StaticPrice
     price: 60
   - type: RadiationBlocker
-    resistance: 2
+    resistance: 4
 
 - type: entity
   id: PlasmaWindowDirectional

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -12,7 +12,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: RadiationBlocker
-    resistance: 4
+    resistance: 8
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -51,7 +51,7 @@
   - type: StaticPrice
     price: 140
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 10
 
 - type: entity
   id: UraniumReinforcedWindowDirectional

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -49,7 +49,7 @@
   - type: StaticPrice
     price: 80
   - type: RadiationBlocker
-    resistance: 3
+    resistance: 5
 
 - type: entity
   id: UraniumWindowDirectional


### PR DESCRIPTION
# Description

This PR is a MUCH needed QOL update for all of our downstream servers that have started mapping in Supermatter engines. I have gone through every single entry of the RadiationResistance component in the game, and tweaked the values of them so that it is actually reasonably practical to provide some protection to the rest of the station during a Supermatter delamination. This fact is highly relevant since one of the things I am working on is a rebase of the wizden map CORE to EE, which will include a replacement of its Singulo with a Supermatter engine. With the pre-existing radiation shielding values, such an engine will near instantly cleanse the entire station of all life within a matter of seconds should it so much as think about delaminating. However with this PR, it's actually practical to shield the station from it. 

One major problem, and something that defies player expectations, is that **Radiation Shutters did not previously provide significant protection from radiation.** They were infact not much better than a standard wall, and provided worse protection than a reinforced wall. 

For reference to understand the issue, a Supermatter engine during its delamination produces 45 rads per second. Which is so overwhelmingly strong, that the Edge station's Supermatter could kill people from as far away as the reporter's office. Something like 70% of the station becomes lethally radioactive. On smaller maps such as Syndicate Station's Shoukou, fully 100% of the map is lethally irradiated. 

The flipside of this is that ordinary walls have had their radiation resistance reduced. Don't count on anything not-reinforced to provide protection. Trust your life in reinforced walls, radiation shutters, blast shields, and plasma/uranium glass or walls. I did however add a concession that firelocks now block 1 point of radiation. It's not much, but it'll help just a smidge. :)

<details><summary><h1>Media</h1></summary>
<p>

What I'm dealing with, and why I can't actually in good conscience release said map unless this PR is merged:

![image](https://github.com/user-attachments/assets/fb4ab6cc-fda9-495e-9bfa-678828e4cdc7)

</p>
</details>

# Changelog

:cl:
- tweak: Radiation shielding objects have been rebalanced, such that objects that players previously assumed would provide reasonable protection from radiation, now factually do. For instance, Radiation Shutters now actually block radiation.
