### PR TITLE
Make Hugging/Petting Interactions Affect Mood

### DIFF
--- a/Content.Server/InteractionVerbs/Actions/MoodAction.cs
+++ b/Content.Server/InteractionVerbs/Actions/MoodAction.cs
@@ -1,0 +1,42 @@
+using Content.Shared.InteractionVerbs;
+using Content.Shared.Mood;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.InteractionVerbs.Actions;
+
+/// <summary>
+///     An action that adds a moodlet to the target, or removes one.
+/// </summary>
+[Serializable]
+public sealed partial class MoodAction : InteractionAction
+{
+    [DataField(required: true)]
+    public ProtoId<MoodEffectPrototype> Effect;
+
+    /// <summary>
+    ///     Parameters for the <see cref="MoodEffectEvent"/>. Only used if <see cref="Remove"/> is false.
+    /// </summary>
+    [DataField]
+    public float Modifier = 1f, Offset = 0f;
+
+    /// <summary>
+    ///     If true, the moodlet will be removed. Otherwise, it will be added.
+    /// </summary>
+    [DataField]
+    public bool Remove = false;
+
+    public override bool CanPerform(InteractionArgs args, InteractionVerbPrototype proto, bool isBefore, VerbDependencies deps)
+    {
+        return true;
+    }
+
+    public override bool Perform(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
+    {
+        if (Remove)
+            deps.EntMan.EventBus.RaiseLocalEvent(args.Target, new MoodRemoveEffectEvent(Effect));
+        else
+            deps.EntMan.EventBus.RaiseLocalEvent(args.Target, new MoodEffectEvent(Effect, Modifier, Offset));
+
+        return true; // Mood system is shitcode so we can't even know if the effect was added or anything
+    }
+}

--- a/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
+++ b/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
@@ -13,11 +13,12 @@ namespace Content.Shared.InteractionVerbs.Requirements;
 [Serializable, NetSerializable]
 public sealed partial class EntityWhitelistRequirement : InteractionRequirement
 {
-    [DataField] public EntityWhitelist Whitelist = new(), Blacklist = new();
+    [DataField] public EntityWhitelist? Whitelist, Blacklist;
 
     public override bool IsMet(InteractionArgs args, InteractionVerbPrototype proto, InteractionAction.VerbDependencies deps)
     {
-        return Whitelist.IsValid(args.Target, deps.EntMan) && !Blacklist.IsValid(args.Target, deps.EntMan);
+        return Whitelist?.IsValid(args.Target, deps.EntMan) != false
+               && Blacklist?.IsValid(args.Target, deps.EntMan) != true;
     }
 }
 

--- a/Resources/Locale/en-US/interaction/verbs/noop.ftl
+++ b/Resources/Locale/en-US/interaction/verbs/noop.ftl
@@ -16,6 +16,12 @@ interaction-Pet-success-self-popup = You pet {THE($target)} on {POSS-ADJ($target
 interaction-Pet-success-target-popup = {THE($user)} pets you on {POSS-ADJ($target)} head.
 interaction-Pet-success-others-popup = {THE($user)} pets {THE($target)}.
 
+interaction-PetAnimal-name = {interaction-Pet-name}
+interaction-PetAnimal-description = Pet an animal.
+interaction-PetAnimal-success-self-popup = {interaction-Pet-success-self-popup}
+interaction-PetAnimal-success-target-popup = {interaction-Pet-success-target-popup}
+interaction-PetAnimal-success-others-popup = {interaction-Pet-success-others-popup}
+
 interaction-KnockOn-name = Knock
 interaction-KnockOn-description = Knock on the target to attract attention.
 interaction-KnockOn-success-self-popup = You knock on {THE($target)}.

--- a/Resources/Locale/en-US/mood/mood.ftl
+++ b/Resources/Locale/en-US/mood/mood.ftl
@@ -37,6 +37,8 @@ mood-effect-Dead = You are dead.
 
 mood-effect-BeingHugged = Hugs are nice.
 
+mood-effect-BeingPet = Someone petted me!
+
 mood-effect-ArcadePlay = I had fun playing an interesting arcade game.
 
 mood-effect-GotBlessed = I was blessed.

--- a/Resources/Locale/en-US/mood/mood.ftl
+++ b/Resources/Locale/en-US/mood/mood.ftl
@@ -37,7 +37,7 @@ mood-effect-Dead = You are dead.
 
 mood-effect-BeingHugged = Hugs are nice.
 
-mood-effect-BeingPet = Someone petted me!
+mood-effect-BeingPet = Someone pet me!
 
 mood-effect-ArcadePlay = I had fun playing an interesting arcade game.
 

--- a/Resources/Prototypes/Interactions/mood_interactions.yml
+++ b/Resources/Prototypes/Interactions/mood_interactions.yml
@@ -1,0 +1,60 @@
+# Hugging - improves the mood of the user
+- type: Interaction
+  id: Hug
+  parent: [BaseGlobal, BaseHands]
+  priority: 2
+  #icon: /Textures/Interface/Actions/hug.png
+  delay: 0.7
+  range: {max: 1}
+  hideByRequirement: true
+  requirement:
+    !type:MobStateRequirement
+    inverted: true
+  action:
+    # TODO: this should pull the target closer or sumth, but I need to code that action first
+    !type:MoodAction
+    effect: BeingHugged
+
+# Petting someone (people) - improves the mood of the target
+- type: Interaction
+  id: Pet
+  parent: [BaseGlobal, BaseHands]
+  priority: 1
+  #icon: /Textures/Interface/Actions/hug.png
+  delay: 0.4
+  range: {max: 1}
+  hideByRequirement: true
+  requirement:
+    !type:ComplexRequirement
+    requirements:
+    - !type:MobStateRequirement
+      inverted: true
+    - !type:EntityWhitelistRequirement
+      whitelist:
+        components: [HumanoidAppearance]
+  action:
+    !type:MoodAction
+    effect: BeingPet
+
+# Petting someone (animals) - improves the mood of the user and the target
+- type: Interaction
+  id: PetAnimal
+  parent: Pet
+  requirement:
+    !type:ComplexRequirement
+    requirements:
+    - !type:MobStateRequirement
+      allowedStates: [Alive]
+    - !type:EntityWhitelistRequirement
+      blacklist:
+        components: [HumanoidAppearance]
+  action:
+    !type:ComplexAction # TODO might wanna make a multiplexer action for situations like this
+    actions:
+    - !type:MoodAction
+      effect: BeingPet
+    - !type:OnUserAction
+      action:
+        !type:MoodAction
+        effect: PetAnimal
+

--- a/Resources/Prototypes/Interactions/noop_interactions.yml
+++ b/Resources/Prototypes/Interactions/noop_interactions.yml
@@ -32,35 +32,6 @@
   action:
     !type:NoOpAction
 
-- type: Interaction
-  id: Hug
-  parent: [BaseGlobal, BaseHands]
-  priority: 2
-  #icon: /Textures/Interface/Actions/hug.png
-  delay: 0.7
-  range: {max: 1}
-  hideByRequirement: true
-  requirement:
-    !type:MobStateRequirement
-    inverted: true
-  action:
-    # TODO: this should pull the target closer or sumth, but I need to code that action first
-    !type:NoOpAction
-
-- type: Interaction
-  id: Pet
-  parent: [BaseGlobal, BaseHands]
-  priority: 1
-  #icon: /Textures/Interface/Actions/hug.png
-  delay: 0.4
-  range: {max: 1}
-  hideByRequirement: true
-  requirement:
-    !type:MobStateRequirement
-    inverted: true
-  action:
-    !type:NoOpAction
-
 # Knocking on the target - windows, doors, etc.
 - type: Interaction
   id: KnockOn

--- a/Resources/Prototypes/Mood/genericPositiveEffects.yml
+++ b/Resources/Prototypes/Mood/genericPositiveEffects.yml
@@ -2,6 +2,13 @@
   id: BeingHugged
   moodChange: 3
   timeout: 120
+  category: PositiveInteraction
+
+- type: moodEffect
+  id: BeingPet
+  moodChange: 3
+  timeout: 120
+  category: PositiveInteraction
 
 - type: moodEffect
   id: ArcadePlay


### PR DESCRIPTION
# Description
Something that was omitted in #733. Hugging and petting now give positive moodlets.

The petting interaction was split into two: one for animals and one for humanoids. The one for animals improves both your own mood and the mood of the animal, whereas petting a humanoid only improves their own mood. In addition to all that, being hugged and being pet do not stack.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/47e8f722-44ee-4d03-a580-65a2946a1920

</p>
</details>

# Changelog
:cl:
- tweak: Hugging and petting interactions now influence mood, just like the old hugging.
