### PR TITLE
Fix IPC Reboot Button

### DIFF
--- a/Content.Server/Silicon/DeadStartupButtonSystem/DeadStartupButtonSystem.cs
+++ b/Content.Server/Silicon/DeadStartupButtonSystem/DeadStartupButtonSystem.cs
@@ -28,6 +28,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
     /// <inheritdoc/>
     public override void Initialize()
     {
+        base.Initialize();
         SubscribeLocalEvent<DeadStartupButtonComponent, OnDoAfterButtonPressedEvent>(OnDoAfter);
         SubscribeLocalEvent<DeadStartupButtonComponent, ElectrocutedEvent>(OnElectrocuted);
         SubscribeLocalEvent<DeadStartupButtonComponent, MobStateChangedEvent>(OnMobStateChanged);

--- a/Content.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
+++ b/Content.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DoAfter;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
@@ -12,7 +13,7 @@ namespace Content.Shared.Silicon.DeadStartupButton;
 ///     This creates a Button that can be activated after an entity, usually a silicon or an IPC, died.
 ///     This will activate a doAfter and then revive the entity, playing a custom afterward sound.
 /// </summary>
-public abstract partial class SharedDeadStartupButtonSystem : EntitySystem
+public partial class SharedDeadStartupButtonSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -27,7 +28,8 @@ public abstract partial class SharedDeadStartupButtonSystem : EntitySystem
 
     private void AddTurnOnVerb(EntityUid uid, DeadStartupButtonComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!_mobState.IsDead(uid)
+        if (!TryComp<MobStateComponent>(uid, out var mobState)
+            || !_mobState.IsDead(uid, mobState)
             || !args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
 

--- a/Content.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
+++ b/Content.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Silicon.DeadStartupButton;
 ///     This creates a Button that can be activated after an entity, usually a silicon or an IPC, died.
 ///     This will activate a doAfter and then revive the entity, playing a custom afterward sound.
 /// </summary>
-public partial class SharedDeadStartupButtonSystem : EntitySystem
+public abstract partial class SharedDeadStartupButtonSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;


### PR DESCRIPTION
# Description

This fixes a bug with IPCs where the button to reboot them wasn't appearing.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/6cd8e896-916d-4021-9095-1bdf90c80715)

</p>
</details>

# Changelog

:cl:
- fix: Fixed a bug where the button to reboot IPCs wasn't appearing.
