### PR TITLE
Nerf Uncloneable

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -65,6 +65,7 @@
 - type: trait
   id: Uncloneable
   category: Physical
+  points: 1
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -65,7 +65,6 @@
 - type: trait
   id: Uncloneable
   category: Physical
-  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
# Description

Uncloneable has rightfully obtained a reputation as **THE** powergamer trait, given the fact that it will extremely rarely come up in game, meaning that it essentially provides a ton of "Free" trait points. Due to its status as an extremely minor trait that's really just an opt-out of Cloning, it is not something that should give any free points at all.

# Changelog

:cl:
- tweak: The Uncloneable trait no longer provides extra trait points.
