### PR TITLE
Variable NPC Juke Aggression

### DIFF
--- a/Content.Server/NPC/Components/NPCJukeComponent.cs
+++ b/Content.Server/NPC/Components/NPCJukeComponent.cs
@@ -1,4 +1,3 @@
-using Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.NPC.Components;
@@ -6,17 +5,20 @@ namespace Content.Server.NPC.Components;
 [RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class NPCJukeComponent : Component
 {
-    [DataField("jukeType")]
+    [DataField]
     public JukeType JukeType = JukeType.Away;
 
-    [DataField("jukeDuration")]
+    [DataField]
     public float JukeDuration = 0.5f;
 
-    [DataField("nextJuke", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField]
+    public float JukeCooldown = 3f;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextJuke;
 
-    [DataField("targetTile")]
+    [DataField]
     public Vector2i? TargetTile;
 }
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/JukeOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/JukeOperator.cs
@@ -6,17 +6,31 @@ public sealed partial class JukeOperator : HTNOperator, IHtnConditionalShutdown
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 
-    [DataField("jukeType")]
+    [DataField]
     public JukeType JukeType = JukeType.AdjacentTile;
 
-    [DataField("shutdownState")]
+    [DataField]
     public HTNPlanState ShutdownState { get; private set; } = HTNPlanState.PlanFinished;
+
+    /// <summary>
+    ///     Controls how long(in seconds) the NPC will move while juking.
+    /// </summary>
+    [DataField]
+    public float JukeDuration = 0.5f;
+
+    /// <summary>
+    ///     Controls how often (in seconds) an NPC will try to juke.
+    /// </summary>
+    [DataField]
+    public float JukeCooldown = 3f;
 
     public override void Startup(NPCBlackboard blackboard)
     {
         base.Startup(blackboard);
         var juke = _entManager.EnsureComponent<NPCJukeComponent>(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
         juke.JukeType = JukeType;
+        juke.JukeDuration = JukeDuration;
+        juke.JukeCooldown = JukeCooldown;
     }
 
     public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)


### PR DESCRIPTION
# Description

This PR un-hardcodes the JukeSystem timer, such that individual NPC HTN Blackboards can directly state how often, and how far they wish to juke. The effect of this is that NPCs are no longer completely impossible to hit with left-clicks in melee combat, while also allowing for more "Elite" enemies that juke more aggressively and more often to be created. 

Additionally, by introducing an exit condition based on this new "Juke Cooldown", I have made the Juke Operator run a metric shitload of expensive calculations 5000 times less often. 

<details><summary><h1>Media</h1></summary>
<p>

Melee enemy with the new default juke settings, 0.5 second juke duration, with 5 second juke Cooldown. The reagent slime will attempt to close to melee with its enemy, but will now only attempt to evade melee attacks once per 5 seconds. They will otherwise attempt to stay within melee range.

https://github.com/user-attachments/assets/653e2064-e404-4be6-a958-da43096de502

</p>
</details>

# Changelog

:cl:
- tweak: JukeOperator now allows for JukeDuration and JukeCooldown arguments. JukeCooldown is a new feature where enemies must wait an amount of time in seconds equal to the JukeCooldown, before they are allowed to attempt to dodge a melee attack.
- tweak: By default, NPCs will only attempt to dodge attacks once every 5 seconds.
- fix: JukeOperator now performs extremely expensive math 5000 times less often. EXIT CONDITIONS PEOPLE!
