### PR TITLE
More Objects Hit By Projectiles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -48,6 +48,31 @@
       path: /Audio/SimpleStation14/Items/Handling/drinkglass_drop.ogg
       params:
         volume: -2
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 30
+        mask:
+        - ItemMask
+        layer:
+        - BulletImpassable # Ever seen a John Woo movie?
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 5
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -6
+      - !type:SpillBehavior { }
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -31,6 +31,9 @@
         !type:DamageTrigger
         damage: 5
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
       - !type:SpillBehavior { }
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -54,6 +54,17 @@
     materialComposition:
       Glass: 60
   - type: SpaceGarbage
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 25
+        mask:
+        - ItemMask
+        layer:
+        - BulletImpassable # Ever seen a John Woo movie?
 
 - type: entity
   name: broken plate

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -33,7 +33,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 25
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -48,6 +48,7 @@
           collection: MetalBreak
   - type: StaticPrice
     price: 10
+  - type: RequireProjectileTarget
 
 #Starts unanchored, cannot be rotated while anchored
 - type: entity


### PR DESCRIPTION
# Description

This PR is a follow up to https://github.com/Simple-Station/Einstein-Engines/pull/939
By increasing the number of items that are struck by bullets, or can be targeted by bullets. To add to the "Cinematic" experience of a gunfight, Bottles, Cups, and Plates of all kinds are automatically struck by bullets when fired over, and *probably* destroyed given that they only have 5 hit points. This also serves to aid in limiting the amount of things that can be hidden underneath when crawling under a table, since the station's bar counter will likely explode into a ton of glass and spilled booze when a gunfight gets near it. 

I also added Chairs to the "RequireProjectileTarget" feature, so that if you click on a chair, you'll shoot the chair and (probably) destroy it.

# Changelog

:cl:
- add: Bottles, Drink Glasses, Plates, and all liquid containers are now struck by bullets(and most likely destroyed in the process). We hope that this will offer both a small tactical advantage/disadvantage, as well as contribute to making gunfights around the bar more "Cinematic".
- add: Chairs are now hit by projectiles if a shooter clicks on them, in addition to Tables.
