### PR TITLE
Psionic Mood System Interactions

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
@@ -32,7 +32,6 @@ public sealed class RevivifyPowerSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly GlimmerSystem _glimmer = default!;
 
-
     public override void Initialize()
     {
         base.Initialize();
@@ -48,26 +47,29 @@ public sealed class RevivifyPowerSystem : EntitySystem
         if (component.DoAfter is not null)
             return;
 
+        args.ModifiedAmplification = _psionics.ModifiedAmplification(uid, component);
+        args.ModifiedDampening = _psionics.ModifiedDampening(uid, component);
+
         if (!args.Immediate)
             AttemptDoAfter(uid, component, args);
         else ActivatePower(uid, component, args);
 
         if (args.PopupText is not null
-            && _glimmer.Glimmer > args.GlimmerPopupThreshold * component.CurrentDampening)
+            && _glimmer.Glimmer > args.GlimmerPopupThreshold * args.ModifiedDampening)
             _popupSystem.PopupEntity(Loc.GetString(args.PopupText, ("entity", uid)), uid,
                 Filter.Pvs(uid).RemoveWhereAttachedEntity(entity => !_examine.InRangeUnOccluded(uid, entity, ExamineRange, null)),
                 true,
                 args.PopupType);
 
         if (args.PlaySound
-            && _glimmer.Glimmer > args.GlimmerSoundThreshold * component.CurrentDampening)
+            && _glimmer.Glimmer > args.GlimmerSoundThreshold * args.ModifiedDampening)
             _audioSystem.PlayPvs(args.SoundUse, uid, args.AudioParams);
 
         // Sanitize the Glimmer inputs because otherwise the game will crash if someone makes MaxGlimmer lower than MinGlimmer.
         var minGlimmer = (int) Math.Round(MathF.MinMagnitude(args.MinGlimmer, args.MaxGlimmer)
-            + component.CurrentAmplification - component.CurrentDampening);
+            * args.ModifiedAmplification - args.ModifiedDampening);
         var maxGlimmer = (int) Math.Round(MathF.MaxMagnitude(args.MinGlimmer, args.MaxGlimmer)
-            + component.CurrentAmplification - component.CurrentDampening);
+            * args.ModifiedAmplification - args.ModifiedDampening);
 
         _psionics.LogPowerUsed(uid, args.PowerName, minGlimmer, maxGlimmer);
         args.Handled = true;
@@ -80,12 +82,15 @@ public sealed class RevivifyPowerSystem : EntitySystem
             ev.HealingAmount = args.HealingAmount;
         if (args.RotReduction is not null)
             ev.RotReduction = args.RotReduction.Value;
+
+        ev.ModifiedAmplification = args.ModifiedAmplification;
+        ev.ModifiedDampening = args.ModifiedDampening;
         ev.DoRevive = args.DoRevive;
         var doAfterArgs = new DoAfterArgs(EntityManager, uid, args.UseDelay, ev, uid, target: args.Target)
         {
             BreakOnUserMove = args.BreakOnUserMove,
             BreakOnTargetMove = args.BreakOnTargetMove,
-            Hidden = _glimmer.Glimmer > args.GlimmerDoAfterVisibilityThreshold * component.CurrentDampening,
+            Hidden = _glimmer.Glimmer > args.GlimmerDoAfterVisibilityThreshold * args.ModifiedDampening,
         };
 
         if (!_doAfterSystem.TryStartDoAfter(doAfterArgs, out var doAfterId))
@@ -118,13 +123,13 @@ public sealed class RevivifyPowerSystem : EntitySystem
             return;
 
         if (args.RotReduction is not null)
-            _rotting.ReduceAccumulator(args.Target.Value, TimeSpan.FromSeconds(args.RotReduction.Value * component.CurrentAmplification));
+            _rotting.ReduceAccumulator(args.Target.Value, TimeSpan.FromSeconds(args.RotReduction.Value * args.ModifiedAmplification));
 
         if (!TryComp<DamageableComponent>(args.Target.Value, out var damageableComponent))
             return;
 
         if (args.HealingAmount is not null)
-            _damageable.TryChangeDamage(args.Target.Value, args.HealingAmount * component.CurrentAmplification, true, false, damageableComponent, uid);
+            _damageable.TryChangeDamage(args.Target.Value, args.HealingAmount * args.ModifiedAmplification, true, false, damageableComponent, uid);
 
         if (!args.DoRevive
             || _rotting.IsRotten(args.Target.Value)
@@ -144,13 +149,13 @@ public sealed class RevivifyPowerSystem : EntitySystem
             return;
 
         if (args.RotReduction is not null)
-            _rotting.ReduceAccumulator(args.Target, TimeSpan.FromSeconds(args.RotReduction.Value * component.CurrentAmplification));
+            _rotting.ReduceAccumulator(args.Target, TimeSpan.FromSeconds(args.RotReduction.Value * args.ModifiedAmplification));
 
         if (!TryComp<DamageableComponent>(args.Target, out var damageableComponent))
             return;
 
         if (args.HealingAmount is not null)
-            _damageable.TryChangeDamage(args.Target, args.HealingAmount * component.CurrentAmplification, true, false, damageableComponent, uid);
+            _damageable.TryChangeDamage(args.Target, args.HealingAmount * args.ModifiedAmplification, true, false, damageableComponent, uid);
 
         if (!args.DoRevive
             || _rotting.IsRotten(args.Target)

--- a/Content.Shared/Actions/Events/PsionicHealOtherPowerActionEvent.cs
+++ b/Content.Shared/Actions/Events/PsionicHealOtherPowerActionEvent.cs
@@ -5,11 +5,21 @@ using Content.Shared.Popups;
 namespace Content.Shared.Actions.Events;
 public sealed partial class PsionicHealOtherPowerActionEvent : EntityTargetActionEvent
 {
+    /// <summary>
+    ///     Caster's Amplification that has been modified by the results of a MoodContest.
+    /// </summary>
+    public float ModifiedAmplification = default!;
+
+    /// <summary>
+    ///     Caster's Dampening that has been modified by the results of a MoodContest.
+    /// </summary>
+    public float ModifiedDampening = default!;
+
     [DataField]
     public DamageSpecifier? HealingAmount = default!;
 
     [DataField]
-    public string PowerName;
+    public string PowerName = default!;
 
     /// Controls whether or not a power fires immediately and with no DoAfter
     [DataField]

--- a/Content.Shared/Psionics/Events.cs
+++ b/Content.Shared/Psionics/Events.cs
@@ -50,6 +50,16 @@ public sealed partial class PsionicHealOtherDoAfterEvent : DoAfterEvent
     [DataField]
     public bool DoRevive;
 
+    /// <summary>
+    ///     Caster's Amplification that has been modified by the results of a MoodContest.
+    /// </summary>
+    public float ModifiedAmplification = default!;
+
+    /// <summary>
+    ///     Caster's Dampening that has been modified by the results of a MoodContest.
+    /// </summary>
+    public float ModifiedDampening = default!;
+
     public PsionicHealOtherDoAfterEvent(TimeSpan startedAt)
     {
         StartedAt = startedAt;

--- a/Content.Shared/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Administration.Logs;
+using Content.Shared.Contests;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;
 using Robust.Shared.Random;
@@ -13,6 +14,7 @@ namespace Content.Shared.Abilities.Psionics
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
+        [Dependency] private readonly ContestsSystem _contests = default!;
 
         public override void Initialize()
         {
@@ -40,6 +42,48 @@ namespace Content.Shared.Abilities.Psionics
             RaiseLocalEvent(uid, ev, false);
 
             _glimmerSystem.Glimmer += _robustRandom.Next(minGlimmer, maxGlimmer);
+        }
+
+        /// <summary>
+        ///     Returns the CurrentAmplification of a given Entity, multiplied by the result of that Entity's MoodContest.
+        ///     Higher mood means more Amplification, Lower mood means less Amplification.
+        /// </summary>
+        public float ModifiedAmplification(EntityUid uid)
+        {
+            if (!TryComp<PsionicComponent>(uid, out var psionicComponent))
+                return 1;
+
+            return ModifiedAmplification(uid, psionicComponent);
+        }
+
+        /// <summary>
+        ///     Returns the CurrentAmplification of a given Entity, multiplied by the result of that Entity's MoodContest.
+        ///     Higher mood means more Amplification, Lower mood means less Amplification.
+        /// </summary>
+        public float ModifiedAmplification(EntityUid uid, PsionicComponent component)
+        {
+            return component.CurrentAmplification * _contests.MoodContest(uid, true);
+        }
+
+        /// <summary>
+        ///     Returns the CurrentDampening of a given Entity, multiplied by the result of that Entity's MoodContest.
+        ///     Lower mood means more Dampening, higher mood means less Dampening.
+        /// </summary>
+        public float ModifiedDampening(EntityUid uid)
+        {
+            if (!TryComp<PsionicComponent>(uid, out var psionicComponent))
+                return 1;
+
+            return ModifiedDampening(uid, psionicComponent);
+        }
+
+        /// <summary>
+        ///     Returns the CurrentDampening of a given Entity, multiplied by the result of that Entity's MoodContest.
+        ///     Lower mood means more Dampening, higher mood means less Dampening.
+        /// </summary>
+        public float ModifiedDampening(EntityUid uid, PsionicComponent component)
+        {
+            return component.CurrentDampening / _contests.MoodContest(uid, true);
         }
     }
 


### PR DESCRIPTION
# Description

This PR implements an initial first foray into adding MoodSystem interactions with Psionics. To put it simply. High mood raises Amplification and lowers Dampening. Low mood lowers Amplification and raises Dampening. 

Sanguine and Saturnine are basically psionic-related traits now. If you're willing to tolerate Saturnine's other debuffs, it will now by extension start making psionic abilities much safer to cast. 

# Changelog

:cl:
- add: Mood System now has some interactions with Psionics. 
