### PR TITLE
Physical Pulling

### DIFF
--- a/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
@@ -36,4 +36,11 @@ public sealed partial class PullableComponent : Component
     [Access(typeof(Systems.PullingSystem), Other = AccessPermissions.ReadExecute)]
     [AutoNetworkedField, DataField]
     public bool PrevFixedRotation;
+
+    /// <summary>
+    ///     Whether the entity is currently being actively pushed by the puller.
+    ///     If true, the entity will be able to enter disposals upon colliding with them, and the like.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BeingActivelyPushed = false;
 }

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Movement.Pulling.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Movement.Pulling.Components;
@@ -11,16 +12,17 @@ namespace Content.Shared.Movement.Pulling.Components;
 [Access(typeof(PullingSystem))]
 public sealed partial class PullerComponent : Component
 {
-    // My raiding guild
     /// <summary>
-    /// Next time the puller can throw what is being pulled.
-    /// Used to avoid spamming it for infinite spin + velocity.
+    ///     Next time the puller change where they are pulling the target towards.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    public TimeSpan NextThrow;
+    public TimeSpan NextPushTargetChange;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan NextPushStop;
 
     [DataField]
-    public TimeSpan ThrowCooldown = TimeSpan.FromSeconds(1);
+    public TimeSpan PushChangeCooldown = TimeSpan.FromSeconds(0.1f), PushDuration = TimeSpan.FromSeconds(2f);
 
     // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
     public float WalkSpeedModifier => Pulling == default ? 1.0f : 0.95f;
@@ -28,14 +30,32 @@ public sealed partial class PullerComponent : Component
     public float SprintSpeedModifier => Pulling == default ? 1.0f : 0.95f;
 
     /// <summary>
-    /// Entity currently being pulled if applicable.
+    ///     Entity currently being pulled/pushed if applicable.
     /// </summary>
     [AutoNetworkedField, DataField]
     public EntityUid? Pulling;
+
+    /// <summary>
+    ///     The position the entity is currently being pulled towards.
+    /// </summary>
+    [AutoNetworkedField, DataField]
+    public EntityCoordinates? PushingTowards;
 
     /// <summary>
     ///     Does this entity need hands to be able to pull something?
     /// </summary>
     [DataField]
     public bool NeedsHands = true;
+
+    /// <summary>
+    ///     The specific force of pushing, in newtons per kilogram. This is multiplied by the puller's physics mass.
+    /// </summary>
+    [DataField]
+    public float SpecificForce = 2.5f;
+
+    /// <summary>
+    ///     The maximum distance between the puller and the point towards which the puller may attempt to pull it, in meters.
+    /// </summary>
+    [DataField]
+    public float MaxPushRange = 2f;
 }

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -51,7 +51,7 @@ public sealed partial class PullerComponent : Component
     ///     The specific force of pushing, in newtons per kilogram. This is multiplied by the puller's physics mass.
     /// </summary>
     [DataField]
-    public float SpecificForce = 2.5f;
+    public float SpecificForce = 0.3f;
 
     /// <summary>
     ///     The maximum distance between the puller and the point towards which the puller may attempt to pull it, in meters.

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -48,10 +48,16 @@ public sealed partial class PullerComponent : Component
     public bool NeedsHands = true;
 
     /// <summary>
-    ///     The specific force of pushing, in newtons per kilogram. This is multiplied by the puller's physics mass.
+    ///     The maximum acceleration of pushing, in meters per second squared.
     /// </summary>
     [DataField]
-    public float SpecificForce = 0.3f;
+    public float PushAcceleration = 0.3f;
+
+    /// <summary>
+    ///     The maximum speed to which the pulled entity may be accelerated relative to the push direction, in meters per second.
+    /// </summary>
+    [DataField]
+    public float MaxPushSpeed = 1.2f;
 
     /// <summary>
     ///     The maximum distance between the puller and the point towards which the puller may attempt to pull it, in meters.

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -8,16 +8,19 @@ using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Projectiles;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -34,6 +37,7 @@ public sealed class PullingSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ActionBlockerSystem _blocker = default!;
     [Dependency] private readonly AlertsSystem _alertsSystem = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _modifierSystem = default!;
@@ -43,7 +47,7 @@ public sealed class PullingSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _xformSys = default!;
-    [Dependency] private readonly ThrowingSystem _throwing = default!;
+    [Dependency] private readonly ThrownItemSystem _thrownItem = default!;
 
     public override void Initialize()
     {
@@ -57,7 +61,9 @@ public sealed class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullableComponent, JointRemovedEvent>(OnJointRemoved);
         SubscribeLocalEvent<PullableComponent, GetVerbsEvent<Verb>>(AddPullVerbs);
         SubscribeLocalEvent<PullableComponent, EntGotInsertedIntoContainerMessage>(OnPullableContainerInsert);
+        SubscribeLocalEvent<PullableComponent, StartCollideEvent>(OnPullableCollide);
 
+        SubscribeLocalEvent<PullerComponent, MoveInputEvent>(OnPullerMoveInput);
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
@@ -67,6 +73,76 @@ public sealed class PullingSystem : EntitySystem
             .Bind(ContentKeyFunctions.MovePulledObject, new PointerInputCmdHandler(OnRequestMovePulledObject))
             .Bind(ContentKeyFunctions.ReleasePulledObject, InputCmdHandler.FromDelegate(OnReleasePulledObject, handle: false))
             .Register<PullingSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        CommandBinds.Unregister<PullingSystem>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient) // Client cannot predict this
+            return;
+
+        var query = EntityQueryEnumerator<PullerComponent, PhysicsComponent, TransformComponent>();
+        while (query.MoveNext(out var puller, out var pullerComp, out var pullerPhysics, out var pullerXForm))
+        {
+            // If not pulling, reset the pushing cooldowns and exit
+            if (pullerComp.Pulling is not { } pulled || !TryComp<PullableComponent>(pulled, out var pulledComp))
+            {
+                pullerComp.PushingTowards = null;
+                pullerComp.NextPushTargetChange = TimeSpan.Zero;
+                continue;
+            }
+
+            pulledComp.BeingActivelyPushed = false; // Temporarily set to false; if the checks below pass, it will be set to true again
+
+            // If pulling but the pullee is invalid or is on a different map, stop pulling
+            var pulledXForm = Transform(pulled);
+            if (!TryComp<PhysicsComponent>(pulled, out var pulledPhysics)
+                || pulledPhysics.BodyType == BodyType.Static
+                || pulledXForm.MapUid != pullerXForm.MapUid)
+            {
+                StopPulling(pulled, pulledComp);
+                continue;
+            }
+
+            if (pullerComp.PushingTowards is null)
+                continue;
+
+            // If pushing but the target position is invalid, or the push action has expired, stop pushing
+            if (pullerComp.NextPushStop < _timing.CurTime
+                || !(pullerComp.PushingTowards.Value.ToMap(EntityManager, _xformSys) is var pushCoordinates)
+                || pushCoordinates.MapId != pulledXForm.MapID)
+            {
+                pullerComp.PushingTowards = null;
+                pullerComp.NextPushTargetChange = TimeSpan.Zero;
+                continue;
+            }
+
+            var desiredDeltaPos = pushCoordinates.Position - Transform(pulled).Coordinates.ToMapPos(EntityManager, _xformSys);
+            var desiredForce = pulledPhysics.Mass * desiredDeltaPos * 60;
+            var maxSourceForce = pullerComp.SpecificForce * pullerPhysics.Mass;
+            var actualForce = desiredForce.LengthSquared() > maxSourceForce * maxSourceForce ? desiredDeltaPos.Normalized() * maxSourceForce : desiredForce;
+
+            _physics.ApplyForce(pulled, actualForce);
+            _physics.ApplyForce(puller, -actualForce);
+            pulledComp.BeingActivelyPushed = true;
+
+            // Means the pullee has been pushed close enough to the destination
+            if (actualForce == desiredForce)
+                pullerComp.PushingTowards = null;
+        }
+        query.Dispose();
+    }
+
+    private void OnPullerMoveInput(EntityUid uid, PullerComponent component, ref MoveInputEvent args)
+    {
+        // Stop pushing
+        component.PushingTowards = null;
+        component.NextPushStop = TimeSpan.Zero;
     }
 
     private void OnPullerContainerInsert(Entity<PullerComponent> ent, ref EntGotInsertedIntoContainerMessage args)
@@ -84,15 +160,26 @@ public sealed class PullingSystem : EntitySystem
         TryStopPull(ent.Owner, ent.Comp);
     }
 
-    public override void Shutdown()
+    private void OnPullableCollide(Entity<PullableComponent> ent, ref StartCollideEvent args)
     {
-        base.Shutdown();
-        CommandBinds.Unregister<PullingSystem>();
+        if (!ent.Comp.BeingActivelyPushed || args.OtherEntity == ent.Comp.Puller)
+            return;
+
+        // This component isn't actually needed anywhere besides the thrownitemsyste`m itself, so we just fake it
+        var fakeThrown = new ThrownItemComponent()
+        {
+            Owner = ent.Owner,
+            Animate = false,
+            Landed = false,
+            PlayLandSound = false,
+            Thrower = ent.Comp.Puller
+        };
+        _thrownItem.ThrowCollideInteraction(fakeThrown, ent, args.OtherEntity);
     }
 
     private void OnPullerUnpaused(EntityUid uid, PullerComponent component, ref EntityUnpausedEvent args)
     {
-        component.NextThrow += args.PausedTime;
+        component.NextPushTargetChange += args.PausedTime;
     }
 
     private void OnVirtualItemDeleted(EntityUid uid, PullerComponent component, VirtualItemDeletedEvent args)
@@ -234,31 +321,22 @@ public sealed class PullingSystem : EntitySystem
 
     private bool OnRequestMovePulledObject(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
     {
-        if (session?.AttachedEntity is not { } player ||
-            !player.IsValid())
-        {
-            return false;
-        }
-
-        if (!TryComp<PullerComponent>(player, out var pullerComp))
+        if (session?.AttachedEntity is not { } player
+            || !player.IsValid()
+            || !TryComp<PullerComponent>(player, out var pullerComp))
             return false;
 
         var pulled = pullerComp.Pulling;
-
-        if (!HasComp<PullableComponent>(pulled))
+        if (!HasComp<PullableComponent>(pulled)
+            || _containerSystem.IsEntityInContainer(player)
+            || _timing.CurTime < pullerComp.NextPushTargetChange)
             return false;
 
-        if (_containerSystem.IsEntityInContainer(player))
-            return false;
-
-        // Cooldown buddy
-        if (_timing.CurTime < pullerComp.NextThrow)
-            return false;
-
-        pullerComp.NextThrow = _timing.CurTime + pullerComp.ThrowCooldown;
+        pullerComp.NextPushTargetChange = _timing.CurTime + pullerComp.PushChangeCooldown;
+        pullerComp.NextPushStop = _timing.CurTime + pullerComp.PushDuration;
 
         // Cap the distance
-        const float range = 2f;
+        var range = pullerComp.MaxPushRange;
         var fromUserCoords = coords.WithEntityId(player, EntityManager);
         var userCoords = new EntityCoordinates(player, Vector2.Zero);
 
@@ -268,8 +346,9 @@ public sealed class PullingSystem : EntitySystem
             fromUserCoords = userCoords.Offset(userDirection.Normalized() * range);
         }
 
+        pullerComp.PushingTowards = fromUserCoords;
         Dirty(player, pullerComp);
-        _throwing.TryThrow(pulled.Value, fromUserCoords, user: player, strength: 4f, animated: false, recoil: false, playSound: false, doSpin: false);
+
         return false;
     }
 

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -25,6 +25,8 @@
   - type: GhostHearing
   - type: Hands
   - type: Puller
+    specificForce: 1000
+    maxPushRange: 20
   - type: CombatMode
   - type: Physics
     ignorePaused: true

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -25,7 +25,7 @@
   - type: GhostHearing
   - type: Hands
   - type: Puller
-    specificForce: 1000
+    pushAcceleration: 1000000 # Will still be capped in max speed
     maxPushRange: 20
   - type: CombatMode
   - type: Physics


### PR DESCRIPTION
# Description
Fixes pulling being obnoxiously unphysical. Entities now exert a specific amount of force defined as the product of their mass and the SpecificForce set in their PullerComponent. Doing a ctrl-right click now sets a target position where your entity begins to continuously push the pulled entity towards, instead of throwing it or pushing it once (however, it should still be possible to drag people and disposals and the like). Additionally, your entity will properly experience recoil from dragging someone around.

# TODO
- [X] Do stuff
- [X] Fix stuff
- [X] Fix aghosts not being able to push (?)
- [X] Fix pulling giving you free kinetic energy while in spess (how?)
- [ ] Test if throwing felinids into disposals via pulling still works :trollface:

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/2498ef8c-f743-4702-b73c-b2da0c16e9aa


</p>
</details>

# Changelog
:cl:
- add: Pulling has been reworked. Your character will now try to continuously push the pulled entity when you use the push keybind.
- remove: You can no longer push the pulled entity while walking, and pushing now follows the momentum conservation laws.