### PR TITLE
Re-Enable Arrivals

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1576,7 +1576,7 @@ namespace Content.Shared.CCVar
         /// Whether the arrivals shuttle is enabled.
         /// </summary>
         public static readonly CVarDef<bool> ArrivalsShuttles =
-            CVarDef.Create("shuttle.arrivals", false, CVar.SERVERONLY);
+            CVarDef.Create("shuttle.arrivals", true, CVar.SERVERONLY);
 
         /// <summary>
         /// The map to use for the arrivals station.


### PR DESCRIPTION
# Description

Apparently people thought we had removed the Arrivals Terminal from the game. This corrects it so that the default behavior is Arrivals to be enabled. 

# Changelog

:cl:
- fix: Arrivals has been re-enabled. I feel sorry for all the people who thought we had disabled it. This was a legacy toggle that was leftover from when we forked DeltaV
