### PR TITLE
Add IPC's Missing Components

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -108,6 +108,9 @@
     - RobotTalk
   - type: WeldingHealable
   - type: PsionicInsulation
+  - type: OfferItem
+  - type: LayingDown
+  - type: Carriable
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description

IPCs were missing Offer Item, Laying Down, and Carriable.

# Changelog

:cl:
- fix: IPCs can now lay down, offer people items, and be picked up and carried.
