### PR TITLE
Heal Other Bugfix 2

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
@@ -107,13 +107,14 @@ public sealed class RevivifyPowerSystem : EntitySystem
     private void OnDoAfter(EntityUid uid, PsionicComponent component, PsionicHealOtherDoAfterEvent args)
     {
         // It's entirely possible for the caster to stop being Psionic(due to mindbreaking) mid cast
-        if (component is null
-            || args.Cancelled)
+        if (component is null)
             return;
         component.DoAfter = null;
 
         // The target can also cease existing mid-cast
-        if (args.Target is null)
+        // Or the DoAfter is cancelled(such as if the caster moves).
+        if (args.Target is null
+            || args.Cancelled)
             return;
 
         if (args.RotReduction is not null)


### PR DESCRIPTION
# Description

This fixes a bug with HealOtherPowerSystem where if the performer was forcibly moved during the cast, they would permanently become unable to cast it. 

# Changelog

:cl:
- fix: Fixed a bug with Healing Word and Breath of Life where if the caster was moved by another person mid-cast, they would permanently become unable to cast it again.
