### PR TITLE
Fix SpawnAndDeleteAllEntities

### DIFF
--- a/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
+++ b/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
@@ -2,7 +2,6 @@ using Content.Shared.Roles;
 using Content.Shared.Radio.Components;
 using Content.Shared.Containers;
 using Robust.Shared.Containers;
-using Content.Server.Cargo.Components;
 
 namespace Content.Server.Silicon.IPC;
 public sealed partial class InternalEncryptionKeySpawner : EntitySystem
@@ -10,7 +9,9 @@ public sealed partial class InternalEncryptionKeySpawner : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     public void TryInsertEncryptionKey(EntityUid target, StartingGearPrototype startingGear, IEntityManager entityManager)
     {
-        if (!TryComp<EncryptionKeyHolderComponent>(target, out var keyHolderComp)
+        if (target == null // For whatever ungodly reason, StationSpawningSystem **absolutely has to assert that a nullable Uid is not null**. This causes random test fails.
+            || !TryComp<EncryptionKeyHolderComponent>(target, out var keyHolderComp)
+            || keyHolderComp is null
             || !startingGear.Equipment.TryGetValue("ears", out var earEquipString)
             || string.IsNullOrEmpty(earEquipString))
             return;

--- a/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
+++ b/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
@@ -9,8 +9,9 @@ public sealed partial class InternalEncryptionKeySpawner : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     public void TryInsertEncryptionKey(EntityUid target, StartingGearPrototype startingGear, IEntityManager entityManager)
     {
-#pragma warning disable CS8073 // target can be null during race conditions intentionally created by awful tests.
-        if (target == null
+#pragma warning disable CS8073
+        if (target == null // target can be null during race conditions intentionally created by awful tests.
+#pragma warning restore CS8073
             || !TryComp<EncryptionKeyHolderComponent>(target, out var keyHolderComp)
             || keyHolderComp is null
             || !startingGear.Equipment.TryGetValue("ears", out var earEquipString)

--- a/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
+++ b/Content.Server/Silicon/IPC/InternalEncryptionKeySpawner.cs
@@ -9,7 +9,8 @@ public sealed partial class InternalEncryptionKeySpawner : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     public void TryInsertEncryptionKey(EntityUid target, StartingGearPrototype startingGear, IEntityManager entityManager)
     {
-        if (target == null // For whatever ungodly reason, StationSpawningSystem **absolutely has to assert that a nullable Uid is not null**. This causes random test fails.
+#pragma warning disable CS8073 // target can be null during race conditions intentionally created by awful tests.
+        if (target == null
             || !TryComp<EncryptionKeyHolderComponent>(target, out var keyHolderComp)
             || keyHolderComp is null
             || !startingGear.Equipment.TryGetValue("ears", out var earEquipString)


### PR DESCRIPTION
# Description

After doing an archaological exploration of the fucking SpawnAndDeleteAllEntities test fail, I eventually tracked down the bug to an issue where InternalEncryptionKeySpawner is randomly being handed a Null EntityUid which was Null Forgiven to make the compiler shut up. The actual EntityUid factually cannot be null during ordinary operation, except for the dumbass race condition provided by TestSpawnAndDeleteAllEntities.  
