### PR TITLE
Fix Door Access

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
@@ -4,16 +4,19 @@
   id: AirlockMantisLocked
   suffix: Mantis, Locked
   components:
-  - type: AccessReader
-    access: [["Mantis"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMantis ]
+
 
 - type: entity
   parent: AirlockScienceGlass
   id: AirlockMantisGlassLocked
   suffix: Mantis, Locked
   components:
-  - type: AccessReader
-    access: [["Mantis"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMantis ]
 
 - type: entity
   parent: AirlockCommand
@@ -102,16 +105,18 @@
   id: AirlockCorpsmanLocked
   suffix: Corpsman, Locked
   components:
-  - type: AccessReader
-    access: [["Corpsman"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCorpsman ]
 
 - type: entity
   parent: AirlockSecurityGlass
   id: AirlockCorpsmanGlassLocked
   suffix: Corpsman, Locked
   components:
-  - type: AccessReader
-    access: [["Corpsman"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCorpsman ]
 
 - type: entity
   parent: AirlockGlassShuttle
@@ -126,72 +131,81 @@
   id: AirlockBoxerLocked
   suffix: Boxer, Locked
   components:
-  - type: AccessReader
-    access: [["Boxer"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
 
 - type: entity
   parent: Airlock
   id: AirlockClownLocked
   suffix: Clown, Locked
   components:
-  - type: AccessReader
-    access: [["Clown"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
 
 - type: entity
   parent: Airlock
   id: AirlockMimeLocked
   suffix: Mime, Locked
   components:
-  - type: AccessReader
-    access: [["Mime"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
 
 - type: entity
   parent: Airlock
   id: AirlockMusicianLocked
   suffix: Musician, Locked
   components:
-  - type: AccessReader
-    access: [["Musician"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
 
 - type: entity
   parent: Airlock
   id: AirlockReporterLocked
   suffix: Reporter, Locked
   components:
-  - type: AccessReader
-    access: [["Reporter"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
 
 - type: entity
   parent: Airlock
   id: AirlockLibraryLocked
   suffix: Library, Locked
   components:
-  - type: AccessReader
-    access: [["Library"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
 
 - type: entity
   parent: Airlock
   id: AirlockZookeeperLocked
   suffix: Zookeeper, Locked
   components:
-  - type: AccessReader
-    access: [["Zookeeper"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]
 
 - type: entity
   parent: AirlockExternal
   id: AirlockExternalSalvageLocked
   suffix: External, Salvage, Locked
   components:
-  - type: AccessReader
-    access: [["Salvage"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSalvage ]
 
 - type: entity
   parent: AirlockMedical
   id: AirlockPsychologistLocked
   suffix: Psychologist, Locked
   components:
-  - type: AccessReader
-    access: [["Psychologist"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
 
 # Glass Airlocks
 - type: entity
@@ -199,72 +213,81 @@
   id: AirlockBoxerGlassLocked
   suffix: Boxer, Locked
   components:
-  - type: AccessReader
-    access: [["Boxer"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockClownGlassLocked
   suffix: Clown, Locked
   components:
-  - type: AccessReader
-    access: [["Clown"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockMimeGlassLocked
   suffix: Mime, Locked
   components:
-  - type: AccessReader
-    access: [["Mime"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockMusicianGlassLocked
   suffix: Musician, Locked
   components:
-  - type: AccessReader
-    access: [["Musician"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockReporterGlassLocked
   suffix: Reporter, Locked
   components:
-  - type: AccessReader
-    access: [["Reporter"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockLibraryGlassLocked
   suffix: Library, Locked
   components:
-  - type: AccessReader
-    access: [["Library"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
 
 - type: entity
   parent: AirlockGlass
   id: AirlockZookeeperGlassLocked
   suffix: Zookeeper, Locked
   components:
-  - type: AccessReader
-    access: [["Zookeeper"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]
 
 - type: entity
   parent: AirlockExternalGlass
   id: AirlockExternalGlassSalvageLocked
   suffix: External, Glass, Salvage, Locked
   components:
-  - type: AccessReader
-    access: [["Salvage"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSalvage ]
 
 - type: entity
   parent: AirlockMedicalGlass
   id: AirlockPsychologistGlassLocked
   suffix: Psychologist, Locked
   components:
-  - type: AccessReader
-    access: [["Psychologist"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
 
 # Maintenance Hatches
 - type: entity
@@ -272,69 +295,78 @@
   id: AirlockMaintBoxerLocked
   suffix: Boxer, Locked
   components:
-  - type: AccessReader
-    access: [["Boxer"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBoxer ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintClownLocked
   suffix: Clown, Locked
   components:
-  - type: AccessReader
-    access: [["Clown"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintMimeLocked
   suffix: Mime, Locked
   components:
-  - type: AccessReader
-    access: [["Mime"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintMusicianLocked
   suffix: Musician, Locked
   components:
-  - type: AccessReader
-    access: [["Musician"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintReporterLocked
   suffix: Reporter, Locked
   components:
-  - type: AccessReader
-    access: [["Reporter"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintLibraryLocked
   suffix: Library, Locked
   components:
-  - type: AccessReader
-    access: [["Library"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintZookeeperLocked
   suffix: Zookeeper, Locked
   components:
-  - type: AccessReader
-    access: [["Zookeeper"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsZookeeper ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintPsychologistLocked
   suffix: Psychologist, Locked
   components:
-  - type: AccessReader
-    access: [["Psychologist"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsPsychologist ]
 
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintSecurityLawyerLocked
   suffix: Security/Lawyer, Locked
   components:
-  - type: AccessReader
-    access: [["Security"], ["Lawyer"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurityLawyer ]

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -318,3 +318,85 @@
   components:
   - type: AccessReader
     access: [["Prosecutor"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMantis
+  suffix: Mantis, Locked
+  components:
+  - type: AccessReader
+    access: [["Mantis"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCorpsman
+  suffix: Corpsman, Locked
+  components:
+  - type: AccessReader
+    access: [["Corpsman"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsBoxer
+  suffix: Boxer, Locked
+  components:
+  - type: AccessReader
+    access: [["Boxer"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsClown
+  suffix: Clown, Locked
+  components:
+  - type: AccessReader
+    access: [["Clown"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMime
+  suffix: Mime, Locked
+  components:
+  - type: AccessReader
+    access: [["Mime"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMusician
+  suffix: Musician, Locked
+  components:
+  - type: AccessReader
+    access: [["Musician"]]
+
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsReporter
+  suffix: Reporter, Locked
+  components:
+  - type: AccessReader
+    access: [["Reporter"]]
+
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsLibrary
+  suffix: Library, Locked
+  components:
+  - type: AccessReader
+    access: [["Library"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsZookeeper
+  suffix: Zookeeper, Locked
+  components:
+  - type: AccessReader
+    access: [["Zookeeper"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsPsychologist
+  suffix: Psychologist, Locked
+  components:
+  - type: AccessReader
+    access: [["Psychologist"]]


### PR DESCRIPTION
# Description
Somehow all the doors accesses broke. Seems somebody used the AccessReader Component on the door instead of the door electronics. This PR fixes all the doors that I could find that were broken.

# Changelog


:cl:

- fix: Fixed most door accesses including: Lawyer, Mantis, Corpsman, Boxer, Clown, Mime, Musician, Reporter, Library, Zookeeper, Salvage and Psychologist.
 
