### PR TITLE
Fix Colored Jumpskirts Actually Being Skirts

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpskirts.yml
@@ -1,6 +1,6 @@
 # White Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorWhite
   name: white jumpskirt
   description: A generic white jumpskirt with no rank markings.
@@ -27,7 +27,7 @@
 
 # Grey Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGrey
   name: grey jumpskirt
   description: A tasteful grey jumpskirt that reminds you of the good old days.
@@ -58,7 +58,7 @@
 
 # Black Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlack
   name: black jumpskirt
   description: A generic black jumpskirt with no rank markings.
@@ -89,7 +89,7 @@
 
 # Blue Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBlue
   name: blue jumpskirt
   description: A generic blue jumpskirt with no rank markings.
@@ -120,7 +120,7 @@
 
 # Dark Blue Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkBlue
   name: dark blue jumpskirt
   description: A generic dark blue jumpskirt with no rank markings.
@@ -151,7 +151,7 @@
 
 # Teal Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorTeal
   name: teal jumpskirt
   description: A generic teal jumpskirt with no rank markings.
@@ -182,7 +182,7 @@
 
 # Green Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorGreen
   name: green jumpskirt
   description: A generic green jumpskirt with no rank markings.
@@ -213,7 +213,7 @@
 
  # Dark Green Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorDarkGreen
   name: dark green jumpskirt
   description: A generic dark green jumpskirt with no rank markings.
@@ -244,7 +244,7 @@
 
 # Orange Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorOrange
   name: orange jumpskirt
   description: Don't wear this near paranoid security officers.
@@ -275,7 +275,7 @@
 
 # Pink Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPink
   name: pink jumpskirt
   description: Just looking at this makes you feel <i>fabulous</i>.
@@ -306,7 +306,7 @@
 
 # Red Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorRed
   name: red jumpskirt
   description: A generic red jumpskirt with no rank markings.
@@ -337,7 +337,7 @@
 
 # Yellow Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorYellow
   name: yellow jumpskirt
   description: A generic yellow jumpskirt with no rank markings.
@@ -368,7 +368,7 @@
 
 # Purple Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorPurple
   name: purple jumpskirt
   description: A generic light purple jumpskirt with no rank markings.
@@ -399,7 +399,7 @@
 
 # Light Brown Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorLightBrown
   name: light brown jumpskirt
   description: A generic light brown jumpskirt with no rank markings.
@@ -430,7 +430,7 @@
 
 # Brown Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorBrown
   name: brown jumpskirt
   description: A generic brown jumpskirt with no rank markings.
@@ -461,7 +461,7 @@
 
 # Maroon Jumpskirt
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtColorMaroon
   name: maroon jumpskirt
   description: A generic maroon jumpskirt with no rank markings.


### PR DESCRIPTION
# Description

This matters for Birbs. All Colored Jumpskirts were incorrectly parented to Jumpsuit and not Jumpskirt, meaning that Harpies couldn't wear them. This fixes that issue. 

# Changelog

:cl:
- add: Due to NUMEROUS complaints, NanoTrasen has swapped the sticker labels on all colored jumpskirts to correctly state that they are infact, "Skirts", so now they can legally be worn by Harpies, Lamia, and Arachne. 
