### PR TITLE
IPC Missing Deathgasp

### DIFF
--- a/Resources/Locale/en-US/emotes/emotes.ftl
+++ b/Resources/Locale/en-US/emotes/emotes.ftl
@@ -1,2 +1,7 @@
 ﻿emote-deathgasp = seizes up and falls limp, {POSS-ADJ($entity)} eyes dead and lifeless...
 silicon-emote-deathgasp =seizes up and falls limp...
+
+# for IPC
+chat-emote-msg-deathgasp-silicon =
+    With a hiss of grinding servos and a screech of dying myomers,
+    {POSS-ADJ($entity)} suddenly goes silent.


### PR DESCRIPTION
# Description

IPC were missing a deathgasp, so I wrote one for them.

![faridaiscute](https://github.com/user-attachments/assets/2e78dcc0-0163-4ec7-bf07-424dbd9d0a91)

# Changelog

:cl:
- fix: IPC now have their own unique deathgasp message.
