### PR TITLE
Make Shoving and Stamina Great Again

### DIFF
--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -183,7 +183,10 @@ namespace Content.Server.Carrying
             // Check if the victim is in any way incapacitated, and if not make an escape attempt.
             // Escape time scales with the inverse of a mass contest. Being lighter makes escape harder.
             if (_actionBlockerSystem.CanInteract(uid, component.Carrier))
-                _escapeInventorySystem.AttemptEscape(uid, component.Carrier, escape, _contests.MassContest(uid, component.Carrier, false, 2f));
+            {
+                var disadvantage = _contests.MassContest(component.Carrier, uid, false, 2f);
+                _escapeInventorySystem.AttemptEscape(uid, component.Carrier, escape, disadvantage);
+            }
         }
 
         private void OnMoveAttempt(EntityUid uid, BeingCarriedComponent component, UpdateCanMoveEvent args)

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -69,8 +69,8 @@ public sealed class EscapeInventorySystem : EntitySystem
         // Contested
         if (_handsSystem.IsHolding(container.Owner, uid, out _))
         {
-            var advantage = _contests.MassContest(uid, container.Owner, rangeFactor: 3f);
-            AttemptEscape(uid, container.Owner, component, advantage);
+            var disadvantage = _contests.MassContest(container.Owner, uid, rangeFactor: 3f);
+            AttemptEscape(uid, container.Owner, component, disadvantage);
             return;
         }
 

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Server.Storage.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
+using Content.Shared.Contests;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
@@ -28,6 +29,7 @@ public sealed class EscapeInventorySystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly CarryingSystem _carryingSystem = default!; // Carrying system from Nyanotrasen.
     [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly ContestsSystem _contests = default!;
 
     /// <summary>
     /// You can't escape the hands of an entity this many times more massive than you.
@@ -67,7 +69,8 @@ public sealed class EscapeInventorySystem : EntitySystem
         // Contested
         if (_handsSystem.IsHolding(container.Owner, uid, out _))
         {
-            AttemptEscape(uid, container.Owner, component);
+            var advantage = _contests.MassContest(uid, container.Owner, rangeFactor: 3f);
+            AttemptEscape(uid, container.Owner, component, advantage);
             return;
         }
 

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -136,8 +136,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             return false;
 
         var chance = CalculateDisarmChance(user, target, inTargetHand, combatMode);
-
-        if (_random.Prob(chance))
+        if (!_random.Prob(chance))
         {
             // Don't play a sound as the swing is already predicted.
             // Also don't play popups because most disarms will miss.
@@ -163,7 +162,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         _audio.PlayPvs(combatMode.DisarmSuccessSound, user, AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
         AdminLogger.Add(LogType.DisarmedAction, $"{ToPrettyString(user):user} used disarm on {ToPrettyString(target):target}");
 
-        var eventArgs = new DisarmedEvent { Target = target, Source = user, PushProbability = 1 - chance };
+        var eventArgs = new DisarmedEvent { Target = target, Source = user, PushProbability = chance };
         RaiseLocalEvent(target, eventArgs);
 
         if (!eventArgs.Handled)
@@ -208,17 +207,17 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (HasComp<DisarmProneComponent>(disarmed))
             return 0.0f;
 
-        var chance = disarmerComp.BaseDisarmFailChance;
+        var chance = 1 - disarmerComp.BaseDisarmFailChance;
 
         if (inTargetHand != null && TryComp<DisarmMalusComponent>(inTargetHand, out var malus))
         {
-            chance += malus.Malus;
+            chance -= malus.Malus;
         }
 
         return Math.Clamp(chance
-                        * _contests.MassContest(disarmer, disarmed, false, 0.5f)
+                        * _contests.MassContest(disarmer, disarmed, false, 2f)
                         * _contests.StaminaContest(disarmer, disarmed, false, 0.5f)
-                        * _contests.HealthContest(disarmer, disarmed, false, 0.5f),
+                        * _contests.HealthContest(disarmer, disarmed, false, 1f),
                         0f, 1f);
     }
 

--- a/Content.Server/Weapons/Melee/ShovingComponent.cs
+++ b/Content.Server/Weapons/Melee/ShovingComponent.cs
@@ -1,0 +1,23 @@
+namespace Content.Server.Weapons.Melee;
+
+[RegisterComponent]
+public sealed partial class ShovingComponent : Component
+{
+    /// <summary>
+    ///     Default shoving stamina damage used if the shoving entity has no ShovingComponent. See <see cref="StaminaDamage"/>.
+    /// </summary>
+    public const float DefaultStaminaDamage = 50f;
+
+    /// <summary>
+    ///     Amount of stamina damage dealt on successful shove if the attacker has a 100% chance to shove the target.
+    ///     If the chance is less than 100% (which it almost always is), the damage is multiplied by the chance.
+    /// </summary>
+    [DataField]
+    public float StaminaDamage = DefaultStaminaDamage;
+
+    /// <summary>
+    ///     Added to the shove/disarm chance on attacks done by this mob, acts opposite to DisarmMalus for targets.
+    /// </summary>
+    [DataField]
+    public float DisarmBonus = 0f;
+}

--- a/Content.Shared/CombatMode/DisarmedEvent.cs
+++ b/Content.Shared/CombatMode/DisarmedEvent.cs
@@ -16,5 +16,10 @@ namespace Content.Shared.CombatMode
         ///     Probability for push/knockdown.
         /// </summary>
         public float PushProbability { get; init; }
+
+        /// <summary>
+        ///     Potential stamina damage if this disarm results in a shove.
+        /// </summary>
+        public float StaminaDamage { get; init; }
     }
 }

--- a/Content.Shared/Contests/ContestsSystem.cs
+++ b/Content.Shared/Contests/ContestsSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.Mood;
 using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
 
-// TODO until the code is rewritten, DO NOT EVER MODIFY ANY RELATED CVARS or you will BREAK THE GAME DUE TO NEGATIVE CONTEST ADVANTAGES
+// TODO until the code is rewritten, DO NOT EVER INCREASE ANY RELATED CVARS ABOVE 0.25x or you will BREAK THE GAME DUE TO NEGATIVE CONTEST ADVANTAGES
 // TODO this code needs a refactor:
 // - misleading x0.25 multiplications in stamina and health contests should be gone
 // - rangeFactor should multiply the resulting value or raise it to the power of itself, NOT modify the clamp range

--- a/Content.Shared/Contests/ContestsSystem.cs
+++ b/Content.Shared/Contests/ContestsSystem.cs
@@ -7,12 +7,6 @@ using Content.Shared.Mood;
 using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
 
-// TODO until the code is rewritten, DO NOT EVER INCREASE ANY RELATED CVARS ABOVE 0.25x or you will BREAK THE GAME DUE TO NEGATIVE CONTEST ADVANTAGES
-// TODO this code needs a refactor:
-// - misleading x0.25 multiplications in stamina and health contests should be gone
-// - rangeFactor should multiply the resulting value or raise it to the power of itself, NOT modify the clamp range
-// - all CVARs should probably be nuked in favor of system-specific cvars.
-// - all output values should be clamped between float.Epsilon and float.MaxValue, softly (via b^x) if possible
 namespace Content.Shared.Contests
 {
     public sealed partial class ContestsSystem : EntitySystem

--- a/Content.Shared/Contests/ContestsSystem.cs
+++ b/Content.Shared/Contests/ContestsSystem.cs
@@ -7,6 +7,12 @@ using Content.Shared.Mood;
 using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
 
+// TODO until the code is rewritten, DO NOT EVER MODIFY ANY RELATED CVARS or you will BREAK THE GAME DUE TO NEGATIVE CONTEST ADVANTAGES
+// TODO this code needs a refactor:
+// - misleading x0.25 multiplications in stamina and health contests should be gone
+// - rangeFactor should multiply the resulting value or raise it to the power of itself, NOT modify the clamp range
+// - all CVARs should probably be nuked in favor of system-specific cvars.
+// - all output values should be clamped between float.Epsilon and float.MaxValue, softly (via b^x) if possible
 namespace Content.Shared.Contests
 {
     public sealed partial class ContestsSystem : EntitySystem

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -51,4 +51,19 @@ public sealed partial class StaminaComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan NextUpdate = TimeSpan.Zero;
+
+    /// <summary>
+    /// Minimum factor of the crit threshold that the mob must receive in stamina damage in order to start slowing down.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SlowdownThresholdFactor = 0.5f;
+
+    /// <summary>
+    /// Speed multiplier for entities that are slowed down due to low stamina. Multiplied by how close the mob is to stamcrit.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SlowdownMultiplier = 0.75f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan SlowdownTime = TimeSpan.FromSeconds(3);
 }

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -63,7 +63,4 @@ public sealed partial class StaminaComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float SlowdownMultiplier = 0.75f;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan SlowdownTime = TimeSpan.FromSeconds(3);
 }

--- a/Content.Shared/Damage/Systems/StaminaSystem.Slowdown.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.Slowdown.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Damage.Components;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Damage.Systems;
+
+public sealed partial class StaminaSystem
+{
+    private void InitializeSlowdown()
+    {
+        SubscribeLocalEvent<StaminaComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshModifiers);
+    }
+
+    private void OnRefreshModifiers(Entity<StaminaComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        var damage = ent.Comp.StaminaDamage;
+        var threshold = ent.Comp.SlowdownThresholdFactor * ent.Comp.CritThreshold;
+        if (damage < threshold)
+            return;
+
+        var factor = ent.Comp.SlowdownMultiplier * damage / ent.Comp.CritThreshold;
+        args.ModifySpeed(factor, factor);
+    }
+}

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -119,13 +119,11 @@ public sealed partial class StaminaSystem : EntitySystem
 
     private void OnDisarmed(EntityUid uid, StaminaComponent component, DisarmedEvent args)
     {
-        // Note: we do not run _random.Prob here because SharedWeaponSystem already rolls it.
+        // Note: we do not run _random.Prob here because SharedWeaponSystem already runs it.
         if (args.Handled || component.Critical)
             return;
 
-        // TODO: this should be inferred from the weapon. For now it's hardcoded to 50% if you're guaranteed to shove, and less if less.
-        var damage = args.PushProbability * 50f;
-        TakeStaminaDamage(uid, damage, component, source: args.Source);
+        TakeStaminaDamage(uid, args.StaminaDamage, component, source: args.Source);
 
         // We need a better method of getting if the entity is going to resist stam damage, both this and the lines in the foreach at the end of OnHit() are awful
         if (!component.Critical)

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -308,6 +308,7 @@
     alternateState: Standing
   - type: OfferItem
   - type: LayingDown
+  - type: Shoving
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description
First off, shoving was broken badly. It would roll shoving chance twice, meaning that you had only about 6% chance to actually shove someone, and it would only remove 6% of their stamina. Additionally, stamcrits have always pissed me off by just how stupid they were. Also, some of the code in the stamina system had highly misleading names, which has led vmsolidus to implement mass contests the wrong way there.

This PR introduces changes to fix those issues:
- Shoving only rolls the shove chance once.
- Shoving deals 50 * shove chance stamina damage, as intended, without depending on target's stamcrit threshold. In the future it should depend on the weapon used (claws, fists, etc), but for now it's fine.
- Shoving advantage ranges were re-evaluated. Mass difference now can give 0.5x-2x advantage, and health difference can give 0.75x - 1.25x. Stamina difference still gives a neglectable 0.9x - 1.1x advantage.
- The stamina slowdown is now added and calculated dynamically using MovementSpeedModifierSystem, which means the slowdown will no longer disappear 3 seconds after receiving damage, and will not stack (however, it now scales with stamina damage).
- When you exit stamcrit, you start at (100 - epsilon) stamina damage. There still exists another check that prevents you from getting re-stunned in the next ~5 seconds (maybe we should remove that too?), but the slowdown and combat disadvantages will apply as they are supposed to. This means you can no longer stand up after being exhausted to the point of fainting on the ground and immediately rush back into combat.

In addition to that, I also did the following:
- Re-added the mass contest to EscapeInventorySystem. It seems like it's been nuked when the new mass contest system was being implemented and never added back.
- Fixed the mass contest in carrying again

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/076b3c3b-cdd1-4ec7-969d-2564c814a40e


</p>
</details>

---

# Changelog
:cl:
- fix: Shoving once again works correctly, and mass difference matters a lot when shoving someone.
- fix: The time it takes to escape one's hands once again depends on the mass difference between the escapee and the holder.
- tweak: Exiting stamina crit now leaves you with 0 stamina. You can't be immediately stunned again, but you will suffer from slowdown and combat disadvantages!
