### PR TITLE
Reduce Default PowerAttack Stamina Cost

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -128,7 +128,7 @@ public sealed partial class MeleeWeaponComponent : Component
     public bool SwingLeft;
 
     [DataField, AutoNetworkedField]
-    public float HeavyStaminaCost = 20f;
+    public float HeavyStaminaCost = 10f;
 
     [DataField, AutoNetworkedField]
     public int MaxTargets = 5;


### PR DESCRIPTION
# Description

The default stamina cost for Power Attack was supposed to be 10, so imagine my surprise when I find out it's been 20 this whole time. Which wasn't intended. 

# Changelog

:cl:
- fix: The default stamina cost for Power Attacks for any weapon that doesn't explicitly modify it is now correctly set to 10 stamina(down from 20).
