### PR TITLE
IPCs Don't Weigh 5kg

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -115,6 +115,18 @@
     whitelist:
       types:
       - Shard
+  - type: Fixtures
+    fixtures: # TODO: This needs a second fixture just for mob collisions.
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 185
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description

The people who made IPC apparently never setup a fixture for them, so they were using the BaseMob default fixture, which provides a mass of 5kg. I've swapped it out for a standard human fixture for the time being. 

# Changelog

:cl:
- fix: IPC now weigh 71kg by default instead of 5kg. Seriously who the fuck made the BeepBoops out of feathers!?!
