### PR TITLE
Fix Command Dumping To Uncategorized

### DIFF
--- a/Resources/Prototypes/Loadouts/Categories/categories.yml
+++ b/Resources/Prototypes/Loadouts/Categories/categories.yml
@@ -43,43 +43,10 @@
   id: JobsAUncategorized
 
 - type: loadoutCategory
-  id: JobsCommand
-  subCategories:
-    - JobsCommandAUncategorized
-    - JobsCommandCaptain
-    - JobsCommandCE
-    - JobsCommandCMO
-    - JobsCommandHOP
-    - JobsCommandHOS
-    - JobsCommandQM
-    - JobsCommandRD
-
-- type: loadoutCategory
-  id: JobsCommandAUncategorized
-
-- type: loadoutCategory
-  id: JobsCommandCaptain
-
-- type: loadoutCategory
-  id: JobsCommandCE
-
-- type: loadoutCategory
-  id: JobsCommandCMO
-
-- type: loadoutCategory
-  id: JobsCommandHOP
-
-- type: loadoutCategory
-  id: JobsCommandHOS
-
-- type: loadoutCategory
-  id: JobsCommandQM
-
-- type: loadoutCategory
-  id: JobsCommandRD
-
-- type: loadoutCategory
   id: JobsCargo
+
+- type: loadoutCategory
+  id: JobsCommand
 
 - type: loadoutCategory
   id: JobsEngineering

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/captain.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandCapNeckMantle
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -12,7 +12,7 @@
 
 - type: loadout
   id: LoadoutCommandCapNeckCloak
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -24,7 +24,7 @@
 
 - type: loadout
   id: LoadoutCommandCapNeckCloakFormal
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -36,7 +36,7 @@
 
 - type: loadout
   id: LoadoutCommandCapJumpsuitFormal
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -48,7 +48,7 @@
 
 - type: loadout
   id: LoadoutCommandCapJumpskirtFormal
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -60,7 +60,7 @@
 
 - type: loadout
   id: LoadoutCommandCapOuterWinter
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -71,7 +71,7 @@
 
 - type: loadout
   id: LoadoutCommandCapGloves
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -82,7 +82,7 @@
 
 - type: loadout
   id: LoadoutCommandCapHat
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -93,7 +93,7 @@
 
 - type: loadout
   id: LoadoutCommandCapHatCapcap
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -104,7 +104,7 @@
 
 - type: loadout
   id: LoadoutCommandCapHatBeret
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -115,7 +115,7 @@
 
 - type: loadout
   id: LoadoutCommandCapMaskGas
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -126,7 +126,7 @@
 
 - type: loadout
   id: LoadoutCommandCapShoesBootsWinter
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -138,7 +138,7 @@
 
 - type: loadout
   id: LoadoutCommandCapItemDrinkFlask
-  category: JobsCommandCaptain
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefEngineer.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandCENeckMantle
-  category: JobsCommandCE
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -12,7 +12,7 @@
 
 - type: loadout
   id: LoadoutCommandCENeckCloak
-  category: JobsCommandCE
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -24,7 +24,7 @@
 
 - type: loadout
   id: LoadoutCommandCEOuterWinter
-  category: JobsCommandCE
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -35,7 +35,7 @@
 
 - type: loadout
   id: LoadoutCommandCEShoesBootsWinter
-  category: JobsCommandCE
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/chiefMedicalOfficer.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandCMONeckMantle
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -12,7 +12,7 @@
 
 - type: loadout
   id: LoadoutCommandCMONeckCloak
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -24,7 +24,7 @@
 
 - type: loadout
   id: LoadoutCommandCMOOuterWinter
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -35,7 +35,7 @@
 
 - type: loadout
   id: LoadoutCommandCMOOuterLab
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -46,7 +46,7 @@
 
 - type: loadout
   id: LoadoutCommandCMOHatBeret
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -57,7 +57,7 @@
 
 - type: loadout
   id: LoadoutCommandCMOShoesBootsWinter
-  category: JobsCommandCMO
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/command.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/command.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandGlovesInspection
-  category: JobsCommandAUncategorized
+  category: JobsCommand
   cost: 1
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfPersonnel.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandHOPNeckMantle
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -12,7 +12,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPNeckCloak
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -24,7 +24,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPJumpsuitTurtleneckBoatswain
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -36,7 +36,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPJumpsuitMess
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -48,7 +48,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPJumpskirtMess
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -60,7 +60,7 @@
 
 - type: loadout
   id: LoadoutcommandHOPOuterCoatFormal
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -71,7 +71,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPBackIan
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 2
   requirements:
     - !type:CharacterJobRequirement
@@ -82,7 +82,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPHatCap
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -93,7 +93,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPShoesBootsWinter
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -105,7 +105,7 @@
 
 - type: loadout
   id: LoadoutCommandHOPBedsheetIan
-  category: JobsCommandHOP
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
@@ -1,6 +1,6 @@
 - type: loadout
   id: LoadoutCommandHOSNeckMantle
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -12,7 +12,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSNeckCloak
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -24,7 +24,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpsuitAlt
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -36,7 +36,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpsuitBlue
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -48,7 +48,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpsuitGrey
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -60,7 +60,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpsuitParade
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -72,7 +72,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpsuitFormal
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -84,7 +84,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpskirtAlt
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -96,7 +96,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpskirtParade
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -108,7 +108,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSJumpskirtFormal
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -120,7 +120,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSOuterWinter
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -131,7 +131,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSOuterTrench
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -142,7 +142,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSHatBeret
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -153,7 +153,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSHatHoshat
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -164,7 +164,7 @@
 
 - type: loadout
   id: LoadoutCommandHOSShoesBootsWinter
-  category: JobsCommandHOS
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/quarterMaster.yml
@@ -1,7 +1,7 @@
 # What? This isn't a thing?? :(
 # - type: loadout
 #   id: LoadoutCommandQMNeckMantle
-#   category: JobsCommandQM
+#   category: JobsCommand
 #   cost: 2
 #   exclusive: true
 #   requirements:
@@ -13,7 +13,7 @@
 
 - type: loadout
   id: LoadoutCommandQMNeckCloak
-  category: JobsCommandQM
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -25,7 +25,7 @@
 
 - type: loadout
   id: LoadoutCommandQMUniformTurtleneck
-  category: JobsCommandQM
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -37,7 +37,7 @@
 
 - type: loadout
   id: LoadoutCommandQMUniformTurtleneckSkirt
-  category: JobsCommandQM
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -49,7 +49,7 @@
 
 - type: loadout
   id: LoadoutCommandQMHeadSoft
-  category: JobsCommandQM
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -60,7 +60,7 @@
 
 - type: loadout
   id: LoadoutCommandQMShoesBootsWinter
-  category: JobsCommandQM
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/researchDirector.yml
@@ -2,7 +2,7 @@
 
 - type: loadout
   id: LoadoutCommandRDOuterWinter
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -13,7 +13,7 @@
 
 - type: loadout
   id: LoadoutCommandRDOuterMysta
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   requirements:
     - !type:CharacterJobRequirement
@@ -26,7 +26,7 @@
 
 - type: loadout
   id: LoadoutCommandRDHeadHatBeretMysta
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -38,7 +38,7 @@
 
 - type: loadout
   id: LoadoutCommandRDHeadHoodMysta
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -52,7 +52,7 @@
 
 - type: loadout
   id: LoadoutCommandRDNeckMantle
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -64,7 +64,7 @@
 
 - type: loadout
   id: LoadoutCommandRDNeckCloak
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -76,7 +76,7 @@
 
 - type: loadout
   id: LoadoutCommandRDNeckCloakMystagogue
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:
@@ -90,7 +90,7 @@
 
 - type: loadout
   id: LoadoutCommandRDShoesBootsWinter
-  category: JobsCommandRD
+  category: JobsCommand
   cost: 0
   exclusive: true
   requirements:


### PR DESCRIPTION
# Description

Between me and a few other people, we have cumulatively spent numerous man hours combing through Loadouts trying to find why the Command loadouts were being dumped to Uncategorized. Finally I've had enough, so they're getting put back into the JobsCommand category. 

# Changelog

:cl:
- fix: Command Loadouts no longer appear in the Uncategorized tab.
