### PR TITLE
Thieves Outside of Traitor

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -8,6 +8,7 @@
   rules:
     - RampingStationEventScheduler
     - BasicRoundstartVariation
+    - SubGamemodesRule
 
 - type: gamePreset
   id: SurvivalHellshift
@@ -19,6 +20,7 @@
   rules:
     - HellshiftStationEventScheduler
     - BasicRoundstartVariation
+    - SubGamemodesRule
 
 - type: gamePreset
   id: AllAtOnce
@@ -43,6 +45,7 @@
   rules:
   - BasicStationEventScheduler
   - BasicRoundstartVariation
+  - SubGamemodesRule
 
 - type: gamePreset
   id: Greenshift


### PR DESCRIPTION


# Description


Mirroring a PR from Floof that I was much too lazy to cherry-pick. This just changes gamemodes outside of tator and rev to allow thieves if it makes sense to.

---


# Changelog

:cl:
- tweak: Thieves are now in Survival, Hellshift, and Extended.
