### PR TITLE
Jetpack Server Configuration

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2467,5 +2467,21 @@ namespace Content.Shared.CCVar
             CVarDef.Create("reclaimer.allow_gibbing", true, CVar.SERVER);
 
         #endregion
+
+        #region Jetpack System
+
+        /// <summary>
+        ///     When true, Jetpacks can be enabled anywhere, even in gravity.
+        /// </summary>
+        public static readonly CVarDef<bool> JetpackEnableAnywhere =
+            CVarDef.Create("jetpack.enable_anywhere", false, CVar.REPLICATED);
+
+        /// <summary>
+        ///     When true, jetpacks can be enabled on grids that have zero gravity.
+        /// </summary>
+        public static readonly CVarDef<bool> JetpackEnableInNoGravity =
+            CVarDef.Create("jetpack.enable_in_no_gravity", true, CVar.REPLICATED);
+
+        #endregion
     }
 }

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -1,9 +1,11 @@
 using Content.Shared.Actions;
+using Content.Shared.CCVar;
 using Content.Shared.Gravity;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
+using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -20,6 +22,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     [Dependency] private   readonly SharedPopupSystem _popup = default!;
     [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     public override void Initialize()
     {
@@ -125,8 +128,11 @@ public abstract class SharedJetpackSystem : EntitySystem
 
     private bool CanEnableOnGrid(EntityUid? gridUid)
     {
-        return gridUid == null ||
-               (!HasComp<GravityComponent>(gridUid));
+        return _config.GetCVar(CCVars.JetpackEnableAnywhere)
+            || gridUid == null
+            || _config.GetCVar(CCVars.JetpackEnableInNoGravity)
+            && TryComp<GravityComponent>(gridUid, out var comp)
+            && comp.Enabled;
     }
 
     private void OnJetpackGetAction(EntityUid uid, JetpackComponent component, GetItemActionsEvent args)


### PR DESCRIPTION
# Description

Jetpacks can now be configured via CCVar in a server's TOML file to allow for certain behaviors that people have repeatedly asked for, and were denied by Wizden on the basis that, "Wizden doesn't want this on their servers". Well the request has reached my lap, and my response to this is, "I have the power to give that choice directly to individual servers."

Here you go. Enjoy.
This PR makes it so that jetpacks can be set in Server Configuration to 
- Be usable in ANY condition, even on grids with gravity
- Be usable in zero gravity, even on grids
- Or set the 2 new CVars to false, and it'll just work like it did before. 

# Changelog

:cl:
- add: Jetpacks now work in zero gravity.
- add: New CCVar "jetpack.enable_anywhere" allows server hosts to optionally make it so that jetpacks can be used anywhere, even in gravity and on grids.
- add: New CCVar "jetpack.enable_in_no_gravity" allows server hosts to optionally disable jetpacks being usable in zero gravity.