### PR TITLE
Melee Part 5: Less Exhaustion

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -110,7 +110,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// Total width of the angle for wide attacks.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Angle Angle = Angle.FromDegrees(45);
+    public Angle Angle = Angle.FromDegrees(60);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Animation = "WeaponArcPunch";
@@ -129,10 +129,10 @@ public sealed partial class MeleeWeaponComponent : Component
     public bool SwingLeft;
 
     [DataField, AutoNetworkedField]
-    public float HeavyStaminaCost = 10f;
+    public float HeavyStaminaCost = 2.5f;
 
     [DataField, AutoNetworkedField]
-    public int MaxTargets = 1;
+    public int MaxTargets = 3;
 
     // Sounds
 

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -25,7 +25,7 @@
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 75
   - type: Item
     size: Normal
@@ -67,7 +67,7 @@
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 75
   - type: Item
     size: Normal
@@ -110,7 +110,7 @@
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 15
+    heavyStaminaCost: 10
     angle: 160
   - type: Wieldable
   - type: IncreaseDamageOnWield
@@ -234,7 +234,7 @@
     bluntStaminaDamageFactor: 2
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 75
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -630,12 +630,11 @@
     state: icon
   - type: MeleeWeapon
     attackRate: 1.5
-    range: 1.3
+    range: 1.5
     damage:
       types:
         Blunt: 0.1
     heavyDamageBaseModifier: 2
-    heavyStaminaCost: 5
     maxTargets: 8
     angle: 25
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -6,8 +6,8 @@
   components:
   - type: Sharp
   - type: MeleeWeapon
-    attackRate: 1.5
-    range: 1.3
+    attackRate: 1.4
+    range: 1.4
     damage:
       types:
         Slash: 4

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -46,8 +46,8 @@
         Blunt: 8
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 2
-    heavyStaminaCost: 15
-    maxTargets: 8
+    heavyStaminaCost: 7.5
+    maxTargets: 6
     soundHit:
       path: /Audio/Weapons/smash.ogg
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -50,7 +50,7 @@
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 5
-    maxTargets: 3
+    maxTargets: 4
   - type: Tag
     tags:
     - Book

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -21,7 +21,6 @@
     heavyRateModifier: 1
     heavyRangeModifier: 1
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 5
     angle: 100
   - type: Item
@@ -48,7 +47,6 @@
     heavyRateModifier: 0.9
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
   - type: Item
@@ -103,7 +101,7 @@
     wideAnimationRotation: 135
     swingLeft: true
     attackRate: 1.25
-    range: 1.25
+    range: 1.4
     damage:
       types:
         Slash: 10

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -16,7 +16,7 @@
     heavyRateModifier: 0.8
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.25
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     maxTargets: 2
     angle: 180
     soundHit:
@@ -64,7 +64,7 @@
       heavyRateModifier: 0.8
       heavyRangeModifier: 1.25
       heavyDamageBaseModifier: 1.25
-      heavyStaminaCost: 10
+      heavyStaminaCost: 7.5
       maxTargets: 2
       angle: 180
       soundHit:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -51,7 +51,7 @@
     - 1,1,1,1
   - type: MeleeWeapon
     attackRate: 0.75
-    range: 1.3
+    range: 1.4
     damage:
       types:
         Piercing: 8
@@ -87,7 +87,7 @@
     wideAnimationRotation: 90
     swingLeft: true
     attackRate: 1.25
-    range: 1.25
+    range: 1.4
     damage:
       types:
         Slash: 7.5
@@ -208,7 +208,8 @@
     heavyStaminaCost: 20
     maxTargets: 8
     angle: 20
-# ~~No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.~~ No, I'm going to saw through your bones.
+# --No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.--
+# No, I'm going to saw through your bones.
 
 - type: entity
   name: choppa
@@ -252,7 +253,7 @@
     storedRotation: 90
   - type: MeleeWeapon
     attackRate: 1.15
-    range: 1.4
+    range: 1.5
     bluntStaminaDamageFactor: 3.0
     damage:
       types:
@@ -260,7 +261,7 @@
         Slash: 5.5
     heavyRateModifier: 0.5
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 15
+    heavyStaminaCost: 10
     maxTargets: 8
     angle: 360
     soundHit:
@@ -282,8 +283,8 @@
     heldPrefix: advanced
     storedRotation: 90
   - type: MeleeWeapon
-    attackRate: 1.25
-    range: 1.4
+    attackRate: 1.15
+    range: 1.5
     bluntStaminaDamageFactor: 5.0
     damage:
       types:
@@ -291,7 +292,7 @@
         Slash: 7.5
     heavyRateModifier: 0.5
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 15
+    heavyStaminaCost: 10
     maxTargets: 8
     angle: 360
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -120,9 +120,8 @@
     damage:
       types:
         Blunt: 6.5
-    bluntStaminaDamageFactor: 1.5
+    bluntStaminaDamageFactor: 2
     heavyRateModifier: 0.9
-    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -41,9 +41,9 @@
     bluntStaminaDamageFactor: 2.5
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1.5
-    heavyStaminaCost: 15
-    maxTargets: 1
-    angle: 140
+    heavyStaminaCost: 10
+    maxTargets: 3
+    angle: 100
   - type: PhysicalComposition
     materialComposition:
       Steel: 185

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -44,8 +44,8 @@
         changeSound: /Audio/Items/change_jaws.ogg
   - type: MeleeWeapon
     wideAnimationRotation: 90
-    attackRate: 0.75
-    range: 1.75
+    attackRate: 0.85
+    range: 1.65
     damage:
       types:
         Blunt: 10
@@ -53,7 +53,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1.5
-    heavyStaminaCost: 10
+    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -28,7 +28,7 @@
         Blunt: 9
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.8
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 80.5
     soundHit:
       path: "/Audio/Weapons/smash.ogg"

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -38,9 +38,7 @@
         Blunt: 6.5
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 4
-    angle: 60
     soundHit:
       path: "/Audio/Items/wirecutter.ogg"
   - type: Tool
@@ -103,7 +101,6 @@
         Piercing: 6
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.5
-    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
     soundHit:
@@ -165,7 +162,6 @@
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 5
     angle: 100
     soundHit:
       collection: MetalThud
@@ -279,7 +275,6 @@
         Shock: 2
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
   - type: Item
@@ -424,7 +419,6 @@
         Piercing: 8
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 1
     angle: 20
     soundHit:
@@ -641,14 +635,14 @@
   - type: MeleeWeapon
     wideAnimationRotation: 45
     attackRate: 0.8
-    range: 2.0
+    range: 1.75
     damage:
       types:
         Blunt: 8
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.5
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 100
     soundHit:
       collection: MetalThud
@@ -696,8 +690,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1.5
-    heavyStaminaCost: 5
-    maxTargets: 1
+    maxTargets: 2
     angle: 20
     soundHit:
       collection: MetalThud

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -17,7 +17,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.5
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 15
+    heavyStaminaCost: 10
     maxTargets: 2
     angle: 120
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -11,7 +11,7 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.25
-    range: 1.4
+    range: 1.5
     damage:
       types:
         Slash: 8
@@ -39,12 +39,12 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 0.75
-    range: 1.75
+    range: 1.65
     damage:
       types:
         Slash: 12
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     maxTargets: 6
     angle: 90
   - type: Item
@@ -70,7 +70,7 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 0.75
+    attackRate: 0.85
     range: 1.75
     damage:
       types:
@@ -79,7 +79,7 @@
         Structural: 5
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 100
     soundHit:
       collection: MetalThud

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/home_run_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/home_run_bat.yml
@@ -14,8 +14,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.5
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 25
-    maxTargets: 2
+    heavyStaminaCost: 15
     angle: 120
     soundHit:
       collection: ExplosionSmall

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -13,13 +13,12 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.25
-    range: 1.4
+    range: 1.5
     damage:
       types:
         Slash: 8
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 3
     angle: 40
     soundHit:
@@ -95,7 +94,6 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.5
-    range: 1.4
     damage:
       types:
         Slash: 9
@@ -122,7 +120,6 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 1.25
-    range: 1.5
     damage:
       types:
         Slash: 8
@@ -204,7 +201,7 @@
     state: icon
   - type: MeleeWeapon
     attackRate: 1.75
-    range: 0.75
+    range: 1.4
     damage:
       types:
         Slash: 5.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -43,8 +43,8 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 0.75
-    range: 1.75
+    attackRate: 0.85
+    range: 1.65
     wideAnimationRotation: -135
     damage:
       types:
@@ -53,7 +53,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 120
     soundHit:
       collection: MetalThud
@@ -92,7 +92,6 @@
         Slash: 9
     heavyRateModifier: 0.9
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
     maxTargets: 2
     angle: 20
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -11,8 +11,8 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
-    attackRate: 0.75
-    range: 1.75
+    attackRate: 0.85
+    range: 1.5
     wideAnimationRotation: -135
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -24,9 +24,8 @@
         Pierce: 3
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 5
-    maxTargets: 2
-    angle: 60
+    maxTargets: 5
+    angle: 80
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -61,19 +60,17 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-    attackRate: 0.5
-    range: 1.4
+    attackRate: 1.2
+    range: 1.5
     damage:
       types:
-        Blunt: 9
+        Blunt: 6
         Slash: 3
         Structural: 12
     bluntStaminaDamageFactor: 4.0
     heavyRateModifier: 1
     heavyRangeModifier: 2
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 10
-    maxTargets: 3
     angle: 20
 
   - type: ReverseEngineering # Nyano

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -9,7 +9,7 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 0.8
+    attackRate: 0.75
     range: 1.75
     damage:
       types:
@@ -18,7 +18,7 @@
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 15
+    heavyStaminaCost: 7.5
     maxTargets: 10
     angle: 120
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -30,17 +30,14 @@
     energyPerUse: 70
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 0.8
-    range: 1.4
+    attackRate: 1
+    range: 1.5
     damage:
       types:
         Blunt: 7.5
     bluntStaminaDamageFactor: 2.0
     heavyRateModifier: 0.8
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 5
-    maxTargets: 3
-    angle: 60
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit
     damage: 22

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -57,9 +57,9 @@
       types:
         Slash: 12
     heavyRateModifier: 0.5
-    heavyRangeModifier: 3 #Superior Japanese folded steel
+    heavyRangeModifier: 2.75 #Superior Japanese folded steel
     heavyDamageBaseModifier: 1.25
-    heavyStaminaCost: 10
+    heavyStaminaCost: 15
     maxTargets: 1
     angle: 20
   - type: Item
@@ -120,7 +120,7 @@
     heavyRateModifier: 0.8
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     angle: 80
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
@@ -151,7 +151,7 @@
     heavyRateModifier: 0.5
     heavyRangeModifier: 1
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 20
+    heavyStaminaCost: 15
     maxTargets: 10
     angle: 200
     soundHit:
@@ -186,7 +186,7 @@
     heavyRateModifier: 0.8
     heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
     maxTargets: 3
     angle: 40
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -34,12 +34,10 @@
     damage:
       types:
         Blunt: 7
-    bluntStaminaDamageFactor: 2.0
+    bluntStaminaDamageFactor: 2.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 5
-    maxTargets: 3
-    angle: 60
+    heavyStaminaCost: 1
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
     damage: 35
@@ -106,7 +104,7 @@
     bluntStaminaDamageFactor: 2
     heavyRateModifier: 1
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 7.5
   - type: Item
     size: Normal
   - type: Clothing


### PR DESCRIPTION

# A followup PR to the previous melee rebalancing, taking in feedback from multiple sources.

There were some unintended changes bundled with the previous melee changes that didn't flow well together. I'm documenting everything here but would like to preface this by saying that, while a number of folks have had issues with the changes, there's been a surprisingly quiet amount of people who have just come forward and said that they've liked a number of the changes. 

Instead of just being satisfied with this, I would like to appease the folks who have had difficulties adjusting to the melee changes by improving the experience on a number of weapons and strange outlier cases that have cropped up. 
Below is the changelog any item not listed was either only changed by the Default Wide Swing change or had no change at all:

**Default Wide Swing**
Angle 45 -> 60
Stamina Cost 10 -> 2.5
MaxTargets 1 -> 3

_-I wasn't aware that the max targets and angle was being dropped when I made my initial changes, the stamina cost was a bit too high(was originally supposed to be 5 at one point). 2.5 should be rarely felt and does more to halt stamina regen than directly impact the stamina pool. Any weapon denoted below with a ^ symbol is buffed by this change._

**ElectricGuitar**
heavyStaminaCost 10 -> 7.5

**BassGuitar**
heavyStaminaCost 10 -> 7.5

**RockGuitar**
heavyStaminaCost 15 -> 10

**Banjo**
heavyStaminaCost 10 -> 7.5

_-All of the guitars have received less of a stamina cost, excluding the acoustic which is fine at 10._

**RubberDuck**
range 1.3 -> 1.5
heavyStaminaCost 5 -> default

_Fear the duck._

**BrokenBottle**
attackRate 1.5 -> 1.4
range 1.3 -> 1.4

_-Normalizing the range to feel less ass, but pulling back the attack rate a smidge as a result._

**FireExtinguisher**
heavyStaminaCost 10 -> 7.5
maxTargets 8 -> 6

**HolyBible**
maxTargets 3 -> 4

**MiniHoe**
heavyStaminaCost 5 -> default

**PlantClippers**
heavyStaminaCost 5 -> default

**Hatchet** ^
range 1.25 -> 1.4

**Mops**
heavyStaminaCost 10 -> 7.5

_-Mopfu is real._

**Drill**
range 1.3 -> 1.4

**Scalpel**
range 1.25 -> 1.4

**CircularSaw + AdvancedCircularSaw**
attackRate 1.25 -> 1.15
range 1.4 -> 1.5
heavyStaminaCost 15 -> 10

_-The heavy attack for these weapons is a 360 spin, try it out._

**SecLight**
BluntStamina 1.5 -> 2
heavyStaminaCost 5 -> default

_-This now does about 14 stamina damage on hit, for when you really need to harm baton._

**GasTanks**
heavyStaminaCost 15 -> 10
maxTargets 1 -> 3
angle 140 -> 100

_-Been told this is a strong weapon, but a bit odd and unreliable. This should be easier to use but still keep it's flavor._

**JawsOfLife**
attackRate 0.75 -> 0.85
range 1.75 -> 1.65
heavyStaminaCost 10 -> 5

**Toolboxes** ^
heavyStaminaCost 10 -> 7.5

**BaseTools**
heavyStaminaCost 5 -> default

**RollingPin**
heavyStaminaCost 5 -> default
maxTargets 1 -> 2

**BaseballBat**
heavyStaminaCost 15 -> 10

**RitualDagger**
range 1.4 -> 1.5

**EldritchBlade**
range 1.75 -> 1.65
heavyStaminaCost 10 -> 7.5

**UnholyHalberd**
attackrate 0.75 -> 0.85
heavyStaminaCost 10 -> 7.5

**HomeRunBat**
heavyStaminaCost 25 -> 15
maxTargets 2 -> Default

**Knife**
range 1.4 -> 1.5
heavyStaminaCost 5 -> default

_-This change parents over to majority of knives including the cleaver._

**Shiv**
range 0.75 -> 1.4

_-Whoops!_

**Crusher** ^
attackRate 0.75 -> 0.85
range 1.75 -> 1.65
heavyStaminaCost 10 -> 7.5

**CrusherDagger**
heavyStaminaCost 5 -> default

**Pickaxe**
attackRate 0.75 -> 0.85
range 1.75 -> 1.5
heavyStaminaCost 5 -> default
maxTargets 2 -> 5
angle 60 -> 80

**Drill**
attackRate 0.5 -> 1.2
range 1.4 -> 1.5
Blunt 9 -> 6
heavyStaminaCost 10 -> default
maxTargets (default)

_-I really despise the current balance of mining/salvage, the gameplay loops require you to destroy fifty rocks to get two plasma and a bar of gold. Your tools are now fixed._

**Sledgehammer**
attackRate 0.75 -> 0.8 
heavyStaminaCost 15 -> 7.5

_-This can hit 10 people btw._

**Spears**
_-No changes here, just a remark that they are pretty strong and a good option yet again._

**Stunprod**
attackRate 0.8 -> 1
range 1.4 -> 1.5
heavyStaminaCost 5 -> default
maxtargets (default)
angle (default

_-So when not powered this thing does 15 stam damage when you smack someone with it, so if it runs out of power you can still smack the person a bit to stun them, but here, it's been buffed a bit more._

**Katana**
heavyRange 3 -> 2.75
heavyStaminaCost 10 -> 15

_-The heavy attack of the Katana is comically overpowered, it has an absurd range. This is still really funny and cool but a little more balanced._

**Machete** ^
heavyStaminaCost 10 -> 7.5

**Claymore**
heavyStaminaCost 20 -> 15

**Cutlass**
heavyStaminaCost 10 -> 7.5

**StunBaton**
bluntStamina 2.0 -> 2.5
heavyStaminaCost 5 -> 1
maxTargets (default)
angle (default)

_-Wow, from all the reports I got about this I thought I messed up on the balance of the stun baton, but honestly it was just a case of security players actually just sucking, lmao, this one is a full problème de compétence but whatever, I'm changing the stamina cost to 1, which shouldn't drop you at all, but will prevent your stamina from recovering if you just spam your wide swing. I've also further buffed the harm baton functionality._

**Truncheon**
heavyStaminaCost 10 -> 7.5

.


And that's it.
Realistically this is just an overall adjustment of stamina costs to be a bit less punishing but this is all fairly redundant, a number of the 'issues' were spawned by default melee values not being updated properly to some codebases and people just spamming their power attack because that's how its been for a few months. 
This should be considerably better but please left click a little instead of flailing around.

:cl: ODJ
- tweak: Tweaked melee; Less stamina usage on heavy attacks.