### PR TITLE
Fix InnatePsionicPowers For Mapped Entities

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -35,14 +35,14 @@ namespace Content.Server.Abilities.Psionics
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<InnatePsionicPowersComponent, ComponentStartup>(InnatePowerStartup);
+            SubscribeLocalEvent<InnatePsionicPowersComponent, ComponentInit>(InnatePowerStartup);
             SubscribeLocalEvent<PsionicComponent, ComponentShutdown>(OnPsionicShutdown);
         }
 
         /// <summary>
         ///     Special use-case for a InnatePsionicPowers, which allows an entity to start with any number of Psionic Powers.
         /// </summary>
-        private void InnatePowerStartup(EntityUid uid, InnatePsionicPowersComponent comp, ComponentStartup args)
+        private void InnatePowerStartup(EntityUid uid, InnatePsionicPowersComponent comp, ComponentInit args)
         {
             // Any entity with InnatePowers should also be psionic, but in case they aren't already...
             EnsureComp<PsionicComponent>(uid, out var psionic);

--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -35,14 +35,14 @@ namespace Content.Server.Abilities.Psionics
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<InnatePsionicPowersComponent, ComponentInit>(InnatePowerStartup);
+            SubscribeLocalEvent<InnatePsionicPowersComponent, MapInitEvent>(InnatePowerStartup);
             SubscribeLocalEvent<PsionicComponent, ComponentShutdown>(OnPsionicShutdown);
         }
 
         /// <summary>
         ///     Special use-case for a InnatePsionicPowers, which allows an entity to start with any number of Psionic Powers.
         /// </summary>
-        private void InnatePowerStartup(EntityUid uid, InnatePsionicPowersComponent comp, ComponentInit args)
+        private void InnatePowerStartup(EntityUid uid, InnatePsionicPowersComponent comp, MapInitEvent args)
         {
             // Any entity with InnatePowers should also be psionic, but in case they aren't already...
             EnsureComp<PsionicComponent>(uid, out var psionic);

--- a/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
@@ -2,7 +2,7 @@
   parent: BaseStructure
   id: Oracle
   name: Oracle
-  description: It asks for items in exchange for knowledge. No one knows how it works.
+  description: She asks for items in exchange for knowledge. No one knows how she works.
   components:
   - type: Sprite
     noRot: true
@@ -15,7 +15,14 @@
         state: oracle-0
   - type: Speech
     speechSounds: Tenor
+  - type: Actions
   - type: Psionic
+    removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - XenoglossyPower
+      - TelepathyPower
+      - NoosphericZapPower
   - type: SolutionContainerManager
     solutions:
       fountain:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseStructure
   id: SophicScribe
-  name: sophie
+  name: Sophia
   description: Latest reports on the Noösphere!
   components:
   - type: Sprite
@@ -27,7 +27,15 @@
     channels:
     - Common
     - Science
+  - type: Prayable
+  - type: Actions
   - type: Psionic
+    removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - XenoglossyPower
+      - TelepathyPower
+      - NoosphericZapPower
   - type: Grammar
     attributes:
       gender: female


### PR DESCRIPTION
# Description

InnatePsionicPowers needed to be moved from ComponentStartup to MapInitEvent, which is a deceptively named event that ALSO functions identically in use to ComponentStartup, except that it's safe to use for entities that are mapped in, in addition to joining the round or being spawned in. Whereas ComponentStartup isn't allowed to modify or add components for any entity that is mapped(which includes Spawners apparently).

This change allows for entities like Oracle and Sophia to make use of InnatePsionicPowers, which is done by request from Rane, who for mysterious reasons wishes for the two divine statues to be both Prayable, and have the Noospheric Zap Power. 

I have also verified by ingame testing that this does infact apply to people who join after the map is initialized, as well as things pre-existing on the map. So Oracle still gets her powers, while a latejoining Mystagogue still gets his. 

# Changelog

:cl:
- fix: InnatePsionicPowers now operates on MapInitEvent instead of ComponentStartup, meaning that it can now be safely used on entities that are mapped in instead of spawned. 
- add: Oracle and Sophia are now recognized as Divine, and as such are creatures that can be prayed to.
