### PR TITLE
Update Noospheric Events' Glimmer Ranges

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -94,7 +94,7 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 590
+      minimumGlimmer: 400
       maximumGlimmer: 1000
       glimmerBurnLower: 18
       glimmerBurnUpper: 40
@@ -129,7 +129,7 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 550 # Requires at least some noospheric activity
+      minimumGlimmer: 300
       maximumGlimmer: 1000
       report: glimmer-event-report-signatures
     - type: FreeProberRule
@@ -147,7 +147,7 @@
       reoccurrenceDelay: 15
       minimumPlayers: 10
     - type: GlimmerEvent
-      minimumGlimmer: 500
+      minimumGlimmer: 250
       maximumGlimmer: 900
       report: glimmer-event-report-signatures
     - type: GlimmerRandomSentienceRule
@@ -158,8 +158,10 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 700
+      minimumGlimmer: 450
       maximumGlimmer: 900
+      glimmerBurnLower: 50
+      glimmerBurnUpper: 100 # Gives epi a chance to recover
       report: glimmer-event-report-signatures
     - type: GlimmerRevenantRule
 
@@ -169,7 +171,7 @@
   noSpawn: true
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 50
+      minimumGlimmer: 250
       maximumGlimmer: 900
       report: glimmer-event-report-signatures
     - type: GlimmerMobRule


### PR DESCRIPTION
# Description
Webedit ops.

The changes to those events were balanced around the fact that all english downstreams had the glimmer changes early-merged, and were not reverted after the said glimmer changes were dropped.

Now:
- PsionicCatGotYourTongue occurs above 400 glimmer
- FreeProber occurs above 300
- GlimmerRevenantSpawn occurs above 450 and burns a substantial amount of glimmer, giving epistemics a chance to recover
- GlimmerMiteSpawn occurs above 250
- GlimmerRandomSentience occurs above 250

Not sure about NoosphericFry. I'm pretty sure probers no longer shoot lightnings, but I'm still opting in to keep it as it is, above 550 glimmer.

# Changelog
:cl:
- tweak: Noospheric events should once again occur on lower glimmer levels.