### PR TITLE
Telepathy (Minor)Refactor

### DIFF
--- a/Content.Server/Chat/TelepathicChatSystem.cs
+++ b/Content.Server/Chat/TelepathicChatSystem.cs
@@ -16,113 +16,112 @@ using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
 
-namespace Content.Server.Chat
+namespace Content.Server.Chat;
+
+/// <summary>
+///     Extensions for Telepathic chat stuff
+/// </summary>
+public sealed class TelepathicChatSystem : EntitySystem
 {
-    /// <summary>
-    /// Extensions for Telepathic chat stuff
-    /// </summary>
-
-    public sealed class TelepathicChatSystem : EntitySystem
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    private IEnumerable<INetChannel> GetPsionicChatClients()
     {
-        [Dependency] private readonly IAdminManager _adminManager = default!;
-        [Dependency] private readonly IChatManager _chatManager = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
-        [Dependency] private readonly ChatSystem _chatSystem = default!;
-        private IEnumerable<INetChannel> GetPsionicChatClients()
+        return Filter.Empty()
+            .AddWhereAttachedEntity(IsEligibleForTelepathy)
+            .Recipients
+            .Select(p => p.ConnectedClient);
+    }
+
+    private IEnumerable<INetChannel> GetAdminClients()
+    {
+        return _adminManager.ActiveAdmins
+            .Select(p => p.ConnectedClient);
+    }
+
+    private List<INetChannel> GetDreamers(IEnumerable<INetChannel> removeList)
+    {
+        var filtered = Filter.Empty()
+            .AddWhereAttachedEntity(entity =>
+                HasComp<PsionicComponent>(entity) && !HasComp<TelepathyComponent>(entity)
+                || HasComp<SleepingComponent>(entity)
+                || HasComp<SeeingRainbowsComponent>(entity) && !HasComp<PsionicsDisabledComponent>(entity) && !HasComp<PsionicInsulationComponent>(entity))
+            .Recipients
+            .Select(p => p.ConnectedClient);
+
+        var filteredList = filtered.ToList();
+
+        foreach (var entity in removeList)
+            filteredList.Remove(entity);
+
+        return filteredList;
+    }
+
+    private bool IsEligibleForTelepathy(EntityUid entity)
+    {
+        return HasComp<TelepathyComponent>(entity)
+            && !HasComp<PsionicsDisabledComponent>(entity)
+            && !HasComp<PsionicInsulationComponent>(entity)
+            && (!TryComp<MobStateComponent>(entity, out var mobstate) || mobstate.CurrentState == MobState.Alive);
+    }
+
+    public void SendTelepathicChat(EntityUid source, string message, bool hideChat)
+    {
+        if (!IsEligibleForTelepathy(source))
+            return;
+
+        var clients = GetPsionicChatClients();
+        var admins = GetAdminClients();
+        string messageWrap;
+        string adminMessageWrap;
+
+        messageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message",
+            ("telepathicChannelName", Loc.GetString("chat-manager-telepathic-channel-name")), ("message", message));
+
+        adminMessageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message-admin",
+            ("source", source), ("message", message));
+
+        _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Telepathic chat from {ToPrettyString(source):Player}: {message}");
+
+        _chatManager.ChatMessageToMany(ChatChannel.Telepathic, message, messageWrap, source, hideChat, true, clients.ToList(), Color.PaleVioletRed);
+
+        _chatManager.ChatMessageToMany(ChatChannel.Telepathic, message, adminMessageWrap, source, hideChat, true, admins, Color.PaleVioletRed);
+
+        if (_random.Prob(0.1f))
+            _glimmerSystem.Glimmer++;
+
+        if (_random.Prob(Math.Min(0.33f + ((float) _glimmerSystem.Glimmer / 1500), 1)))
         {
-            return Filter.Empty()
-                .AddWhereAttachedEntity(IsEligibleForTelepathy)
-                .Recipients
-                .Select(p => p.ConnectedClient);
+            float obfuscation = (0.25f + (float) _glimmerSystem.Glimmer / 2000);
+            var obfuscated = ObfuscateMessageReadability(message, obfuscation);
+            _chatManager.ChatMessageToMany(ChatChannel.Telepathic, obfuscated, messageWrap, source, hideChat, false, GetDreamers(clients), Color.PaleVioletRed);
         }
 
-        private IEnumerable<INetChannel> GetAdminClients()
+        foreach (var repeater in EntityQuery<TelepathicRepeaterComponent>())
+            _chatSystem.TrySendInGameICMessage(repeater.Owner, message, InGameICChatType.Speak, false);
+    }
+
+    private string ObfuscateMessageReadability(string message, float chance)
+    {
+        var modifiedMessage = new StringBuilder(message);
+
+        for (var i = 0; i < message.Length; i++)
         {
-            return _adminManager.ActiveAdmins
-                .Select(p => p.ConnectedClient);
-        }
-
-        private List<INetChannel> GetDreamers(IEnumerable<INetChannel> removeList)
-        {
-            var filtered = Filter.Empty()
-                .AddWhereAttachedEntity(entity => HasComp<SleepingComponent>(entity) || HasComp<SeeingRainbowsComponent>(entity) && !HasComp<PsionicsDisabledComponent>(entity) && !HasComp<PsionicInsulationComponent>(entity))
-                .Recipients
-                .Select(p => p.ConnectedClient);
-
-            var filteredList = filtered.ToList();
-
-            foreach (var entity in removeList)
-                filteredList.Remove(entity);
-
-            return filteredList;
-        }
-
-        private bool IsEligibleForTelepathy(EntityUid entity)
-        {
-            return HasComp<PsionicComponent>(entity)
-                && !HasComp<PsionicsDisabledComponent>(entity)
-                && !HasComp<PsionicInsulationComponent>(entity)
-                && (!TryComp<MobStateComponent>(entity, out var mobstate) || mobstate.CurrentState == MobState.Alive);
-        }
-
-        public void SendTelepathicChat(EntityUid source, string message, bool hideChat)
-        {
-            if (!IsEligibleForTelepathy(source))
-                return;
-
-            var clients = GetPsionicChatClients();
-            var admins = GetAdminClients();
-            string messageWrap;
-            string adminMessageWrap;
-
-            messageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message",
-                ("telepathicChannelName", Loc.GetString("chat-manager-telepathic-channel-name")), ("message", message));
-
-            adminMessageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message-admin",
-                ("source", source), ("message", message));
-
-            _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Telepathic chat from {ToPrettyString(source):Player}: {message}");
-
-            _chatManager.ChatMessageToMany(ChatChannel.Telepathic, message, messageWrap, source, hideChat, true, clients.ToList(), Color.PaleVioletRed);
-
-            _chatManager.ChatMessageToMany(ChatChannel.Telepathic, message, adminMessageWrap, source, hideChat, true, admins, Color.PaleVioletRed);
-
-            if (_random.Prob(0.1f))
-                _glimmerSystem.Glimmer++;
-
-            if (_random.Prob(Math.Min(0.33f + ((float) _glimmerSystem.Glimmer / 1500), 1)))
+            if (char.IsWhiteSpace((modifiedMessage[i])))
             {
-                float obfuscation = (0.25f + (float) _glimmerSystem.Glimmer / 2000);
-                var obfuscated = ObfuscateMessageReadability(message, obfuscation);
-                _chatManager.ChatMessageToMany(ChatChannel.Telepathic, obfuscated, messageWrap, source, hideChat, false, GetDreamers(clients), Color.PaleVioletRed);
+                continue;
             }
 
-            foreach (var repeater in EntityQuery<TelepathicRepeaterComponent>())
+            if (_random.Prob(1 - chance))
             {
-                _chatSystem.TrySendInGameICMessage(repeater.Owner, message, InGameICChatType.Speak, false);
+                modifiedMessage[i] = '~';
             }
         }
 
-        private string ObfuscateMessageReadability(string message, float chance)
-        {
-            var modifiedMessage = new StringBuilder(message);
-
-            for (var i = 0; i < message.Length; i++)
-            {
-                if (char.IsWhiteSpace((modifiedMessage[i])))
-                {
-                    continue;
-                }
-
-                if (_random.Prob(1 - chance))
-                {
-                    modifiedMessage[i] = '~';
-                }
-            }
-
-            return modifiedMessage.ToString();
-        }
+        return modifiedMessage.ToString();
     }
 }

--- a/Content.Server/Chat/TelepathicRepeaterComponent.cs
+++ b/Content.Server/Chat/TelepathicRepeaterComponent.cs
@@ -1,11 +1,8 @@
-namespace Content.Server.Chat
-{
-    /// <summary>
-    /// Repeats whatever is happening in telepathic chat.
-    /// </summary>
-    [RegisterComponent]
-    public sealed partial class TelepathicRepeaterComponent : Component
-    {
+namespace Content.Server.Chat;
 
-    }
-}
+/// <summary>
+///     Repeats whatever is happening in telepathic chat.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TelepathicRepeaterComponent : Component { }
+

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 using Content.Server.Abilities.Psionics;
+using Content.Shared.Psionics;
 
 namespace Content.Server.Traits;
 
@@ -110,6 +111,7 @@ public sealed class TraitSystem : EntitySystem
             return;
 
         foreach (var powerProto in traitPrototype.PsionicPowers)
-            _psionicAbilities.InitializePsionicPower(uid, powerProto, false);
+            if (_prototype.TryIndex<PsionicPowerPrototype>(powerProto, out var psionicPower))
+                _psionicAbilities.InitializePsionicPower(uid, psionicPower, false);
     }
 }

--- a/Content.Shared/Psionics/TelepathyComponent.cs
+++ b/Content.Shared/Psionics/TelepathyComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Abilities.Psionics;
+
+/// <summary>
+///     Used for determining eligibility for Telepathy.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TelepathyComponent : Component { }

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Customization.Systems;
 using Content.Shared.Psionics;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Traits;
 
@@ -47,5 +48,5 @@ public sealed partial class TraitPrototype : IPrototype
     ///     The list of all Psionic Powers that this trait adds. If this list is not empty, the trait will also Ensure that a player is Psionic.
     /// </summary>
     [DataField]
-    public List<PsionicPowerPrototype>? PsionicPowers { get; private set; } = default!;
+    public List<string>? PsionicPowers { get; private set; } = default!;
 }

--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -74,4 +74,10 @@ xenoglossy-power-initialization-feedback =
 
 psionic-language-power-metapsionic-feedback = The noösphere flows freely through {CAPITALIZE($entity)}, who seems to digest it and pass it back out undisturbed.
 
+# Telepathy
+telepathy-power-description = You are capable of both sending and receiving telepathic messages.
+telepathy-power-initialization-feedback =
+    The voices I've heard all my life begin to clear, yet they do not leave me. Before, they were as incoherent whispers,
+    now my senses broaden, I come to a realization that they are part of a communal shared hallucination. Behind every voice is a glimmering sentience.
+
 mindbreaking-feedback = The light of life vanishes from {CAPITALIZE($entity)}'s eyes, leaving behind a husk pretending at sapience

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -202,3 +202,10 @@ trait-description-LatentPsychic =
     Your mind and soul are open to the noosphere, allowing for use of Telepathy.
     Thus, you are eligible for potentially receiving psychic powers.
     It is possible that you may be hunted by otherworldly forces, so consider keeping your powers a secret.
+
+trait-name-NaturalTelepath = Natural Telepath
+trait-description-NaturalTelepath =
+    As a naturally occuring Telepath, you are capable of fluent telepathic communication, regardless of
+    whether or not you possess any notable psychic powers. This offers all of the same benefits and
+    drawbacks of Latent Psychic, except that you are guaranteed to start with full Telepathy. You may
+    still gain powers as normal for a Latent Psychic.

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -28,6 +28,7 @@
     - type: InnatePsionicPowers
       powersToAdd:
         - MetapsionicPower
+        - TelepathyPower
 
 - type: startingGear
   id: ForensicMantisGear

--- a/Resources/Prototypes/Nyanotrasen/psionicPowers.yml
+++ b/Resources/Prototypes/Nyanotrasen/psionicPowers.yml
@@ -9,3 +9,4 @@
     MassSleepPower: 0.3
 #    PsionicInvisibilityPower: 0.15
     MindSwapPower: 0.15
+    TelepathyPower: 1

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -119,3 +119,12 @@
     - type: UniversalLanguageSpeaker
   initializationFeedback: xenoglossy-power-initialization-feedback
   metapsionicFeedback: psionic-language-power-feedback # Reuse for telepathy, clairaudience, etc
+
+- type: psionicPower
+  id: TelepathyPower
+  name: Telepathy
+  description: telepathy-power-description
+  components:
+    - type: Telepathy
+  initializationFeedback: telepathy-power-initialization-feedback
+  metapsionicFeedback: psionic-language-power-feedback # Reuse for telepathy, clairaudience, etc

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -20,6 +20,9 @@
     - type: BibleUser #Lets them heal with bibles
     - type: Psionic
       powerRollMultiplier: 3
+    - type: InnatePsionicPowers
+      powersToAdd:
+        - TelepathyPower
 
 - type: startingGear
   id: ChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -21,6 +21,7 @@
     - type: InnatePsionicPowers
       powersToAdd:
         - XenoglossyPower
+        - TelepathyPower
 
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -38,6 +38,7 @@
         powersToAdd:
           - DispelPower
           - MetapsionicPower
+          - TelepathyPower
 
 - type: startingGear
   id: ResearchDirectorGear

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -175,7 +175,7 @@
 - type: trait
   id: LatentPsychic
   category: Mental
-  points: -6
+  points: -4
   components:
     - type: Psionic
   requirements:
@@ -192,3 +192,14 @@
       inverted: true
       species:
         - IPC
+
+- type: trait
+  id: NaturalTelepath
+  category: Mental
+  points: -2
+  psionicPowers:
+    - TelepathyPower
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+        - LatentPsychic

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -203,3 +203,10 @@
     - !type:CharacterTraitRequirement
       traits:
         - LatentPsychic
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - ResearchDirector
+        - ForensicMantis
+        - Chaplain
+        - Librarian


### PR DESCRIPTION
# Description

This PR re-introduces a feature that was present in the Psionic Refactor version 1, that of the Natural Telepath trait. Where before Natural Telepath was treated as an "Upgraded" version of Latent Psychic, now it is a standalone trait that makes use of new functionality, where traits can add psionic powers directly, as opposed to relying on just adding components. To accomodate for this, the Telepathy functionality has been modified such that it no longer makes the expectation that PsionicComponent users have the ability to coherently speak telepathically, and instead checks for a specific TelepathyComponent. Since Telepathy is added to a Psion via their ActivePowers list, it is also eliminated when the Psion is mindbroken.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b017b027-d283-484e-812e-37804d839c4a)

</p>
</details>

# Changelog

:cl:
- add: TelepathyComponent has been split off from the PsionicComponent, now as it's own standalone feature.
- add: Telepathy has been added as a new Psionic Power
- add: Natural Telepath has returned from Psionic-Refactor V1, now using new functionality from the trait system that allows traits to buy psionic powers directly. 
- add: Latent Psychics who have neither bought Natural Telepath, nor acquired Telepathy during the round, can sometimes hear snippets of conversation from telepathic chat.
- tweak: The cost of Latent Psychic has been reduced from 6 to 4 points, this is to accommodate for the loss of Telepathy as a bonus feature for all Psionics. Since Natural Telepath is a 2 point trait, this gives a net 0 change in trait points for anyone who wishes to keep being a roundstart Telepath.
- tweak: Psionic Mantis, Mystagogue, Chaplain, and Cataloguer are all Naturally Telepathic, and thus get the new trait for free.
