### PR TITLE
Make Height Sliders Affect Your Bloodstream Volume

### DIFF
--- a/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Body.Components;
+using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Shared.CCVar;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Contests;
+using Content.Shared.HeightAdjust;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.HeightAdjust;
+
+public sealed class BloodstreamAdjustSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly ContestsSystem _contests = default!;
+    [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<BloodstreamAffectedByMassComponent, MapInitEvent>((uid, comp, _) => TryAdjustBloodstream((uid, comp)));
+        SubscribeLocalEvent<BloodstreamAffectedByMassComponent, HeightAdjustedEvent>((uid, comp, _) => TryAdjustBloodstream((uid, comp)));
+    }
+
+    /// <summary>
+    ///     Adjusts the bloodstream of the specified entity based on the settings provided by the component.
+    /// </summary>
+    public bool TryAdjustBloodstream(Entity<BloodstreamAffectedByMassComponent> ent)
+    {
+        if (!TryComp<BloodstreamComponent>(ent, out var bloodstream)
+            || !_solutionContainer.TryGetSolution(ent.Owner, bloodstream.BloodSolutionName, out var bloodSolutionEnt)
+            || !_config.GetCVar(CCVars.HeightAdjustModifiesBloodstream))
+            return false;
+
+        var bloodSolution = bloodSolutionEnt.Value.Comp.Solution;
+
+        var factor = Math.Pow(_contests.MassContest(ent, bypassClamp: true, rangeFactor: 4f), ent.Comp.Power);
+        factor = Math.Clamp(factor, ent.Comp.Min, ent.Comp.Max);
+
+        var newVolume = bloodstream.BloodMaxVolume * factor;
+        var newBloodLevel = bloodSolution.FillFraction * newVolume;
+        bloodSolution.MaxVolume = newVolume;
+        bloodSolution.SetContents([new ReagentQuantity(bloodstream.BloodReagent, newBloodLevel, null)], false);
+
+        return true;
+    }
+}

--- a/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
@@ -4,8 +4,8 @@ namespace Content.Server.HeightAdjust;
 
 /// <summary>
 ///     When applied to a humanoid or any mob, adjusts their blood level based on the mass contest between them
-///     and an average humanoid. <br/><br/>
-///
+///     and an average humanoid.
+///     <br/>
 ///     The formula for the resulting bloodstream volume is <code>V = BloodMaxVolume * MassContest^Power</code>
 ///     clamped between the specified Min and Max values.
 /// </summary>

--- a/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAffectedByMassComponent.cs
@@ -1,0 +1,26 @@
+using Content.Server.Body.Components;
+
+namespace Content.Server.HeightAdjust;
+
+/// <summary>
+///     When applied to a humanoid or any mob, adjusts their blood level based on the mass contest between them
+///     and an average humanoid. <br/><br/>
+///
+///     The formula for the resulting bloodstream volume is <code>V = BloodMaxVolume * MassContest^Power</code>
+///     clamped between the specified Min and Max values.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BloodstreamAffectedByMassComponent : Component
+{
+    /// <summary>
+    ///     Minimum and maximum resulting volume factors. A minimum value of 0.5 means that the resulting volume will be at least 50% of the original.
+    /// </summary>
+    [DataField]
+    public float Min = 1 / 3f, Max = 3f;
+
+    /// <summary>
+    ///     The power to which the outcome of the mass contest will be risen.
+    /// </summary>
+    [DataField]
+    public float Power = 1f;
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2295,6 +2295,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("heightadjust.modifies_zoom", false, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Whether height & width sliders adjust a player's bloodstream volume.
+        /// </summary>
+        /// <remarks>This can be configured more precisely by modifying BloodstreamAffectedByMassComponent.</remarks>
+        public static readonly CVarDef<bool> HeightAdjustModifiesBloodstream =
+            CVarDef.Create("heightadjust.modifies_bloodstream", true, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Enables station goals
         /// </summary>
         public static readonly CVarDef<bool> StationGoalsEnabled =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2297,7 +2297,9 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Whether height & width sliders adjust a player's bloodstream volume.
         /// </summary>
-        /// <remarks>This can be configured more precisely by modifying BloodstreamAffectedByMassComponent.</remarks>
+        /// <remarks>
+        ///     This can be configured more precisely by modifying BloodstreamAffectedByMassComponent.
+        /// </remarks>
         public static readonly CVarDef<bool> HeightAdjustModifiesBloodstream =
             CVarDef.Create("heightadjust.modifies_bloodstream", true, CVar.SERVERONLY);
 

--- a/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
+++ b/Content.Shared/HeightAdjust/HeightAdjustSystem.cs
@@ -25,27 +25,7 @@ public sealed class HeightAdjustSystem : EntitySystem
     /// <returns>True if all operations succeeded</returns>
     public bool SetScale(EntityUid uid, float scale)
     {
-        var succeeded = true;
-        if (_config.GetCVar(CCVars.HeightAdjustModifiesZoom) && EntityManager.TryGetComponent<ContentEyeComponent>(uid, out var eye))
-            _eye.SetMaxZoom(uid, eye.MaxZoom * scale);
-        else
-            succeeded = false;
-
-        if (_config.GetCVar(CCVars.HeightAdjustModifiesHitbox) && EntityManager.TryGetComponent<FixturesComponent>(uid, out var fixtures))
-            foreach (var fixture in fixtures.Fixtures)
-                _physics.SetRadius(uid, fixture.Key, fixture.Value, fixture.Value.Shape, MathF.MinMagnitude(fixture.Value.Shape.Radius * scale, 0.49f));
-        else
-            succeeded = false;
-
-        if (EntityManager.HasComponent<HumanoidAppearanceComponent>(uid))
-        {
-            _appearance.SetHeight(uid, scale);
-            _appearance.SetWidth(uid, scale);
-        }
-        else
-            succeeded = false;
-
-        return succeeded;
+        return SetScale(uid, new Vector2(scale, scale));
     }
 
     /// <summary>
@@ -74,6 +54,8 @@ public sealed class HeightAdjustSystem : EntitySystem
             _appearance.SetScale(uid, scale);
         else
             succeeded = false;
+
+        RaiseLocalEvent(uid, new HeightAdjustedEvent { NewScale = scale });
 
         return succeeded;
     }

--- a/Content.Shared/HeightAdjust/HeightAdjustedEvent.cs
+++ b/Content.Shared/HeightAdjust/HeightAdjustedEvent.cs
@@ -1,0 +1,11 @@
+using System.Numerics;
+
+namespace Content.Shared.HeightAdjust;
+
+/// <summary>
+///     Raised on a humanoid after their scale has been adjusted in accordance with their profile and their physics have been updated.
+/// </summary>
+public sealed class HeightAdjustedEvent : EntityEventArgs
+{
+    public Vector2 NewScale;
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -309,6 +309,8 @@
   - type: OfferItem
   - type: LayingDown
   - type: Shoving
+  - type: BloodstreamAffectedByMass
+    power: 0.6 # A minimum size felinid will have 30% blood, a minimum size vulp will have 60%, a maximum size oni will have ~200%
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description
Something that just makes sense, this makes your effect character weight affect your bloodstream volume. As a minimum size felinid you will get 33% of normal blood volume, whereas as something as huge as a lamia you may get up to 3 times the normal blood volume.

The resulting volume of your bloodstream can be calculated as `V = clamp(normal_volume * mass_contest ^ 0.6)` (assuming default parameters), where mass_contest is the result of a mass contest between your entity and the average humanoid. For average species like vulps, this means that their bloodstream can become up to ~40% smaller than normal (at minimum size), or up to 50% larger than normal (at maximum size). For onis the range is shifted towards higher values, a maximum size oni will have twice as much blood as an average human.

This has both drawbacks and advantages. For instance, having little blood means you can bleed out easily, but at the same time it means it will take way less blood packs/saline/iron/proteins to restore your blood to the normal level. Opposite is also true, having more blood means you will be harder to heal.

Also, this PR slightly refactors the HeightAdjustSystem to be more flexible.

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/951c2391-09d8-4a4a-812b-a2394862fadd


</p>
</details>

# Changelog
:cl:
- add: Your character size now affects your blood level. Smaller characters will have less blood, and larger characters will have more.