### PR TITLE
Miscellaneous Item Groups

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/miscItemGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/miscItemGroups.yml
@@ -1,0 +1,123 @@
+- type: characterItemGroup
+  id: LoadoutSmokes
+  items:
+    - type: loadout
+      id: LoadoutItemCig
+    - type: loadout
+      id: LoadoutItemCigsGreen
+    - type: loadout
+      id: LoadoutItemCigsRed
+    - type: loadout
+      id: LoadoutItemCigsBlue
+    - type: loadout
+      id: LoadoutItemCigsBlack
+    - type: loadout
+      id: LoadoutItemCigsMixed
+    - type: loadout
+      id: LoadoutItemCigsSyndicate
+    - type: loadout
+      id: LoadoutItemSmokingPipeFilledTobacco
+    - type: loadout
+      id: LoadoutItemBlunt
+    - type: loadout
+      id: LoadoutItemJoint
+
+- type: characterItemGroup
+  id: LoadoutLighters
+  items:
+    - type: loadout
+      id: LoadoutItemLighter
+    - type: loadout
+      id: LoadoutItemLighterCheap
+    - type: loadout
+      id: LoadoutItemLighterFlippo
+
+- type: characterItemGroup
+  id: LoadoutInstrumentsAny
+  maxItems: 2
+  items:
+    - type: loadout
+      id: LoadoutItemMicrophoneInstrument
+    - type: loadout
+      id: LoadoutItemKalimbaInstrument
+    - type: loadout
+      id: LoadoutItemTrumpetInstrument
+    - type: loadout
+      id: LoadoutItemElectricGuitar
+    - type: loadout
+      id: LoadoutItemBassGuitar
+    - type: loadout
+      id: LoadoutItemRockGuitar
+    - type: loadout
+      id: LoadoutItemAcousticGuitar
+    - type: loadout
+      id: LoadoutItemViolin
+    - type: loadout
+      id: LoadoutItemHarmonica
+    - type: loadout
+      id: LoadoutItemAccordion
+    - type: loadout
+      id: LoadoutItemFlute
+    - type: loadout
+      id: LoadoutItemOcarina
+
+- type: characterItemGroup
+  id: LoadoutAirTank
+  items:
+    - type: loadout
+      id: LoadoutItemsEmergencyOxygenTank
+    - type: loadout
+      id: LoadoutItemsExtendedEmergencyOxygenTank
+    - type: loadout
+      id: LoadoutItemsDoubleEmergencyOxygenTank
+    - type: loadout
+      id: LoadoutSpeciesEmergencyNitrogenTank
+    - type: loadout
+      id: LoadoutSpeciesExtendedEmergencyNitrogenTank
+    - type: loadout
+      id: LoadoutSpeciesDoubleEmergencyNitrogenTank
+
+- type: characterItemGroup
+  id: LoadoutBoxKits
+  items:
+    - type: loadout
+      id: LoadoutItemBoxSurvival
+    - type: loadout
+      id: LoadoutItemBoxSurvivalEngineering
+    - type: loadout
+      id: LoadoutItemBoxSurvivalSecurity
+    - type: loadout
+      id: LoadoutItemBoxSurvivalBrigmedic
+    - type: loadout
+      id: LoadoutItemBoxSurvivalMedical
+    - type: loadout
+      id: LoadoutItemBoxHug
+    - type: loadout
+      id: LoadoutMedkitFilled
+    - type: loadout
+      id: LoadoutMedkitBruteFilled
+    - type: loadout
+      id: LoadoutMedkitBurnFilled
+    - type: loadout
+      id: LoadoutMedkitToxinFilled
+    - type: loadout
+      id: LoadoutMedkitOxygenFilled
+    - type: loadout
+      id: LoadoutMedkitRadiationFilled
+    - type: loadout
+      id: LoadoutMedkitAdvancedFilled
+    - type: loadout
+      id: LoadoutMedkitCombatFilled
+
+- type: characterItemGroup
+  id: LoadoutWritables
+  maxItems: 2
+  items:
+    - type: loadout
+      id: LoadoutItemPapers
+    - type: loadout
+      id: LoadoutItemBoxFolderGrey
+    - type: loadout
+      id: LoadoutBookRandom
+    - type: loadout
+      id: LoadoutPen

--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -2,206 +2,289 @@
 - type: loadout
   id: LoadoutItemCig
   category: Items
-  cost: 1
+  cost: 0
   items:
     - Cigarette
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsGreen
   category: Items
-  cost: 2
+  cost: 0
   items:
     - CigPackGreen
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsRed
   category: Items
-  cost: 2
+  cost: 0
   items:
     - CigPackRed
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsBlue
   category: Items
-  cost: 2
+  cost: 0
   items:
     - CigPackBlue
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsBlack
   category: Items
-  cost: 2
+  cost: 0
   items:
     - CigPackBlack
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsMixed
   category: Items
-  cost: 3
+  cost: 1
   items:
     - CigPackMixed
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemCigsSyndicate
   category: Items
-  cost: 4
+  cost: 2
   items:
     - CigPackSyndicate
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemLighter
   category: Items
-  cost: 2
+  cost: 1
   items:
     - Lighter
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutLighters
 
 - type: loadout
   id: LoadoutItemLighterCheap
   category: Items
-  cost: 1
+  cost: 0
   items:
     - CheapLighter
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutLighters
 
 - type: loadout
   id: LoadoutItemLighterFlippo
   category: Items
-  cost: 3
+  cost: 2
   items:
     - FlippoLighter
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutLighters
 
 - type: loadout
   id: LoadoutItemSmokingPipeFilledTobacco
   category: Items
-  cost: 2
+  cost: 0
   items:
     - SmokingPipeFilledTobacco
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemBlunt
   category: Items
-  cost: 2
+  cost: 0
   items:
     - Blunt
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 - type: loadout
   id: LoadoutItemJoint
   category: Items
-  cost: 2
+  cost: 0
   items:
     - Joint
-
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSmokes
 
 # Instruments
 - type: loadout
   id: LoadoutItemMicrophoneInstrument
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MicrophoneInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemKalimbaInstrument
   category: Items
-  cost: 4
+  cost: 2
   items:
     - KalimbaInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemTrumpetInstrument
   category: Items
-  cost: 6
+  cost: 4
   items:
     - TrumpetInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemElectricGuitar
   category: Items
-  cost: 7
+  cost: 5
   items:
     - ElectricGuitarInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemBassGuitar
   category: Items
-  cost: 7
+  cost: 5
   items:
     - BassGuitarInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemRockGuitar
   category: Items
-  cost: 7
+  cost: 5
   items:
     - RockGuitarInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemAcousticGuitar
   category: Items
-  cost: 7
+  cost: 5
   items:
     - AcousticGuitarInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemViolin
   category: Items
-  cost: 6
+  cost: 4
   items:
     - ViolinInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemHarmonica
   category: Items
-  cost: 3
+  cost: 1
   items:
     - HarmonicaInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemAccordion
   category: Items
-  cost: 6
+  cost: 4
   items:
     - AccordionInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemFlute
   category: Items
-  cost: 4
+  cost: 2
   items:
     - FluteInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 - type: loadout
   id: LoadoutItemOcarina
   category: Items
-  cost: 3
+  cost: 1
   items:
     - OcarinaInstrument
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutInstrumentsAny
 
 # Survival Kit
 - type: loadout
   id: LoadoutItemsEmergencyOxygenTank
   category: Items
-  cost: 1
+  cost: 0
   items:
     - EmergencyOxygenTankFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
 
 - type: loadout
   id: LoadoutItemsExtendedEmergencyOxygenTank
   category: Items
-  cost: 2
+  cost: 1
   items:
     - ExtendedEmergencyOxygenTankFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
 
 - type: loadout
   id: LoadoutItemsDoubleEmergencyOxygenTank
   category: Items
-  cost: 4
+  cost: 2
   items:
     - DoubleEmergencyOxygenTankFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
 
 - type: loadout
   id: LoadoutItemClothingMaskBreath
   category: Items
-  cost: 1
+  cost: 0
   items:
     - ClothingMaskBreath
 
@@ -251,19 +334,25 @@
 - type: loadout
   id: LoadoutItemPapers
   category: Items
-  cost: 1
+  cost: 0
   items:
     - Paper
     - Paper
     - Paper
     - Paper
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWritables
 
 - type: loadout
   id: LoadoutItemBoxFolderGrey
   category: Items
-  cost: 1
+  cost: 0
   items:
     - BoxFolderGrey
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWritables
 
 - type: loadout
   id: LoadoutBookRandom
@@ -271,13 +360,19 @@
   cost: 1
   items:
     - BookRandom
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWritables
 
 - type: loadout
   id: LoadoutPen
   category: Items
-  cost: 1
+  cost: 0
   items:
     - Pen
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWritables
 
 # Food and drink
 - type: loadout
@@ -305,7 +400,7 @@
 - type: loadout
   id: LoadoutItemBoxSurvival
   category: Items
-  cost: 2 #All survival kits are intentionally cheaper than their contents to help encourage people to buy them. The contents can be bought separately to save space, or as spares
+  cost: 0
   items:
     - BoxSurvival
   requirements:
@@ -319,22 +414,26 @@
        inverted: true
        jobs:
          - Clown
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutItemBoxSurvivalEngineering
   category: Items
-  cost: 2
+  cost: 0
   items:
     - BoxSurvivalEngineering
   requirements:
     - !type:CharacterDepartmentRequirement
        departments:
          - Engineering
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutItemBoxSurvivalSecurity
   category: Items
-  cost: 2
+  cost: 0
   items:
     - BoxSurvivalSecurity
   requirements:
@@ -345,52 +444,63 @@
        inverted: true
        jobs:
          - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutItemBoxSurvivalBrigmedic
   category: Items
-  cost: 2
+  cost: 0
   items:
     - BoxSurvivalBrigmedic
   requirements:
     - !type:CharacterJobRequirement
        jobs:
          - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutItemBoxSurvivalMedical
   category: Items
-  cost: 2
+  cost: 0
   items:
     - BoxSurvivalMedical
   requirements:
     - !type:CharacterDepartmentRequirement
        departments:
          - Medical
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutItemBoxHug
   category: Items
-  cost: 2
+  cost: 0
   items:
     - BoxHug
   requirements:
     - !type:CharacterJobRequirement
        jobs:
          - Clown
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 # Medkits
 - type: loadout
   id: LoadoutMedkitFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitBruteFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitBruteFilled
   requirements:
@@ -401,11 +511,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitBurnFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitBurnFilled
   requirements:
@@ -416,11 +528,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitToxinFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitToxinFilled
   requirements:
@@ -431,11 +545,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitOxygenFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitOxygenFilled
   requirements:
@@ -446,11 +562,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitRadiationFilled
   category: Items
-  cost: 4
+  cost: 2
   items:
     - MedkitRadiationFilled
   requirements:
@@ -461,11 +579,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitAdvancedFilled
   category: Items
-  cost: 5
+  cost: 3
   items:
     - MedkitAdvancedFilled
   requirements:
@@ -476,11 +596,13 @@
         - ChiefMedicalOfficer
         - MedicalIntern
         - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 - type: loadout
   id: LoadoutMedkitCombatFilled
   category: Items
-  cost: 4 # Discounted for the CMO and Corpsman
+  cost: 3
   items:
     - MedkitCombatFilled
   requirements:
@@ -488,6 +610,8 @@
        jobs:
          - ChiefMedicalOfficer
          - Brigmedic
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBoxKits
 
 #Misc Items
 - type: loadout

--- a/Resources/Prototypes/Loadouts/species.yml
+++ b/Resources/Prototypes/Loadouts/species.yml
@@ -7,6 +7,8 @@
       species:
         - SlimePerson
         - Vox
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
   items:
     - EmergencyNitrogenTankFilled
 
@@ -19,17 +21,21 @@
       species:
         - SlimePerson
         - Vox
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
   items:
     - ExtendedEmergencyNitrogenTankFilled
 
 - type: loadout
   id: LoadoutSpeciesDoubleEmergencyNitrogenTank
   category: Species
-  cost: 3
+  cost: 2
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
         - SlimePerson
         - Vox
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAirTank
   items:
     - DoubleEmergencyNitrogenTankFilled


### PR DESCRIPTION
# Description

This is the last of the Loadout Item Group PRs I'm going to do for now. This PR adds several more than the previous ones, primarily to split up the Items tab into several distinct groups so as to push down the costs of many items. In particular, the new groups are:

1. Smokes
2. Lighters
3. Instruments
4. Air tanks
5. Box Kits(Survival Boxes or Medkits)
6. Writables

Survival boxes sharing an Item Group with Medkits is kind of intentional here. Both of them take up a SIGNIFICANT amount of your starting inventory space. Now we can have free survival kits once again, but also have as an option, where you can elect to spend some of your loadout points to take a personal Medkit instead of a survival box. You can think of it as an upgrade over a standard survival kit. :)

# Changelog

:cl:
- tweak: Item groups for Smokes, Lighters, Instruments, Air Tanks, SurvivalBoxes/Medkits, and Writable items have been added. All items in these categories have received discounts to their costs, and in some cases have become free. 
