### PR TITLE
Make Blood Deficiency Bloodloss Consistent

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -181,9 +181,9 @@ namespace Content.Server.Body.Components
         public bool HasBloodDeficiency = false;
 
         /// <summary>
-        ///     How much reagent of blood should be removed with blood deficiency in each update interval?
+        ///     How much percentage of max blood volume should be removed with blood deficiency in each update interval?
         /// </summary>
         [DataField]
-        public FixedPoint2 BloodDeficiencyLossAmount;
+        public float BloodDeficiencyLossPercentage;
     }
 }

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -122,7 +122,7 @@ public sealed class BloodstreamSystem : EntitySystem
             if (bloodstream.HasBloodDeficiency)
             {
                 if (!_mobStateSystem.IsDead(uid))
-                    RemoveBlood(uid, bloodstream.BloodDeficiencyLossAmount, bloodstream);
+                    RemoveBlood(uid, bloodstream.BloodMaxVolume * bloodstream.BloodDeficiencyLossPercentage, bloodstream);
             }
             // Adds blood to their blood level if it is below the maximum.
             else if (bloodSolution.Volume < bloodSolution.MaxVolume && !_mobStateSystem.IsDead(uid))
@@ -347,6 +347,14 @@ public sealed class BloodstreamSystem : EntitySystem
             return;
 
         comp.BloodlossThreshold = threshold;
+    }
+
+    public void SetBloodMaxVolume(EntityUid uid, FixedPoint2 volume, BloodstreamComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        comp.BloodMaxVolume = volume;
     }
 
     /// <summary>

--- a/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
+++ b/Content.Server/HeightAdjust/BloodstreamAdjustSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Components;
+using Content.Server.Body.Systems;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Shared.CCVar;
 using Content.Shared.Chemistry.Reagent;
@@ -10,6 +11,7 @@ namespace Content.Server.HeightAdjust;
 
 public sealed class BloodstreamAdjustSystem : EntitySystem
 {
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly ContestsSystem _contests = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
@@ -39,6 +41,8 @@ public sealed class BloodstreamAdjustSystem : EntitySystem
         var newBloodLevel = bloodSolution.FillFraction * newVolume;
         bloodSolution.MaxVolume = newVolume;
         bloodSolution.SetContents([new ReagentQuantity(bloodstream.BloodReagent, newBloodLevel, null)], false);
+
+        _bloodstream.SetBloodMaxVolume(ent.Owner, newVolume, bloodstream);
 
         return true;
     }

--- a/Content.Server/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Server/Traits/BloodDeficiencyComponent.cs
@@ -7,8 +7,8 @@ namespace Content.Server.Traits.Assorted;
 public sealed partial class BloodDeficiencyComponent : Component
 {
     // <summary>
-    //     How much reagent of blood should be removed in each update interval?
+    ///     How much percentage of max blood volume should be removed in each update interval?
     // </summary>
     [DataField(required: true)]
-    public float BloodLossAmount;
+    public float BloodLossPercentage;
 }

--- a/Content.Server/Traits/BloodDeficiencySystem.cs
+++ b/Content.Server/Traits/BloodDeficiencySystem.cs
@@ -18,6 +18,6 @@ public sealed class BloodDeficiencySystem : EntitySystem
             return;
 
         bloodstream.HasBloodDeficiency = true;
-        bloodstream.BloodDeficiencyLossAmount = component.BloodLossAmount;
+        bloodstream.BloodDeficiencyLossPercentage = component.BloodLossPercentage;
     }
 }

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -168,8 +168,8 @@
       species:
         - IPC
   components:
-    - type: BloodDeficiency  # 0.07 = start taking bloodloss damage at around ~21.4 minutes,
-      bloodLossAmount: 0.07  # then become crit ~10 minutes later
+    - type: BloodDeficiency              # by default, start taking bloodloss damage at around ~21.4 minutes,
+      bloodLossPercentage: 0.0002333333  # then become crit ~10 minutes
 
 - type: trait
   id: Hemophilia


### PR DESCRIPTION
# Description

With https://github.com/Simple-Station/Einstein-Engines/pull/858 (Make Height Sliders Affect Your Bloodstream Volume) being merged, it introduced variable blood volumes for differing sizes, whereas before everyone had the same blood volume (300u).

Because Blood Deficiency subtracted a flat amount from the bloodstream, it resulted in an unintended consequence where small characters died very quickly due to blood loss, while large characters could live for hours. This makes the blood loss amount of Blood Deficiency a **percentage** of the entity's max blood volume, which means that the time to become low blood is now the same regardless of blood volume.

# Changelog

:cl: Skubman
- fix: Blood Deficiency now makes you lose a consistent percentage of blood regardless of your blood volume, which is dictated by size. This makes the time to low blood and death consistent for every character of all sizes with this trait.