### PR TITLE
Psionic Extraplanar Creatures

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/familiars.yml
@@ -95,6 +95,7 @@
   - type: InnatePsionicPowers
     powersToAdd:
       - PyrokinesisPower
+      - TelepathyPower
   - type: Grammar
     attributes:
       proper: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -101,6 +101,8 @@
       - SimpleHostile
   - type: Damageable
     damageContainer: StructuralInorganic
+  - type: Psionic
+    removable: false
 
 - type: entity
   parent: MobOreCrab
@@ -293,6 +295,8 @@
     solution: bloodstream
   - type: DrainableSolution
     solution: bloodstream
+  - type: Psionic
+    removable: false
 
 - type: entity
   name: Reagent Slime Spawner
@@ -319,6 +323,7 @@
         - ReagentSlimeNorepinephricAcid
         - ReagentSlimeEphedrine
         - ReagentSlimeRobustHarvest
+        - ReagentSlimeLotophagoiOil
       chance: 1
 
 - type: entity
@@ -523,6 +528,23 @@
     bloodReagent: RobustHarvest
   - type: PointLight
     color: "#3e901c"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#3e901c"
+
+- type: entity
+  id: ReagentSlimeLotophagoiOil
+  parent: ReagentSlime
+  suffix: Lotophagoi Oil
+  components:
+  - type: Bloodstream
+    bloodReagent: LotophagoiOil
+  - type: PointLight
+    color: "#FFBF00"
   - type: Sprite
     drawdepth: Mobs
     sprite: Mobs/Aliens/elemental.rsi

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -552,3 +552,6 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#3e901c"
+  - type: GhostRole
+    prob: 1 #it's significantly more psionic than the others
+    description: ghost-role-information-angry-slimes-description

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -103,6 +103,9 @@
     damageContainer: StructuralInorganic
   - type: Psionic
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
 
 - type: entity
   parent: MobOreCrab
@@ -297,6 +300,9 @@
     solution: bloodstream
   - type: Psionic
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
 
 - type: entity
   name: Reagent Slime Spawner

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -97,7 +97,6 @@
     - RevenantTheme
   - type: Speech
     speechVerb: Ghost
-  - type: UniversalLanguageSpeaker
   - type: Psionic
     removable: false
   - type: InnatePsionicPowers

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -98,3 +98,9 @@
   - type: Speech
     speechVerb: Ghost
   - type: UniversalLanguageSpeaker
+  - type: Psionic
+    removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - XenoglossyPower
+      - TelepathyPower

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -36,6 +36,9 @@
   - type: Familiar
   - type: Psionic #Nyano - Summary: Makes psionic on creation.
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
 
 - type: entity
   name: Cerberus
@@ -93,6 +96,9 @@
   - type: Dispellable
   - type: Psionic #Nyano - Summary: makes psionic on creation.
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
   - type: Vocal
     sounds:
       Male: Cerberus

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -161,6 +161,9 @@
           shader: unshaded
     - type: Psionic
       removable: false
+    - type: InnatePsionicPowers
+      powersToAdd:
+        - TelepathyPower
 
 - type: entity
   name: HoloClown

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -159,6 +159,8 @@
           map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
           color: "#40a7d7"
           shader: unshaded
+    - type: Psionic
+      removable: false
 
 - type: entity
   name: HoloClown

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -50,6 +50,9 @@
       path: /Audio/Effects/teleport_arrival.ogg
   - type: Psionic
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
   - type: GlimmerSource
     active: false
   - type: SecretDataAnomaly

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -48,8 +48,9 @@
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Effects/teleport_arrival.ogg
-  - type: Psionic #Nyano - Summary: makes psionic on creation.
-  - type: GlimmerSource #Nyano - Summary: makes this a potential source of Glimmer.
+  - type: Psionic
+    removable: false
+  - type: GlimmerSource
     active: false
   - type: SecretDataAnomaly
     randomStartSecretMin: 0

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -6,6 +6,9 @@
   components:
   - type: Psionic
     removable: false
+  - type: InnatePsionicPowers
+    powersToAdd:
+      - TelepathyPower
   - type: GlimmerSource
   - type: Construction
     graph: GlimmerDevices

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -5,6 +5,7 @@
   description: Probes the noösphere to generate research points. Might be worth turning off if glimmer is a problem.
   components:
   - type: Psionic
+    removable: false
   - type: GlimmerSource
   - type: Construction
     graph: GlimmerDevices
@@ -91,6 +92,7 @@
   description: Uses electricity to try and sort out the noösphere, reducing its level of entropy.
   components:
   - type: Psionic
+    removable: false
   - type: GlimmerSource
     addToGlimmer: false
   - type: Construction


### PR DESCRIPTION
# Description

Certain things in the game were intended to be classed as Psionic(And mostly without powers), but were apparently lacking the components. To clarify, ANYTHING that comes from an alternate layer of reality, alternative plane of existence, extra dimensions, other universes, bluespace, etc, is intended to have a PsionicComponent to abstract represent their nature as a magical being of some variety. The importance of this is largely related to the use of Metapsionics to detect them, but also for the valid target lists for Anti-Psychic abilities, such as the bonus damage from the Anti-Psychic Knife.

While here, I've also added the "Loto Oil Slime" from Psionic Refactor Version 1, now that Reagent Slimes(as Extraplanar creatures brought to this world by Liquid Anomalies) have a PsionicComponent.

needs https://github.com/Simple-Station/Einstein-Engines/pull/824

# Changelog

:cl:
- add: Revenants, Reagent Slimes, and Ore Crabs are now considered to be Psionic(But cannot gain powers randomly). This is due to their status as "Magical And/Or Extraplanar Creatures", which makes them valid targets for anti-psychic abilities such as the Psionic Mantis' Anti-Psychic Knife. 
- add: Some Reagent Slimes can now contain Lotophagoi Oil.
