### PR TITLE
Allow Crawling Entities To Go Under Tables

### DIFF
--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -55,7 +55,8 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
     {
         var uid = GetEntity(args.Uid);
 
-        if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp<LayingDownComponent>(uid, out var component))
+        if (!TryComp<SpriteComponent>(uid, out var sprite) 
+            || !TryComp<LayingDownComponent>(uid, out var component))
             return;
 
         if (!component.OriginalDrawDepth.HasValue)

--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -21,7 +21,7 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
         base.Initialize();
 
         SubscribeLocalEvent<LayingDownComponent, MoveEvent>(OnMovementInput);
-        SubscribeNetworkEvent<DownedEvent>(OnDowned);
+        SubscribeNetworkEvent<DrawDownedEvent>(OnDowned);
         SubscribeLocalEvent<LayingDownComponent, StoodEvent>(OnStood);
 
         SubscribeNetworkEvent<CheckAutoGetUpEvent>(OnCheckAutoGetUp);
@@ -51,12 +51,9 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
         sprite.Rotation = Angle.FromDegrees(90);
     }
 
-    private void OnDowned(DownedEvent ev, EntitySessionEventArgs args)
+    private void OnDowned(DrawDownedEvent args)
     {
-        if (!args.SenderSession.AttachedEntity.HasValue)
-            return;
-
-        var uid = args.SenderSession.AttachedEntity.Value;
+        var uid = GetEntity(args.Uid);
 
         if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp<LayingDownComponent>(uid, out var component))
             return;

--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -66,7 +66,8 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
 
     private void OnStood(EntityUid uid, LayingDownComponent component, StoodEvent args)
     {
-        if (!TryComp<SpriteComponent>(uid, out var sprite) || !component.OriginalDrawDepth.HasValue)
+        if (!TryComp<SpriteComponent>(uid, out var sprite) 
+            || !component.OriginalDrawDepth.HasValue)
             return;
 
         sprite.DrawDepth = component.OriginalDrawDepth.Value;

--- a/Content.Server/Flight/FlightSystem.cs
+++ b/Content.Server/Flight/FlightSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Flight;
 using Content.Shared.Flight.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Zombies;
 using Robust.Shared.Audio.Systems;
@@ -16,6 +17,7 @@ public sealed class FlightSystem : SharedFlightSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     public override void Initialize()
     {
@@ -27,6 +29,7 @@ public sealed class FlightSystem : SharedFlightSystem
         SubscribeLocalEvent<FlightComponent, EntityZombifiedEvent>(OnZombified);
         SubscribeLocalEvent<FlightComponent, KnockedDownEvent>(OnKnockedDown);
         SubscribeLocalEvent<FlightComponent, StunnedEvent>(OnStunned);
+        SubscribeLocalEvent<FlightComponent, DownedEvent>(OnDowned);
         SubscribeLocalEvent<FlightComponent, SleepStateChangedEvent>(OnSleep);
     }
     public override void Update(float frameTime)
@@ -103,6 +106,13 @@ public sealed class FlightSystem : SharedFlightSystem
             _popupSystem.PopupEntity(Loc.GetString("no-flight-while-zombified"), uid, uid, PopupType.Medium);
             return false;
         }
+
+        if (HasComp<StandingStateComponent>(uid) && _standing.IsDown(uid))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("no-flight-while-lying"), uid, uid, PopupType.Medium);
+            return false;
+        }
+
         return true;
     }
 
@@ -135,6 +145,14 @@ public sealed class FlightSystem : SharedFlightSystem
     }
 
     private void OnStunned(EntityUid uid, FlightComponent component, ref StunnedEvent args)
+    {
+        if (!component.On)
+            return;
+
+        ToggleActive(uid, false, component);
+    }
+
+    private void OnDowned(EntityUid uid, FlightComponent component, ref DownedEvent args)
     {
         if (!component.On)
             return;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2470,9 +2470,16 @@ namespace Content.Shared.CCVar
 
         public static readonly CVarDef<bool> HoldLookUp =
             CVarDef.Create("rest.hold_look_up", false, CVar.CLIENT | CVar.ARCHIVE);
-            
+
+        /// <summary>
+        ///     When true, entities that fall to the ground will be able to crawl under tables and 
+        ///     plastic flaps, allowing them to take cover from gunshots. 
+        /// </summary>
+        public static readonly CVarDef<bool> CrawlUnderTables =
+            CVarDef.Create("rest.crawlundertables", false, CVar.REPLICATED);
+
         #endregion
-        
+
         #region Material Reclaimer
 
         /// <summary>
@@ -2498,5 +2505,6 @@ namespace Content.Shared.CCVar
             CVarDef.Create("jetpack.enable_in_no_gravity", true, CVar.REPLICATED);
 
         #endregion
+
     }
 }

--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -14,6 +14,9 @@ public sealed partial class LayingDownComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool AutoGetUp;
+
+    [DataField, AutoNetworkedField]
+    public int? OriginalDrawDepth { get; set; }
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -27,3 +27,9 @@ public sealed class CheckAutoGetUpEvent(NetEntity user) : CancellableEntityEvent
 {
     public NetEntity User = user;
 }
+
+[Serializable, NetSerializable]
+public sealed class DrawDownedEvent(NetEntity uid) : EntityEventArgs
+{
+    public NetEntity Uid = uid;
+}

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -69,7 +69,7 @@ public sealed class StandingStateSystem : EntitySystem
         RaiseLocalEvent(uid, new DownedEvent(), false);
 
         // Raising this event will lower the entity's draw depth to the same as a small mob.
-        if (!_config.GetCVar(CCVars.CrawlUnderTables))
+        if (_config.GetCVar(CCVars.CrawlUnderTables))
             RaiseNetworkEvent(new DrawDownedEvent(GetNetEntity(uid)));
 
         // Seemed like the best place to put it

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -1,12 +1,15 @@
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
+using Content.Shared.CCVar;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Rotation;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Standing;
 
@@ -17,6 +20,7 @@ public sealed class StandingStateSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     // If StandingCollisionLayer value is ever changed to more than one layer, the logic needs to be edited.
     private const int StandingCollisionLayer = (int) CollisionGroup.MidImpassable;
@@ -63,6 +67,10 @@ public sealed class StandingStateSystem : EntitySystem
         standingState.CurrentState = StandingState.Lying;
         Dirty(standingState);
         RaiseLocalEvent(uid, new DownedEvent(), false);
+
+        // Raising this event will lower the entity's draw depth to the same as a small mob.
+        if (_config.GetCVar(CCVars.CrawlUnderTables))
+            RaiseNetworkEvent(new DownedEvent(), uid);
 
         // Seemed like the best place to put it
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
@@ -157,4 +165,6 @@ public sealed class StoodEvent : EntityEventArgs { }
 /// <summary>
 ///     Raised when an entity is not standing
 /// </summary>
+
+[Serializable, NetSerializable]
 public sealed class DownedEvent : EntityEventArgs { }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -69,8 +69,8 @@ public sealed class StandingStateSystem : EntitySystem
         RaiseLocalEvent(uid, new DownedEvent(), false);
 
         // Raising this event will lower the entity's draw depth to the same as a small mob.
-        if (_config.GetCVar(CCVars.CrawlUnderTables))
-            RaiseNetworkEvent(new DownedEvent(), uid);
+        if (!_config.GetCVar(CCVars.CrawlUnderTables))
+            RaiseNetworkEvent(new DrawDownedEvent(GetNetEntity(uid)));
 
         // Seemed like the best place to put it
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
@@ -165,6 +165,4 @@ public sealed class StoodEvent : EntityEventArgs { }
 /// <summary>
 ///     Raised when an entity is not standing
 /// </summary>
-
-[Serializable, NetSerializable]
 public sealed class DownedEvent : EntityEventArgs { }

--- a/Resources/Locale/en-US/flight/flight_system.ftl
+++ b/Resources/Locale/en-US/flight/flight_system.ftl
@@ -1,2 +1,3 @@
 no-flight-while-restrained = You can't fly right now.
 no-flight-while-zombified = You can't use your wings right now.
+no-flight-while-lying = You can't fly right now.

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -20,6 +20,7 @@
         - TableMask
         layer:
         - TableLayer
+        - BulletImpassable
   - type: SpriteFade
   - type: Sprite
   - type: Icon
@@ -38,7 +39,8 @@
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepHull
-
+  - type: RequireProjectileTarget
+  
 - type: entity
   id: CounterBase
   parent: TableBase

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -137,7 +137,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 15
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -178,7 +178,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 15
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -216,7 +216,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 75
+        damage: 30
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -263,7 +263,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 15
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -379,7 +379,7 @@
           collection: GlassBreak
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 30
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -426,7 +426,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 40
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -546,7 +546,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 40
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -573,7 +573,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 20
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -26,6 +26,7 @@
         - TabletopMachineMask
         layer:
         - MidImpassable
+        - BulletImpassable
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
@@ -33,7 +34,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -45,7 +46,8 @@
     node: plasticFlaps
   - type: StaticPrice
     price: 83
-
+  - type: RequireProjectileTarget
+  
 - type: entity
   id: PlasticFlapsOpaque
   parent: PlasticFlapsClear
@@ -65,6 +67,7 @@
         layer:
         - Opaque
         - MidImpassable
+        - BulletImpassable
   - type: Occluder
   - type: Construction
     graph: PlasticFlapsGraph
@@ -81,7 +84,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 75
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -103,7 +106,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 75
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
# Description

Adds a CVAR that when enabled, allows entities to crawl under tables/flaps by lowering their DrawDepth, which in turn protects them from being targeted for projectiles while crawling. 

Additionally tables and plastic flaps were given collision properties along with reduced damage thresholds, so guns can target & destroy them easily if your mouse is on top of them. 

---

<h1>Media</h1>
<p>

https://github.com/user-attachments/assets/77a04198-11cb-4895-bf2d-6f82b7f2bb5b

</p>
</details>

---

# Changelog

:cl:
- add: Adds an optional server variable which allows entities to crawl under tables.
- tweak: Tables and plastic flaps are less resistant to damage, and can now be targeted by guns by aiming on top of them.
