### PR TITLE
Add Access Wire to Airlocks

### DIFF
--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -1,6 +1,7 @@
 - type: wireLayout
   id: Airlock
   wires:
+  - !type:AccessWireAction
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
@@ -44,6 +45,7 @@
 - type: wireLayout
   id: HighSec
   wires:
+  - !type:AccessWireAction
   - !type:PowerWireAction
     pulseTimeout: 10
   - !type:DoorBoltWireAction


### PR DESCRIPTION
# Description

Access wire is cool, this PR adds it back to airlocks

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/622d01ac-01e5-4290-af26-6175fa3eca6c


</p>
</details>

---

# Changelog

:cl:
- add: Airlocks once again have access wires. Happy hacking!
