### PR TITLE
[Port] StepTriggerGroup From WhiteDream

### DIFF
--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -54,22 +54,18 @@ public sealed partial class StepTriggerComponent : Component
     public bool IgnoreWeightless;
 
     /// <summary>
-    /// Does this have separate "StepOn" and "StepOff" triggers.
+    ///     Does this have separate "StepOn" and "StepOff" triggers.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool StepOn = false;
 
     /// <summary>
-    /// If TriggerGroups is specified, it will check StepTriggerImmunityComponent to have the same TriggerType to activate immunity
+    ///     If TriggerGroups is specified, it will check StepTriggerImmunityComponent to have the same TriggerType to activate immunity
     /// </summary>
-    // WD EDIT
     [DataField]
     public StepTriggerGroup? TriggerGroups;
 }
 
 [RegisterComponent]
 [Access(typeof(StepTriggerSystem))]
-public sealed partial class StepTriggerActiveComponent : Component
-{
-
-}
+public sealed partial class StepTriggerActiveComponent : Component { }

--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.StepTrigger.Prototypes;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
@@ -57,6 +58,13 @@ public sealed partial class StepTriggerComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool StepOn = false;
+
+    /// <summary>
+    /// If TriggerGroups is specified, it will check StepTriggerImmunityComponent to have the same TriggerType to activate immunity
+    /// </summary>
+    // WD EDIT
+    [DataField]
+    public StepTriggerGroup? TriggerGroups;
 }
 
 [RegisterComponent]

--- a/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.StepTrigger.Prototypes;
+using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.StepTrigger.Components;
@@ -12,4 +14,12 @@ namespace Content.Shared.StepTrigger.Components;
 ///     Consider using a subscription to StepTriggerAttemptEvent if you wish to be more selective.
 /// </remarks>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class StepTriggerImmuneComponent : Component { }
+[Access(typeof(StepTriggerSystem))]
+public sealed partial class StepTriggerImmuneComponent : Component
+{
+    /// <summary>
+    /// WhiteList of immunity step triggers.
+    /// </summary>
+    [DataField]
+    public StepTriggerGroup? Whitelist;
+}

--- a/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.StepTrigger.Components;
 public sealed partial class StepTriggerImmuneComponent : Component
 {
     /// <summary>
-    /// WhiteList of immunity step triggers.
+    ///     WhiteList of immunity step triggers.
     /// </summary>
     [DataField]
     public StepTriggerGroup? Whitelist;

--- a/Content.Shared/StepTrigger/Prototypes/StepTriggerGroup.cs
+++ b/Content.Shared/StepTrigger/Prototypes/StepTriggerGroup.cs
@@ -1,0 +1,77 @@
+﻿using Content.Shared.Damage.Prototypes;
+using Content.Shared.StepTrigger.Components;
+using Content.Shared.StepTrigger.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
+namespace Content.Shared.StepTrigger.Prototypes
+{
+    /// <summary>
+    /// A group of <see cref="StepTriggerTypePrototype">
+    /// Used to determine StepTriggerTypes like Tags.
+    /// Used for better work with Immunity.
+    /// StepTriggerTypes in StepTriggerTypes.yml
+    /// WD EDIT
+    /// </summary>
+    /// <code>
+    /// stepTriggerGroups:
+    ///   types:
+    ///   - Lava
+    ///   - Landmine
+    ///   - Shard
+    ///   - Chasm
+    ///   - Mousetrap
+    ///   - SlipTile
+    ///   - SlipEntity
+    /// </code>
+    [DataDefinition]
+    [Serializable, NetSerializable]
+    public sealed partial class StepTriggerGroup
+    {
+        [DataField]
+        public List<ProtoId<StepTriggerTypePrototype>>? Types = null;
+
+        /// <summary>
+        /// Checks if types of this StepTriggerGroup is similar to types of AnotherGroup
+        /// </summary>
+        public bool IsValid(StepTriggerGroup? AnotherGroup)
+        {
+            if (Types != null)
+            {
+                foreach (var type in Types)
+                {
+                    if (AnotherGroup != null
+                        && AnotherGroup.Types != null
+                        && AnotherGroup.Types.Contains(type))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks validation (if types of this StepTriggerGroup are similar to types of
+        /// another StepTriggerComponent.
+        /// </summary>
+        public bool IsValid(StepTriggerComponent component)
+        {
+            if (component.TriggerGroups != null)
+            {
+                return IsValid(component.TriggerGroups);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks validation (if types of this StepTriggerGroup are similar to types of
+        /// another StepTriggerImmuneComponent.
+        /// </summary>
+        public bool IsValid(StepTriggerImmuneComponent component)
+        {
+            if (component.Whitelist != null)
+                return IsValid(component.Whitelist);
+            return false;
+        }
+    }
+}

--- a/Content.Shared/StepTrigger/Prototypes/StepTriggerGroup.cs
+++ b/Content.Shared/StepTrigger/Prototypes/StepTriggerGroup.cs
@@ -1,77 +1,72 @@
-﻿using Content.Shared.Damage.Prototypes;
-using Content.Shared.StepTrigger.Components;
-using Content.Shared.StepTrigger.Systems;
+﻿using Content.Shared.StepTrigger.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
-namespace Content.Shared.StepTrigger.Prototypes
+namespace Content.Shared.StepTrigger.Prototypes;
+
+/// <summary>
+///     A group of <see cref="StepTriggerTypePrototype">
+///     Used to determine StepTriggerTypes like Tags.
+///     Used for better work with Immunity.
+///     StepTriggerTypes in StepTriggerTypes.yml
+/// </summary>
+/// <code>
+/// stepTriggerGroups:
+///   types:
+///   - Lava
+///   - Landmine
+///   - Shard
+///   - Chasm
+///   - Mousetrap
+///   - SlipTile
+///   - SlipEntity
+/// </code>
+[DataDefinition]
+[Serializable, NetSerializable]
+public sealed partial class StepTriggerGroup
 {
+    [DataField]
+    public List<ProtoId<StepTriggerTypePrototype>>? Types = null;
+
     /// <summary>
-    /// A group of <see cref="StepTriggerTypePrototype">
-    /// Used to determine StepTriggerTypes like Tags.
-    /// Used for better work with Immunity.
-    /// StepTriggerTypes in StepTriggerTypes.yml
-    /// WD EDIT
+    ///     Checks if types of this StepTriggerGroup is similar to types of AnotherGroup
     /// </summary>
-    /// <code>
-    /// stepTriggerGroups:
-    ///   types:
-    ///   - Lava
-    ///   - Landmine
-    ///   - Shard
-    ///   - Chasm
-    ///   - Mousetrap
-    ///   - SlipTile
-    ///   - SlipEntity
-    /// </code>
-    [DataDefinition]
-    [Serializable, NetSerializable]
-    public sealed partial class StepTriggerGroup
+    public bool IsValid(StepTriggerGroup? anotherGroup)
     {
-        [DataField]
-        public List<ProtoId<StepTriggerTypePrototype>>? Types = null;
-
-        /// <summary>
-        /// Checks if types of this StepTriggerGroup is similar to types of AnotherGroup
-        /// </summary>
-        public bool IsValid(StepTriggerGroup? AnotherGroup)
-        {
-            if (Types != null)
-            {
-                foreach (var type in Types)
-                {
-                    if (AnotherGroup != null
-                        && AnotherGroup.Types != null
-                        && AnotherGroup.Types.Contains(type))
-                        return true;
-                }
-            }
+        if (Types is null)
             return false;
-        }
 
-        /// <summary>
-        /// Checks validation (if types of this StepTriggerGroup are similar to types of
-        /// another StepTriggerComponent.
-        /// </summary>
-        public bool IsValid(StepTriggerComponent component)
+        foreach (var type in Types)
         {
-            if (component.TriggerGroups != null)
-            {
-                return IsValid(component.TriggerGroups);
-            }
-            return false;
+            if (anotherGroup != null
+                && anotherGroup.Types != null
+                && anotherGroup.Types.Contains(type))
+                return true;
         }
+        return false;
+    }
 
-        /// <summary>
-        /// Checks validation (if types of this StepTriggerGroup are similar to types of
-        /// another StepTriggerImmuneComponent.
-        /// </summary>
-        public bool IsValid(StepTriggerImmuneComponent component)
-        {
-            if (component.Whitelist != null)
-                return IsValid(component.Whitelist);
+    /// <summary>
+    ///     Checks validation (if types of this StepTriggerGroup are similar to types of
+    ///     another StepTriggerComponent.
+    /// </summary>
+    public bool IsValid(StepTriggerComponent component)
+    {
+        if (component.TriggerGroups is null)
             return false;
-        }
+
+        return IsValid(component.TriggerGroups);
+    }
+
+    /// <summary>
+    ///     Checks validation (if types of this StepTriggerGroup are similar to types of
+    ///     another StepTriggerImmuneComponent.
+    /// </summary>
+    public bool IsValid(StepTriggerImmuneComponent component)
+    {
+        if (component.Whitelist is null)
+            return false;
+
+        return IsValid(component.Whitelist);
     }
 }

--- a/Content.Shared/StepTrigger/Prototypes/StepTriggerTypePrototype.cs
+++ b/Content.Shared/StepTrigger/Prototypes/StepTriggerTypePrototype.cs
@@ -1,19 +1,15 @@
 ﻿using Robust.Shared.Prototypes;
 
-namespace Content.Shared.StepTrigger.Prototypes
-{
-    /// <summary>
-    ///     Prototype representing a StepTriggerType in YAML.
-    ///     Meant to only have an ID property, as that is the only thing that
-    ///     gets saved in StepTriggerGroup.
-    /// </summary>
-    // WD EDIT
-    [Prototype("stepTriggerType")]
-    public sealed partial class StepTriggerTypePrototype : IPrototype
-    {
-        [ViewVariables]
-        [IdDataField]
-        public string ID { get; private set; } = default!;
-    }
-}
+namespace Content.Shared.StepTrigger.Prototypes;
 
+/// <summary>
+///     Prototype representing a StepTriggerType in YAML.
+///     Meant to only have an ID property, as that is the only thing that
+///     gets saved in StepTriggerGroup.
+/// </summary>
+[Prototype]
+public sealed partial class StepTriggerTypePrototype : IPrototype
+{
+    [ViewVariables, IdDataField]
+    public string ID { get; private set; } = default!;
+}

--- a/Content.Shared/StepTrigger/Prototypes/StepTriggerTypePrototype.cs
+++ b/Content.Shared/StepTrigger/Prototypes/StepTriggerTypePrototype.cs
@@ -1,0 +1,19 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Shared.StepTrigger.Prototypes
+{
+    /// <summary>
+    ///     Prototype representing a StepTriggerType in YAML.
+    ///     Meant to only have an ID property, as that is the only thing that
+    ///     gets saved in StepTriggerGroup.
+    /// </summary>
+    // WD EDIT
+    [Prototype("stepTriggerType")]
+    public sealed partial class StepTriggerTypePrototype : IPrototype
+    {
+        [ViewVariables]
+        [IdDataField]
+        public string ID { get; private set; } = default!;
+    }
+}
+

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -4,7 +4,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
-using Enumerable = System.Linq.Enumerable;
 
 namespace Content.Shared.StepTrigger.Systems;
 
@@ -119,7 +118,6 @@ public sealed class StepTriggerSystem : EntitySystem
 
     private bool CanTrigger(EntityUid uid, EntityUid otherUid, StepTriggerComponent component)
     {
-        // WD EDIT START
         if (!component.Active
             || component.CurrentlySteppedOn.Contains(otherUid))
             return false;
@@ -129,7 +127,6 @@ public sealed class StepTriggerSystem : EntitySystem
             && component.TriggerGroups != null
             && component.TriggerGroups.IsValid(stepTriggerImmuneComponent))
             return false;
-        // WD EDIT END
 
         // Can't trigger if we don't ignore weightless entities
         // and the entity is flying or currently weightless

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
+using Enumerable = System.Linq.Enumerable;
 
 namespace Content.Shared.StepTrigger.Systems;
 
@@ -118,10 +119,17 @@ public sealed class StepTriggerSystem : EntitySystem
 
     private bool CanTrigger(EntityUid uid, EntityUid otherUid, StepTriggerComponent component)
     {
-        if (HasComp<StepTriggerImmuneComponent>(otherUid)
-            || !component.Active
+        // WD EDIT START
+        if (!component.Active
             || component.CurrentlySteppedOn.Contains(otherUid))
             return false;
+
+        // Immunity checks
+        if (TryComp<StepTriggerImmuneComponent>(otherUid, out var stepTriggerImmuneComponent)
+            && component.TriggerGroups != null
+            && component.TriggerGroups.IsValid(stepTriggerImmuneComponent))
+            return false;
+        // WD EDIT END
 
         // Can't trigger if we don't ignore weightless entities
         // and the entity is flying or currently weightless

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -77,6 +77,9 @@
     animationState: foam-dissolve
   - type: Slippery
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipTile
   # disabled until foam reagent duplication is fixed
   #- type: ScoopableSolution
   #  solution: solutionArea
@@ -135,7 +138,7 @@
   - type: RCDDeconstructable
     cost: 2
     delay: 2
-    fx: EffectRCDDeconstruct2  
+    fx: EffectRCDDeconstruct2
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -77,7 +77,7 @@
     animationState: foam-dissolve
   - type: Slippery
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipTile
   # disabled until foam reagent duplication is fixed

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -149,6 +149,9 @@
   - type: EdgeSpreader
     id: Puddle
   - type: StepTrigger
+    triggerGroups:
+      types:
+      - SlipTile
   - type: Drink
     delay: 3
     transferAmount: 1

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1689,6 +1689,10 @@
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning
+  - type: StepTriggerImmune # WD EDIT START
+    whitelist:
+      types:
+      - Landmine # END
 
 - type: entity
   parent: MobMouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1689,10 +1689,10 @@
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning
-  - type: StepTriggerImmune # WD EDIT START
+  - type: StepTriggerImmune
     whitelist:
       types:
-      - Landmine # END
+      - Landmine
 
 - type: entity
   parent: MobMouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -137,6 +137,9 @@
   - type: Speech
     speechVerb: Cluwne
   - type: StepTrigger
+    triggerGroups:
+      types:
+      - SlipEntity
     intersectRatio: 0.2
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -111,7 +111,7 @@
   - type: OfferItem
   - type: LayingDown
   - type: Carriable
-  - type: StepTriggerImmune #WD EDIT
+  - type: StepTriggerImmune
     whitelist:
       types:
       - Shard

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -111,6 +111,10 @@
   - type: OfferItem
   - type: LayingDown
   - type: Carriable
+  - type: StepTriggerImmune #WD EDIT
+    whitelist:
+      types:
+      - Shard
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -114,6 +114,10 @@
     walkModifier: 0.75
   - type: SpeedModifierImmunity
   - type: NoSlip
+  - type: StepTriggerImmune
+    whitelist:
+      types:
+      - Shard
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -123,7 +123,7 @@
     - GalacticCommon
     - SolCommon
   - type: StepTriggerImmune
-    whitelist: # WD EDIT
+    whitelist:
       types:
       - Shard
       - Landmine

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -123,6 +123,11 @@
     - GalacticCommon
     - SolCommon
   - type: StepTriggerImmune
+    whitelist: # WD EDIT
+      types:
+      - Shard
+      - Landmine
+      - Mousetrap
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -314,6 +314,9 @@
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
     intersectRatio: 0.2
+    triggerGroups:
+      types:
+      - SlipEntity
   - type: CollisionWake
     enabled: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
@@ -13,6 +13,9 @@
     - type: StepTrigger
       intersectRatio: 0.2
       requiredTriggeredSpeed: 0
+      triggerGroups: # WD EDIT
+        types:
+        - Mousetrap
     - type: Mousetrap
     - type: TriggerOnStepTrigger
     - type: ShoesRequiredStepTrigger

--- a/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
@@ -13,7 +13,7 @@
     - type: StepTrigger
       intersectRatio: 0.2
       requiredTriggeredSpeed: 0
-      triggerGroups: # WD EDIT
+      triggerGroups:
         types:
         - Mousetrap
     - type: Mousetrap

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -272,7 +272,7 @@
     paralyzeTime: 4
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipEntity
   - type: CollisionWake

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -272,6 +272,9 @@
     paralyzeTime: 4
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipEntity
   - type: CollisionWake
     enabled: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -119,7 +119,7 @@
         mask:
         - ItemMask
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - Shard
     intersectRatio: 0.2

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -119,6 +119,9 @@
         mask:
         - ItemMask
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - Shard
     intersectRatio: 0.2
   - type: TriggerOnStepTrigger
   - type: ShoesRequiredStepTrigger

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -64,6 +64,9 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - Shard
     intersectRatio: 0.2
   - type: ShoesRequiredStepTrigger
   - type: Slippery

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -64,7 +64,7 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - Shard
     intersectRatio: 0.2

--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -40,6 +40,9 @@
         params:
             maxDistance: 10
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - Landmine
     requiredTriggeredSpeed: 0
     stepOn: true
 

--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -40,7 +40,7 @@
         params:
             maxDistance: 10
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - Landmine
     requiredTriggeredSpeed: 0

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -111,6 +111,9 @@
       paralyzeTime: 2
       launchForwardsMultiplier: 1.5
     - type: StepTrigger
+      triggerGroups:
+        types:
+        - SlipTile
       intersectRatio: 0.2
     - type: Physics
     - type: Fixtures

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -24,7 +24,7 @@
     paralyzeTime: 2
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipEntity
     intersectRatio: 0.2
@@ -160,7 +160,7 @@
     paralyzeTime: 5
     launchForwardsMultiplier: 2.5
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipEntity
     intersectRatio: 0.04
@@ -204,7 +204,7 @@
   - type: Slippery
     paralyzeTime: 2
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipEntity
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -24,6 +24,9 @@
     paralyzeTime: 2
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipEntity
     intersectRatio: 0.2
   - type: CollisionWake
     enabled: false
@@ -157,6 +160,9 @@
     paralyzeTime: 5
     launchForwardsMultiplier: 2.5
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipEntity
     intersectRatio: 0.04
   - type: Item
     heldPrefix: syndie
@@ -198,6 +204,9 @@
   - type: Slippery
     paralyzeTime: 2
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipEntity
   - type: Item
     heldPrefix: gibs
   - type: FlavorProfile

--- a/Resources/Prototypes/Entities/Tiles/bananium.yml
+++ b/Resources/Prototypes/Entities/Tiles/bananium.yml
@@ -47,7 +47,7 @@
     paralyzeTime: 2
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - SlipTile
     intersectRatio: 0.2

--- a/Resources/Prototypes/Entities/Tiles/bananium.yml
+++ b/Resources/Prototypes/Entities/Tiles/bananium.yml
@@ -47,6 +47,9 @@
     paralyzeTime: 2
     launchForwardsMultiplier: 1.5
   - type: StepTrigger
+    triggerGroups: # WD EDIT
+      types:
+      - SlipTile
     intersectRatio: 0.2
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -14,7 +14,7 @@
     blacklist:
       tags:
       - Catwalk
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - Chasm
   - type: Transform

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -14,6 +14,9 @@
     blacklist:
       tags:
       - Catwalk
+    triggerGroups: # WD EDIT
+      types:
+      - Chasm
   - type: Transform
     anchored: true
   - type: Clickable
@@ -55,7 +58,7 @@
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorDesertChasm
@@ -65,7 +68,7 @@
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorSnowChasm

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -13,6 +13,9 @@
     blacklist:
       tags:
         - Catwalk
+    triggerGroups: # WD EDIT
+      types:
+        - Lava
   - type: Lava
     fireStacks: 0.75
   - type: Transform

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -13,7 +13,7 @@
     blacklist:
       tags:
         - Catwalk
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
         - Lava
   - type: Lava

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -13,6 +13,9 @@
     blacklist:
       tags:
       - Catwalk
+    triggerGroups: # WD EDIT
+      types:
+      - Lava
   - type: Lava
     fireStacks: 0.75
   - type: Transform

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -13,7 +13,7 @@
     blacklist:
       tags:
       - Catwalk
-    triggerGroups: # WD EDIT
+    triggerGroups:
       types:
       - Lava
   - type: Lava

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -80,6 +80,12 @@
     stripTimeReduction: 0
     stripTimeMultiplier: 0.667
   - type: StepTriggerImmune
+    whitelist: # WD EDIT
+      types:
+        - Shard
+        - Landmine
+        - Mousetrap
+        - SlipEntity
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -80,7 +80,7 @@
     stripTimeReduction: 0
     stripTimeMultiplier: 0.667
   - type: StepTriggerImmune
-    whitelist: # WD EDIT
+    whitelist:
       types:
         - Shard
         - Landmine

--- a/Resources/Prototypes/StepTrigger/StepTriggerTypes.yml
+++ b/Resources/Prototypes/StepTrigger/StepTriggerTypes.yml
@@ -1,0 +1,20 @@
+﻿- type: stepTriggerType
+  id: Lava
+
+- type: stepTriggerType
+  id: Landmine
+
+- type: stepTriggerType
+  id: Shard
+
+- type: stepTriggerType
+  id: Chasm
+
+- type: stepTriggerType
+  id: Mousetrap
+
+- type: stepTriggerType
+  id: SlipTile
+
+- type: stepTriggerType
+  id: SlipEntity

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -270,6 +270,12 @@
   points: -3
   components:
     - type: StepTriggerImmune
+      whitelist: # WD EDIT
+        types:
+        - Shard
+        - Landmine
+        - Mousetrap
+        - SlipEntity
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -270,7 +270,7 @@
   points: -3
   components:
     - type: StepTriggerImmune
-      whitelist: # WD EDIT
+      whitelist:
         types:
         - Shard
         - Landmine


### PR DESCRIPTION
# Description

This is a port of https://github.com/WWhiteDreamProject/wwdpublic/pull/53 from White Dream. This PR improves the StepTriggerImmune component by making it operate on a more granular Blacklist system, such that StepTriggerImmune entities can further clarify via prototypes which kinds of floor traps they are immune to, such as landmines/mousetraps, and not have blanket immunity to everything. Because it turns out things like Lava and Soap also were caught by the immunity, when really we just wanted Harpies & Felinids to not trigger landmines. 



<details><summary><h1>Media</h1></summary>
<p>

> # Описание
> Необходимо настроить модификатор урона, чтобы IPC не получали урон от осколков стекла.
> 
> Иммунитет StepTriggerImmuneComponent доработан. Теперь имеются несколько типов (types): Lava - тип тайла, наступив на который появляется урон. Это собственно лава и LiquidPlasma Landmine - мины. Chasm - дырка в карте, куда можно провалиться Mousetrap - Мышеловка SlipTile - Все, что должно подскальзывать игроков, имеющее размер тайла SlipEntity - Все, что должно подскальзывать игроков, имеющее развер энтити. Разделено для баланса. Самые ловки могут игнорировать мелкие предметы (энтити), т.е. уворачиваться от них. Но большие по площади вещи (тайлы по типу разлитой воды, бананиума) просчитываются отдельно.
> 
> # Изменения
> * [x]  Улучшить StepTriggerSystem (Immune)
> * [x]  Добавлены типы триггера. - Lava Landmine Shard Chasm Mousetrap SlipTile SlipEntity
> * [x]  Исправить осколки у IPC
> * [x]  Исправить отсутствие урона от лавы и падение в дыры у фелинидов и гарпий.
> 
> 🆑 Hell_Cat
> 
> * Feature: StepTriggerSystem is improved | Улучшена StepTriggerSystem
> * fix: IPC: Immunity for shards and SpiderWeb | Иммунитет осколкам.
> * fix: Felinid | Фелиниды : Immunity for Shard Landmine Mousetrap SlipEntities | Иммунитет для осколков, жидкости, мин, мышеловок, мыла и бананов.
> * fix: Harpy | Гарпия : Immunity for Shards Landmine Mousetrap | Иммунитет для осколков, жидкости, мин и мышеловок.
> * fix: Mice | Мыши : Don't blow up on landmines | Мыши не подрываются на минах.

</p>
</details>

# Changelog

:cl: Hell_Cat
Feature: StepTriggerSystem has been improved with new StepTriggerGroups. Additionally, the StepTriggerImmune component now allows declaring for specific StepTriggerGroups for a given entity to be immune to. Some examples may be, Felinids, Mice, and Harpies being unable to set off Landmines. 