### PR TITLE
Station Only Glimmer Mites

### DIFF
--- a/Content.Server/DeltaV/StationEvents/Events/GlimmerMobSpawnRule.cs
+++ b/Content.Server/DeltaV/StationEvents/Events/GlimmerMobSpawnRule.cs
@@ -81,6 +81,8 @@ public sealed class GlimmerMobRule : StationEventSystem<GlimmerMobRuleComponent>
                 i++;
                 continue;
             }
+
+            return;
         }
     }
 }


### PR DESCRIPTION
# Description

This PR makes it so that Glimmer Mites can only spawn on "The Main Station", as defined by GetSpawnableStations. Yes this is seemingly pretty hardcodey, but because on our codebase it's simply not possible for GetSpawnableStations to ever return anything other than a list with an index of 0, we can extremely reliably count on GetSpawnableStations()[0] to be "THE Station".

This fixes an issue whereby Glimmer Mites can spawn in places where it is simply not possible for players to reach them. Such as random asteroids in space, CENTCOMM, Nukie World, or the Syndicate Listening Outpost.

# Changelog

:cl:
- fix: Glimmer Mites can no longer spawn anywhere other than "THE" Station.
