### PR TITLE
Fix Markings Menu

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
@@ -199,8 +199,10 @@
                 <ui:NeoTabContainer Name="CLoadoutsTabs" VerticalExpand="True" SeparatorMargin="0" />
             </BoxContainer>
             <BoxContainer Name="CMarkingsTab" HorizontalExpand="True" Orientation="Vertical" Margin="10">
-                <!-- Markings -->
-                <humanoid:MarkingPicker Name="CMarkings" IgnoreCategories="Hair,FacialHair" />
+                <ScrollContainer HorizontalExpand="True" HScrollEnabled="True" VerticalExpand="True" VScrollEnabled="True">
+                    <!-- Markings -->
+                    <humanoid:MarkingPicker Name="CMarkings" IgnoreCategories="Hair,FacialHair" />
+                </ScrollContainer>
             </BoxContainer>
         </ui:NeoTabContainer>
     </BoxContainer>


### PR DESCRIPTION
# Description

This PR adds a vertical scroll bar to the Markings tab, which fixes an issue where markings with > 2 color selections could not be used. 

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/fe4ea61a-ced2-4d6d-bc8c-92e752a77d98)

</p>
</details>

# Changelog

:cl:
- fix: Fixed the Markings menu by adding a scroll container to it. Markings with greater than 2 color selections can now be used.
