### PR TITLE
Interaction Verb Minor Fixes

### DIFF
--- a/Content.Server/InteractionVerbs/Actions/ChangeStandingStateAction.cs
+++ b/Content.Server/InteractionVerbs/Actions/ChangeStandingStateAction.cs
@@ -15,23 +15,24 @@ public sealed partial class ChangeStandingStateAction : InteractionAction
             return false;
 
         if (isBefore)
-            args.Blackboard["standing"] = state.Standing;
+            args.Blackboard["standing"] = state.CurrentState;
 
-        return state.Standing ? MakeLaying : MakeStanding;
+        return state.CurrentState == StandingState.Standing && MakeLaying
+               || state.CurrentState == StandingState.Lying && MakeStanding;
     }
 
     public override bool Perform(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
     {
         var stateSystem = deps.EntMan.System<StandingStateSystem>();
-        var isDown = stateSystem.IsDown(args.Target);
 
-        if (args.TryGetBlackboard("standing", out bool wasStanding) && wasStanding != !isDown)
-            return false; // The target changed its standing state during the do-after - sus
+        if (!deps.EntMan.TryGetComponent<StandingStateComponent>(args.Target, out var state)
+            || args.TryGetBlackboard("standing", out StandingState oldStanding) && oldStanding != state.CurrentState)
+            return false;
 
         // Note: these will get cancelled if the target is forced to stand/lay, e.g. due to a buckle or stun or something else.
-        if (isDown && MakeStanding)
+        if (state.CurrentState == StandingState.Lying && MakeStanding)
             return stateSystem.Stand(args.Target);
-        else if (!isDown && MakeLaying)
+        else if (state.CurrentState == StandingState.Standing && MakeLaying)
             return stateSystem.Down(args.Target);
 
         return false;

--- a/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/InteractionVerbs/InteractionVerbsSystem.cs
@@ -13,6 +13,14 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactions = default!;
 
+    private EntityQuery<OccluderComponent> _occluderQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _occluderQuery = GetEntityQuery<OccluderComponent>();
+    }
+
     protected override void SendChatLog(string message, EntityUid source, Filter filter, InteractionPopupPrototype popup, bool clip)
     {
         if (filter.Count <= 0)
@@ -24,7 +32,7 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
         // Exclude entities who cannot directly see the target of the popup. TODO this may have a high performance cost - although whispers do the same.
         // We only do this if the popup has to be logged into chat since that has some gameplay implications.
         if (clip && popup.DoClipping)
-            filter.RemoveWhereAttachedEntity(ent => !_interactions.InRangeUnobstructed(ent, source, popup.VisibilityRange, CollisionGroup.Opaque));
+            filter.RemoveWhereAttachedEntity(ent => !CanSee(ent, source, popup.VisibilityRange));
 
         if (filter.Count == 1)
             _chatManager.ChatMessageToOne(popup.LogChannel, message, wrappedMessage, source, false, filter.Recipients.First().Channel, color);
@@ -39,4 +47,15 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
         PopupType.Medium or PopupType.Small => Color.LightGray,
         _ => Color.White
     };
+
+    private bool CanSee(EntityUid source, EntityUid target, float maxRange)
+    {
+        // TODO: InRangeUnobstructed has a pretty high performance cost and is not intended to be used like that.
+        // We should see if we can move this to client side later, aka make the client check if the target is visible for it.
+        return _interactions.InRangeUnobstructed(
+            source, target, maxRange,
+            CollisionGroup.Opaque,
+            uid => !_occluderQuery.TryComp(uid, out var occluder) || !occluder.Enabled, // We ignore all entities that do not occlude light
+            false);
+    }
 }

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -153,7 +153,7 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
     public bool RequiresHands = false;
 
     /// <summary>
-    ///     Whether this verb requires the user to be able to interact with the target normally.
+    ///     Whether this verb requires the user to be able to access the target normally (with their hands or otherwise).
     /// </summary>
     /// <remarks>The misleading yml name is kept for backwards compatibility with downstreams.</remarks>
     [DataField("requiresCanInteract")]

--- a/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
+++ b/Content.Shared/InteractionVerbs/InteractionVerbPrototype.cs
@@ -152,8 +152,12 @@ public sealed partial class InteractionVerbPrototype : IPrototype, IInheritingPr
     [DataField]
     public bool RequiresHands = false;
 
-    [DataField]
-    public bool RequiresCanInteract = true;
+    /// <summary>
+    ///     Whether this verb requires the user to be able to interact with the target normally.
+    /// </summary>
+    /// <remarks>The misleading yml name is kept for backwards compatibility with downstreams.</remarks>
+    [DataField("requiresCanInteract")]
+    public bool RequiresCanAccess = true;
 
     /// <summary>
     ///     If true, this verb can be invoked by the user on itself.

--- a/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
+++ b/Content.Shared/InteractionVerbs/Requirements/AssortedRequirements.cs
@@ -55,7 +55,8 @@ public sealed partial class StandingStateRequirement : InteractionRequirement
         if (!deps.EntMan.TryGetComponent<StandingStateComponent>(args.Target, out var state))
             return false;
 
-        return state.Standing ? AllowStanding : AllowLaying;
+        return state.CurrentState == StandingState.Standing && AllowStanding
+            || state.CurrentState == StandingState.Lying && AllowLaying;
     }
 }
 

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -178,7 +178,8 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
         if (_net.IsClient)
             return; // this leads to issues
 
-        if (!proto.Action!.CanPerform(args, proto, false, _verbDependencies) && !force
+        if (!PerformChecks(proto, ref args, out _, out _)
+            || !proto.Action!.CanPerform(args, proto, false, _verbDependencies) && !force
             || !proto.Action.Perform(args, proto, _verbDependencies))
         {
             CreateVerbEffects(proto.EffectFailure, Fail, proto, args);

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -178,7 +178,7 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
         if (_net.IsClient)
             return; // this leads to issues
 
-        if (!PerformChecks(proto, ref args, out _, out _)
+        if (!PerformChecks(proto, ref args, out _, out _) && !force
             || !proto.Action!.CanPerform(args, proto, false, _verbDependencies) && !force
             || !proto.Action.Perform(args, proto, _verbDependencies))
         {

--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -156,7 +156,7 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
             Broadcast = true,
             BreakOnHandChange = proto.RequiresHands,
             NeedHand = proto.RequiresHands,
-            RequireCanInteract = proto.RequiresCanInteract,
+            RequireCanInteract = proto.RequiresCanAccess,
             Delay = delay,
             Event = new InteractionVerbDoAfterEvent(proto.ID, args)
         };
@@ -271,7 +271,7 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
             return false;
         }
 
-        if (proto.RequiresCanInteract && args is not { CanInteract: true, CanAccess: true } || !proto.Range.IsInRange(distance))
+        if (!args.CanInteract || proto.RequiresCanAccess && !args.CanAccess || !proto.Range.IsInRange(distance))
         {
             errorLocale = "interaction-verb-cannot-reach";
             return false;


### PR DESCRIPTION
# Description
- Updates the standing state requirement and the change standing state action to use the new laying down system (CurrentState instead of the old boolean Standing).
- Makes it so that you cannot use any interaction verbs on entities you cannot interact with (fixes it being possible to look at entities while being in crit)
- Changes the interaction popup clipping algorithm to include a predicate that ignores any entity that does not occlude light (fixes mobs, welding tanks, and some other non-opaque things preventing you from seeing interaction popups)
- Makes it so that the verb requirements are checked one additional time before the verb is interaction is actually executed. (this e.g. prevents the MakeSleepOther from working if the target stands up during the do-after)

# Changelog
:cl:
- fix: Fixed multiple minor issues with interaction verbs. Most importantly, interaction popups will now always be shown correctly.
