### PR TITLE
Uncomment Immovable Rod

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class ImmovableRodComponent : Component
     ///     If true, this will gib & delete bodies
     /// </summary>
     [DataField]
-    public bool ShouldGib = false;
+    public bool ShouldGib;
 
     /// <summary>
     ///     Damage done, if not gibbing

--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class ImmovableRodComponent : Component
     ///     If true, this will gib & delete bodies
     /// </summary>
     [DataField]
-    public bool ShouldGib = true;
+    public bool ShouldGib = false;
 
     /// <summary>
     ///     Damage done, if not gibbing

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -92,3 +92,6 @@
   components:
   - type: ImmovableRod
     randomizeVelocity: false
+    damage:
+      types:
+        Blunt: 120

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -517,18 +517,18 @@
     sounds:
       collection: Paracusia
 
-#- type: entity # DeltaV - Why does this exist??
-#  id: ImmovableRodSpawn
-#  parent: BaseGameRule
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    startAnnouncement: true
-#    weight: 5
-#    duration: 1
-#    earliestStart: 45
-#    minimumPlayers: 20
-#  - type: ImmovableRodRule
+- type: entity # DeltaV - Why does this exist??
+  id: ImmovableRodSpawn
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: true
+    weight: 2
+    duration: 1
+    earliestStart: 45
+    minimumPlayers: 20
+  - type: ImmovableRodRule
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -517,13 +517,13 @@
     sounds:
       collection: Paracusia
 
-- type: entity # DeltaV - Why does this exist??
+- type: entity
   id: ImmovableRodSpawn
   parent: BaseGameRule
   noSpawn: true
   components:
   - type: StationEvent
-    startAnnouncement: true
+    startAnnouncement: false
     weight: 2
     duration: 1
     earliestStart: 45


### PR DESCRIPTION
# Description

Part of the important gameplay loop for engineering is that they're supposed to be repairing the station when shit breaks it, so the ImmovableRod event is a key part of the game. However, it was currently commented out because people didn't like it gibbing characters with no reactability? Well news flash for people, there's a datafield for that. I can also directly control how much damage it deals.

So in exchange for uncommenting the Immovable Rod event, I've set the immovable rod spawned to be a little fairer for players, while still being able to cause damage to the station that will require repairs(And also expose players to vacuum. So that it puts them in danger.

# Changelog

:cl:
- add: Immovable Rod Event has returned
- add: Immovable Rod Event has been made more fair. It won't automatically gib people, just crit them with a ton of blunt damage(That you can survive by wearing good armor), or just being an Oni funnily enough.
