### PR TITLE
Reverse Engineering Update Pr Port/ Board Cost Balance 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -28,6 +28,10 @@
     - type: Tag
       tags:
       - WhitelistChameleon
+    - type: ReverseEngineering
+      difficulty: 2
+      recipes:
+        - ClothingShoesBootsMag
 
 - type: entity
   parent: ClothingShoesBootsMag

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -87,10 +87,10 @@
         MatterBin: 4
       materialRequirements:
         Glass: 1
-   - type: ReverseEngineering # Delta
-     difficulty: 2
-     recipes:
-       - BiofabricatorMachineCircuitboard
+    - type: ReverseEngineering # Delta
+      difficulty: 2
+      recipes:
+        - BiofabricatorMachineCircuitboard
 
 - type: entity
   id: SecurityTechFabCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -29,6 +29,10 @@
         Amount: 1
         DefaultPrototype: Igniter
         ExamineName: Igniter
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - AutolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   id: ProtolatheMachineCircuitboard
@@ -66,6 +70,10 @@
         Amount: 1
         DefaultPrototype: Igniter
         ExamineName: Igniter
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - ProtolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   id: BiofabricatorMachineCircuitboard
@@ -151,10 +159,6 @@
         Amount: 2
         DefaultPrototype: Beaker
         ExamineName: Glass Beaker
-  - type: ReverseEngineering # Nyano
-    difficulty: 3
-    recipes:
-      - CircuitImprinterMachineCircuitboard
 
 - type: entity
   id: ExosuitFabricatorMachineCircuitboard
@@ -171,7 +175,7 @@
     materialRequirements:
       Glass: 5
   - type: ReverseEngineering # Nyano
-    difficulty: 3
+    difficulty: 2
     recipes:
       - ExosuitFabricatorMachineCircuitboard
   - type: GuideHelp
@@ -202,10 +206,6 @@
     requirements:
       MatterBin: 1
       Manipulator: 2
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - UniformPrinterMachineCircuitboard
 
 - type: entity
   id: VaccinatorMachineCircuitboard
@@ -313,6 +313,10 @@
     materialRequirements:
       Glass: 1
       Steel: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - ArtifactCrusherMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -350,6 +354,10 @@
       Cable: 5
       PlasmaGlass: 15
       MetalRod: 4
+  - type: ReverseEngineering # Nyano
+    difficulty: 2
+    recipes:
+      - AnomalyVesselExperimentalCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -367,6 +375,10 @@
       materialRequirements:
         PlasmaGlass: 5
         Cable: 5
+    - type: ReverseEngineering # Delta
+      difficulty: 3
+      recipes:
+        - AnomalySynchronizerCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -451,6 +463,10 @@
     deconstructionTarget: null
     graph: ThermomachineBoard
     node: hellfirefreezer
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - HellfireFreezerMachineCircuitBoard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -596,6 +612,10 @@
       materialRequirements:
         Steel: 1
         Cable: 2
+    - type: ReverseEngineering # Delta
+      difficulty: 3
+      recipes:
+        - CrewMonitoringServerMachineCircuitboard
 
 - type: entity
   id: CryoPodMachineCircuitboard
@@ -635,10 +655,6 @@
           Amount: 2
           DefaultPrototype: Beaker
           ExamineName: Glass Beaker
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - ChemMasterMachineCircuitboard
 
 - type: entity
   id: ChemDispenserMachineCircuitboard
@@ -660,10 +676,6 @@
           Amount: 2
           DefaultPrototype: Beaker
           ExamineName: Glass Beaker
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - ChemDispenserMachineCircuitboard
 
 - type: entity
   id: BiomassReclaimerMachineCircuitboard
@@ -750,9 +762,6 @@
         PowerCell: 4
       materialRequirements:
         CableHV: 10
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - SMESMachineCircuitboard
 
 - type: entity
   id: CellRechargerCircuitboard
@@ -862,6 +871,10 @@
     materialComposition:
       Steel: 30
       Plastic: 30
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - TurboItemRechargerCircuitboard
 
 - type: entity
   id: SubstationMachineCircuitboard
@@ -877,9 +890,6 @@
       materialRequirements:
         CableMV: 5
         CableHV: 5
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - SubstationMachineCircuitboard
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -921,7 +931,7 @@
           DefaultPrototype: SaxophoneInstrument
           ExamineName: Woodwind Instrument
     - type: ReverseEngineering # Nyano
-      difficulty: 3
+      difficulty: 2
       recipes:
         - DawInstrumentMachineCircuitboard
 
@@ -938,10 +948,6 @@
         Capacitor: 1
       materialRequirements:
         CableHV: 5
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - GeneratorPlasmaMachineCircuitboard
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -949,6 +955,10 @@
         Silicon: 20
     - type: StaticPrice
       price: 40
+    - type: ReverseEngineering # Nyano
+      difficulty: 2
+      recipes:
+        - PortableGeneratorPacmanMachineCircuitboard
 
 - type: entity
   id: ThrusterMachineCircuitboard
@@ -961,6 +971,10 @@
       Capacitor: 4
     materialRequirements:
       Steel: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - ThrusterMachineCircuitboard
 
 - type: entity
   id: GyroscopeMachineCircuitboard
@@ -974,6 +988,10 @@
       Capacitor: 1
     materialRequirements:
       Glass: 2
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - GyroscopeMachineCircuitboard
 
 - type: entity
   id: PortableGeneratorSuperPacmanMachineCircuitboard
@@ -993,12 +1011,12 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 40
     - type: ReverseEngineering # Nyano
       difficulty: 2
       recipes:
         - PortableGeneratorSuperPacmanMachineCircuitboard
-    - type: StaticPrice
-      price: 40
 
 - type: entity
   id: PortableGeneratorJrPacmanMachineCircuitboard
@@ -1020,6 +1038,10 @@
         Silicon: 20
     - type: StaticPrice
       price: 40
+    - type: ReverseEngineering # Nyano
+      difficulty: 2
+      recipes:
+        - PortableGeneratorJrPacmanMachineCircuitboard
 
 - type: entity
   id: ReagentGrinderMachineCircuitboard
@@ -1054,7 +1076,7 @@
         Capacitor: 2
       materialRequirements:
         Glass: 1
-    - type: ReverseEngineering # Nyano
+    - type: ReverseEngineering # Delta
       difficulty: 2
       recipes:
         - HotplateMachineCircuitboard
@@ -1072,6 +1094,10 @@
     materialRequirements:
       Glass: 2
       Cable: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - ElectricGrillMachineCircuitboard
 
 - type: entity
   id: StasisBedMachineCircuitboard
@@ -1137,6 +1163,10 @@
       materialRequirements:
         Steel: 5
         Plastic: 5
+    - type: ReverseEngineering # Delta
+      difficulty: 2
+      recipes:
+        - MaterialReclaimerMachineCircuitboard
 
 - type: entity
   id: OreProcessorMachineCircuitboard
@@ -1152,9 +1182,6 @@
         Manipulator: 3
       materialRequirements:
         Glass: 1
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - OreProcessorMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1170,6 +1197,10 @@
       Manipulator: 3
     materialRequirements:
       Glass: 1
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - OreProcessorIndustrialMachineCircuitboard
 
 - type: entity
   id: SheetifierMachineCircuitboard
@@ -1216,6 +1247,10 @@
           Amount: 1
           DefaultPrototype: ForkPlastic
           ExamineName: Utensil
+    - type: ReverseEngineering # Delta
+      difficulty: 2
+      recipes:
+        - FatExtractorMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1229,6 +1264,10 @@
       MatterBin: 1
     materialRequirements:
       Steel: 1
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      - FlatpackerMachineCircuitboard
 
 - type: entity
   id: EmitterCircuitboard
@@ -1348,9 +1387,6 @@
             Amount: 1
             DefaultPrototype: Beaker
             ExamineName: Glass Beaker
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - BoozeDispenserMachineCircuitboard
 
 - type: entity
   id: CargoTelepadMachineCircuitboard
@@ -1367,6 +1403,10 @@
       materialRequirements:
         Steel: 5
         Bluespace: 2  #DeltaV Bluespace Exists
+    - type: ReverseEngineering # Delta
+      difficulty: 3
+      recipes:
+        - CargoTelepadMachineCircuitboard
 
 - type: entity
   id: SodaDispenserMachineCircuitboard
@@ -1385,9 +1425,6 @@
             Amount: 1
             DefaultPrototype: Beaker
             ExamineName: Glass Beaker
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - SodaDispenserMachineCircuitboard
 
 - type: entity
   id: TelecomServerCircuitboard
@@ -1437,6 +1474,10 @@
       Steel: 5
       CableHV: 5
       Uranium: 2
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - MiniGravityGeneratorCircuitboard
 
 - type: entity
   id: ShuttleGunSvalinnMachineGunCircuitboard
@@ -1454,6 +1495,10 @@
     materialRequirements:
       Steel: 5
       CableHV: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - ShuttleGunSvalinnMachineGunCircuitboard
 
 - type: entity
   id: ShuttleGunPerforatorCircuitboard
@@ -1471,6 +1516,10 @@
     materialRequirements:
       Steel: 10
       CableHV: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - ShuttleGunPerforatorCircuitboard
 
 - type: entity
   id: ShuttleGunFriendshipCircuitboard
@@ -1488,6 +1537,10 @@
     materialRequirements:
       Steel: 7
       CableHV: 5
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - ShuttleGunFriendshipCircuitboard
 
 - type: entity
   id: ShuttleGunDusterCircuitboard
@@ -1506,6 +1559,10 @@
       Steel: 10
       CableHV: 5
       Uranium: 2
+  - type: ReverseEngineering # Delta
+    difficulty: 4
+    recipes:
+      -  ShuttleGunDusterCircuitboard
 
 - type: entity
   id: ShuttleGunKineticCircuitboard
@@ -1523,6 +1580,10 @@
     materialRequirements:
       Steel: 5
       CableHV: 2
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      -  ShuttleGunKineticCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1536,6 +1597,10 @@
       Manipulator: 3
     materialRequirements:
       Glass: 1
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      -  ReagentGrinderIndustrialMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1550,3 +1615,8 @@
       Steel: 2
       Glass: 5
       Cable: 2
+  - type: ReverseEngineering # Delta
+    difficulty: 2
+    recipes:
+      -  JukeboxCircuitBoard
+

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -87,6 +87,10 @@
         MatterBin: 4
       materialRequirements:
         Glass: 1
+   - type: ReverseEngineering # Delta
+     difficulty: 2
+     recipes:
+       - BiofabricatorMachineCircuitboard
 
 - type: entity
   id: SecurityTechFabCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -122,6 +122,10 @@
       prototype: ComputerSalvageExpedition
     - type: StealTarget
       stealGroup: SalvageExpeditionsComputerCircuitboard
+    - type: ReverseEngineering # Nyano
+      difficulty: 2
+      recipes:
+        - SalvageExpeditionsComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -176,6 +180,10 @@
       prototype: ComputerTelevision
     - type: Tag
       tags:
+        - ComputerTelevisionCircuitboard
+    - type: ReverseEngineering # Nyano
+      difficulty: 2
+      recipes:
         - ComputerTelevisionCircuitboard
 
 - type: entity
@@ -286,6 +294,10 @@
   components:
   - type: ComputerBoard
     prototype: ComputerRadar
+  - type: ReverseEngineering # Nyano
+    difficulty: 2
+    recipes:
+       - RadarConsoleCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -339,6 +351,10 @@
   components:
     - type: ComputerBoard
       prototype: ComputerShuttle
+    - type: ReverseEngineering # Nyano
+      difficulty: 3
+      recipes:
+        - ShuttleConsoleCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -396,6 +412,10 @@
       price: 150
     - type: ComputerBoard
       prototype: ComputerMassMedia
+    - type: ReverseEngineering # Nyano
+      difficulty: 3
+      recipes:
+        - ComputerMassMediaCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -9,10 +9,6 @@
     layers:
     - state: icon
   - type: HandTeleporter
-  - type: ReverseEngineering # Nyano
-    difficulty: 4
-    recipes:
-      - HandTeleporter
   - type: Tag
     tags:
     - HighRiskItem

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -68,6 +68,7 @@
   - type: StaticPrice
     price: 80
   - type: ReverseEngineering # Nyano
+    difficulty: 3
     recipes:
       - HolofanProjector
 
@@ -98,6 +99,10 @@
         - HolofanProjector
     - type: StaticPrice
       price: 130
+    - type: ReverseEngineering # Nyano
+      difficulty: 3
+      recipes:
+        - HoloprojectorField
 
 - type: entity
   parent: HoloprojectorField

--- a/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
@@ -25,3 +25,7 @@
   - type: Tag
     tags:
     - QuantumSpinInverter
+  - type: ReverseEngineering # Delta
+    difficulty: 4
+    recipes:
+      - DeviceQuantumSpinInverter

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -227,6 +227,10 @@
       beaker:
         maxVol: 60
         canReact: false
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - CryostasisBeaker
 
 - type: entity
   name: bluespace beaker
@@ -245,6 +249,10 @@
       beaker:
         maxVol: 1000
         canMix: true
+  - type: ReverseEngineering # Delta
+    difficulty: 4
+    recipes:
+      - BluespaceBeaker
 
 - type: entity
   name: dropper
@@ -401,6 +409,10 @@
     tags:
     - Syringe
     - Trash
+  - type: ReverseEngineering # Delta
+    difficulty: 4
+    recipes:
+      - SyringeBluespace
 
 - type: entity
   id: SyringeCryostasis
@@ -432,7 +444,10 @@
     tags:
     - Syringe
     - Trash
-
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - SyringeCryostasis
 
 - type: entity
   name: pill

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -38,6 +38,10 @@
         type: RadarConsoleBoundUserInterface
   - type: StaticPrice
     price: 150
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - HandHeldMassScanner
 
 - type: entity
   id: HandHeldMassScannerEmpty

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -58,6 +58,10 @@
     angle: 20
     soundHit:
       collection: MetalThud
+  - type: ReverseEngineering # Delta
+    difficulty: 3
+    recipes:
+      - JawsOfLife
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -413,10 +413,6 @@
       Plastic: 100
 #  - type: DynamicPrice
 #    price: 100
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - PowerDrill
   - type: StaticPrice
     price: 100
   - type: MeleeWeapon
@@ -433,6 +429,10 @@
     angle: 20
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
+  - type: ReverseEngineering # Nyano
+    difficulty: 2
+    recipes:
+      - PowerDrill
 
 - type: entity
   id: RCD
@@ -477,8 +477,8 @@
     - Belt
   - type: PhysicalComposition
     materialComposition:
-      Steel: 600
-      Plastic: 100
+      Steel: 1200
+      Plastic: 200
   - type: StaticPrice
     price: 100
   - type: UserInterface
@@ -487,6 +487,10 @@
       type: RCDMenuBoundUserInterface
   - type: ActivatableUI
     key: enum.RcdUiKey.Key
+  - type: ReverseEngineering # Nyano
+    difficulty: 3
+    recipes:
+      - RCD
 
 - type: entity
   id: RCDEmpty

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -490,7 +490,7 @@
   - type: ReverseEngineering # Nyano
     difficulty: 3
     recipes:
-      - RCDEmpty
+      - RCD
 
 - type: entity
   id: RCDEmpty

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -552,7 +552,7 @@
     heldPrefix: ammo
   - type: PhysicalComposition
     materialComposition:
-      Steel: 100
+      Steel: 600
       Plastic: 100
   - type: StaticPrice
     price: 60

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -477,8 +477,8 @@
     - Belt
   - type: PhysicalComposition
     materialComposition:
-      Steel: 1200
-      Plastic: 200
+      Steel: 600
+      Plastic: 150
   - type: StaticPrice
     price: 100
   - type: UserInterface
@@ -552,7 +552,7 @@
     heldPrefix: ammo
   - type: PhysicalComposition
     materialComposition:
-      Steel: 600
+      Steel: 300
       Plastic: 100
   - type: StaticPrice
     price: 60

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -490,7 +490,7 @@
   - type: ReverseEngineering # Nyano
     difficulty: 3
     recipes:
-      - RCD
+      - RCDEmpty
 
 - type: entity
   id: RCDEmpty

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -355,6 +355,8 @@
       - AnimalTranslator
       - MofficTranslatorImplanter
       - MofficTranslator
+      - RCDammo #DeltaV
+      - RCD #EE
   - type: EmagLatheRecipes
     emagDynamicRecipes:
       - ExplosivePayload
@@ -510,8 +512,6 @@
       - MetempsychoticMachineCircuitboard
     # End Nyano additions
       - SalvageExpeditionsComputerCircuitboard # DeltaV
-      - RCDammo #DeltaV
-      - RCD #EE
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -355,7 +355,7 @@
       - AnimalTranslator
       - MofficTranslatorImplanter
       - MofficTranslator
-      - RCDammo #DeltaV
+      - RCDAmmo #DeltaV
       - RCD #EE
   - type: EmagLatheRecipes
     emagDynamicRecipes:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -510,6 +510,8 @@
       - MetempsychoticMachineCircuitboard
     # End Nyano additions
       - SalvageExpeditionsComputerCircuitboard # DeltaV
+      - RCDammo #DeltaV
+      - RCD #EE
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/CircuitBoards/production.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/CircuitBoards/production.yml
@@ -12,9 +12,8 @@
         MatterBin: 1
         Manipulator: 1
       materialRequirements:
-        Glass: 1
         Cable: 1
-        Diamond: 10
+        PlasmaGlass: 5
       tagRequirements:
         BorgArm:
           Amount: 3

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -17,12 +17,12 @@
      Gold: 100
 
 - type: latheRecipe
- id: CrewMonitoringComputerCircuitboard
- result: CrewMonitoringComputerCircuitboard
- completetime: 4
- materials:
-    Steel: 100
-    Glass: 400
+   id: CrewMonitoringComputerCircuitboard
+   result: CrewMonitoringComputerCircuitboard
+   completetime: 4
+   materials:
+      Steel: 100
+      Glass: 400
 
 - type: latheRecipe
   id: ClothingEyesHudMedical

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -1,28 +1,28 @@
-- type: latheRecipe
-  id: ReverseEngineeringMachineCircuitboard
-  result: ReverseEngineeringMachineCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 500
-     Gold: 100
+#- type: latheRecipe
+#  id: ReverseEngineeringMachineCircuitboard
+#  result: ReverseEngineeringMachineCircuitboard
+#  completetime: 4
+#  materials:
+#     Steel: 100
+#     Glass: 900
+#     Gold: 100
 
-- type: latheRecipe
-  id: SalvageMagnetMachineCircuitboard
-  result: SalvageMagnetMachineCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 500
-     Gold: 100
+#- type: latheRecipe
+#  id: SalvageMagnetMachineCircuitboard
+#  result: SalvageMagnetMachineCircuitboard
+#  completetime: 4
+#  materials:
+#     Steel: 100
+#     Glass: 900
+#    Gold: 100
 
-- type: latheRecipe
-  id: CrewMonitoringComputerCircuitboard
-  result: CrewMonitoringComputerCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 500
+#- type: latheRecipe
+# id: CrewMonitoringComputerCircuitboard
+# result: CrewMonitoringComputerCircuitboard
+# completetime: 4
+# materials:
+#    Steel: 100
+#     Glass: 900
 
 - type: latheRecipe
   id: ClothingEyesHudMedical
@@ -34,11 +34,11 @@
     Glass: 300
     Plasma: 200
 
-- type: latheRecipe
-  id: DeepFryerMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
-  result: DeepFryerMachineCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 900
+#- type: latheRecipe
+#  id: DeepFryerMachineCircuitboard
+#  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
+#  result: DeepFryerMachineCircuitboard
+#  completetime: 4
+#  materials:
+#     Steel: 100
+#     Glass: 900

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -4,7 +4,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 900
+     Glass: 500
      Gold: 100
 
 - type: latheRecipe
@@ -13,7 +13,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 900
+     Glass: 500
      Gold: 100
 
 - type: latheRecipe
@@ -22,7 +22,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 900
+     Glass: 500
 
 - type: latheRecipe
   id: ClothingEyesHudMedical

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -17,12 +17,12 @@
      Gold: 100
 
 - type: latheRecipe
-   id: CrewMonitoringComputerCircuitboard
-   result: CrewMonitoringComputerCircuitboard
-   completetime: 4
-   materials:
-      Steel: 100
-      Glass: 400
+  id: CrewMonitoringComputerCircuitboard
+  result: CrewMonitoringComputerCircuitboard
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 400
 
 - type: latheRecipe
   id: ClothingEyesHudMedical

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -1,28 +1,28 @@
-#- type: latheRecipe
-#  id: ReverseEngineeringMachineCircuitboard
-#  result: ReverseEngineeringMachineCircuitboard
-#  completetime: 4
-#  materials:
-#     Steel: 100
-#     Glass: 900
-#     Gold: 100
+- type: latheRecipe
+  id: ReverseEngineeringMachineCircuitboard
+  result: ReverseEngineeringMachineCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 400
+     Gold: 100
 
-#- type: latheRecipe
-#  id: SalvageMagnetMachineCircuitboard
-#  result: SalvageMagnetMachineCircuitboard
-#  completetime: 4
-#  materials:
-#     Steel: 100
-#     Glass: 900
-#    Gold: 100
+- type: latheRecipe
+  id: SalvageMagnetMachineCircuitboard
+  result: SalvageMagnetMachineCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 400
+     Gold: 100
 
-#- type: latheRecipe
-# id: CrewMonitoringComputerCircuitboard
-# result: CrewMonitoringComputerCircuitboard
-# completetime: 4
-# materials:
-#    Steel: 100
-#     Glass: 900
+- type: latheRecipe
+ id: CrewMonitoringComputerCircuitboard
+ result: CrewMonitoringComputerCircuitboard
+ completetime: 4
+ materials:
+    Steel: 100
+    Glass: 400
 
 - type: latheRecipe
   id: ClothingEyesHudMedical
@@ -34,11 +34,11 @@
     Glass: 300
     Plasma: 200
 
-#- type: latheRecipe
-#  id: DeepFryerMachineCircuitboard
-#  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
-#  result: DeepFryerMachineCircuitboard
-#  completetime: 4
-#  materials:
-#     Steel: 100
-#     Glass: 900
+- type: latheRecipe
+  id: DeepFryerMachineCircuitboard
+  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
+  result: DeepFryerMachineCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 400

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -4,7 +4,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 600
+     Glass: 700
      Gold: 100
 
 - type: latheRecipe
@@ -13,7 +13,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 600
+     Glass: 700
      Gold: 100
 
 - type: latheRecipe
@@ -22,7 +22,7 @@
   completetime: 4
   materials:
     Steel: 100
-    Glass: 600
+    Glass: 700
 
 - type: latheRecipe
   id: ClothingEyesHudMedical
@@ -41,4 +41,4 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 600
+     Glass: 700

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/electronics.yml
@@ -4,7 +4,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 400
+     Glass: 600
      Gold: 100
 
 - type: latheRecipe
@@ -13,7 +13,7 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 400
+     Glass: 600
      Gold: 100
 
 - type: latheRecipe
@@ -22,7 +22,7 @@
   completetime: 4
   materials:
     Steel: 100
-    Glass: 400
+    Glass: 600
 
 - type: latheRecipe
   id: ClothingEyesHudMedical
@@ -41,4 +41,4 @@
   completetime: 4
   materials:
      Steel: 100
-     Glass: 400
+     Glass: 600

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -56,6 +56,7 @@
   cost: 5000
   recipeUnlocks:
   - TechDiskComputerCircuitboard
+  - ReverseEngineeringMachineCircuitboard #DeltaV
 
 - type: technology
   id: MagnetsTech


### PR DESCRIPTION

Ports the re update from delta and adds the Rcd and its ammo to the re machine along with jaws of life for more potential usage. Also moves the Re components to the Bottom of each yml item for items with the Re component placed in the middle likely from time and neglect, so it's consistent and less messy and better to understand. Also makes the cost of the naynoboards consistent with the other boards 


Expands the re machines catalog and adds it to alternate research tech as well as making it craft able via plasma glass, makes all Nanyo-boards the same cost as the ones from the hyper lathe updates such 
I think this would help those who wish to work on the re machine helps with future updates I need to flesh out too such as the other syndicate suits and items, adds a little more use and makes it consistent with another tech in nt's catalog. The Remechine has been neglected for a long time, and it seems that super parts are in the work here so ill likely make the suits and wait for the updates rather than making a super re-machine like planed.
--
Media 

![Screenshot 2024-09-11 114101](https://github.com/user-attachments/assets/b337ee2b-e851-40c4-9377-8ff17c932908)
![Screenshot 2024-09-11 114140](https://github.com/user-attachments/assets/3f75f8ca-ca04-4670-b254-cdd6b6f703be)
![Screenshot 2024-09-11 113137](https://github.com/user-attachments/assets/00b31c57-6d8d-46ba-8887-0e6e2a55269d)


---

# Changelog


:cl:
- add: added rcds to the list of possible re and ported over the re update from delta 
- tweak: tweaked the costs of boards re-machine boards to be more consistent with their post hyper lathe update counter parts

