### PR TITLE
Nerf Default Power Attack

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -109,7 +109,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// Total width of the angle for wide attacks.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Angle Angle = Angle.FromDegrees(30);
+    public Angle Angle = Angle.FromDegrees(45);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Animation = "WeaponArcPunch";

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -109,7 +109,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// Total width of the angle for wide attacks.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Angle Angle = Angle.FromDegrees(60);
+    public Angle Angle = Angle.FromDegrees(30);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Animation = "WeaponArcPunch";
@@ -131,7 +131,7 @@ public sealed partial class MeleeWeaponComponent : Component
     public float HeavyStaminaCost = 10f;
 
     [DataField, AutoNetworkedField]
-    public int MaxTargets = 5;
+    public int MaxTargets = 1;
 
     // Sounds
 


### PR DESCRIPTION
# Description

We had some issues and concerns reported by more than a few server hosts that having the default right click be *both* a power attack and a wide swing was extremely undesireable. Since our original intention was to actually deprecate "Wide Swing" only to a handful of a few weapons designed around it, the behavior of this is now that power attack with no wide swing is the default for all weapons. Power attacks are still easier to aim than left clicks, but can only hit a single target except on certain weapons, deal bonus damage in exchange for stamina, and have a narrow 45 degree cone so as to enforce the need to right click at least relatively near your intended target. 

# Changelog

:cl:
- tweak: Wide Swing is no longer possible as a default on all weapons, the default is now Power Attack (10 stamina spent, for 20% bonus damage to single target only). Only a small number of weapons designed to "Cleave", still have their wide swing functionality.
