### PR TITLE
Uncomment Grapple And Tether Guns

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -325,11 +325,11 @@
       - HolofanProjector
       - BluespaceBeaker
       - SyringeBluespace
-      #- WeaponForceGun
+      - WeaponForceGun
       - WeaponLaserSvalinn
       - WeaponProtoKineticAccelerator
-      #- WeaponTetherGun
-      #- WeaponGrapplingGun
+      - WeaponTetherGun
+      - WeaponGrapplingGun
       - ClothingBackpackHolding
       - ClothingBackpackSatchelHolding
       - ClothingBackpackDuffelHolding

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -599,7 +599,7 @@
     - BorgModuleLightReplacer
     - BorgModuleAdvancedCleaning
     - BorgModuleMining
-    #- BorgModuleGrapplingGun
+    - BorgModuleGrapplingGun
     - BorgModuleAdvancedTool
     - BorgModuleGPS
     - BorgModuleRCD

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -76,7 +76,7 @@
     Steel: 100
     Plastic: 200
     Glass: 100
-    
+
 - type: latheRecipe
   id: SignallerAdvanced
   result: RemoteSignallerAdvanced
@@ -178,15 +178,15 @@
     Plasma: 1000 #DeltaV: Bluespace Exists so less plasma used, no uranium
     Bluespace: 200 #DeltaV: Bluespace Exists
 
-#- type: latheRecipe #DeltaV - LRP
-#  id: WeaponForceGun
-#  result: WeaponForceGun
-#  category: Tools
-#  completetime: 5
-#  materials:
-#    Steel: 500
-#    Glass: 400
-#    Silver: 200
+- type: latheRecipe
+  id: WeaponForceGun
+  result: WeaponForceGun
+  category: Tools
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 400
+    Silver: 200
 
 - type: latheRecipe
   id: DeviceQuantumSpinInverter
@@ -207,22 +207,22 @@
     Glass: 500
     Silver: 100
 
-#- type: latheRecipe #DeltaV - LRP
-#  id: WeaponTetherGun
-#  result: WeaponTetherGun
-#  category: Tools
-#  completetime: 5
-#  materials:
-#    Steel: 500
-#    Glass: 400
-#    Silver: 100
+- type: latheRecipe
+  id: WeaponTetherGun
+  result: WeaponTetherGun
+  category: Tools
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 400
+    Silver: 100
 
-#- type: latheRecipe #DeltaV - LRP
-#  id: WeaponGrapplingGun
-#  result: WeaponGrapplingGun
-#  category: Tools
-#  completetime: 5
-#  materials:
-#    Steel: 500
-#    Glass: 400
-#    Gold: 100
+- type: latheRecipe
+  id: WeaponGrapplingGun
+  result: WeaponGrapplingGun
+  category: Tools
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 400
+    Gold: 100

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -427,16 +427,16 @@
     Glass: 250
     Plastic: 250
 
-#- type: latheRecipe
-#  id: BorgModuleGrapplingGun
-#  result: BorgModuleGrapplingGun
-#  category: Robotics
-#  completetime: 3
-#  materials:
-#    Steel: 500
-#    Glass: 500
-#    Plastic: 250
-#    Gold: 50
+- type: latheRecipe
+  id: BorgModuleGrapplingGun
+  result: BorgModuleGrapplingGun
+  category: Robotics
+  completetime: 3
+  materials:
+    Steel: 500
+    Glass: 500
+    Plastic: 250
+    Gold: 50
 
 - type: latheRecipe
   id: BorgModuleAdvancedTool

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -183,18 +183,18 @@
   - SuperMatterBinStockPart
   - PicoManipulatorStockPart
 
-#- type: technology # DeltaV - LRP
-#  id: GravityManipulation
-#  name: research-technology-gravity-manipulation
-#  icon:
-#    sprite: Objects/Weapons/Guns/Launchers/tether_gun.rsi
-#    state: base
-#  discipline: Experimental
-#  tier: 3
-#  cost: 10000
-#  recipeUnlocks:
-#    - WeaponForceGun
-#    - WeaponTetherGun
+- type: technology
+  id: GravityManipulation
+  name: research-technology-gravity-manipulation
+  icon:
+    sprite: Objects/Weapons/Guns/Launchers/tether_gun.rsi
+    state: base
+  discipline: Experimental
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+    - WeaponForceGun
+    - WeaponTetherGun
 
 - type: technology
   id: QuantumLeaping

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -105,18 +105,18 @@
   - RipleyPeripheralsElectronics
   - MechEquipmentGrabber
 
-#- type: technology
-#  id: Grappling
-#  name: research-technology-grappling
-#  icon:
-#    sprite: Objects/Weapons/Guns/Launchers/grappling_gun.rsi
-#    state: base
-#  discipline: Industrial
-#  tier: 1
-#  cost: 5000
-#  recipeUnlocks:
-#  - WeaponGrapplingGun
-#  - BorgModuleGrapplingGun
+- type: technology
+  id: Grappling
+  name: research-technology-grappling
+  icon:
+    sprite: Objects/Weapons/Guns/Launchers/grappling_gun.rsi
+    state: base
+  discipline: Industrial
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+  - WeaponGrapplingGun
+  - BorgModuleGrapplingGun
 
 # Tier 2
 


### PR DESCRIPTION
# Description

Pretty easy PR, this just uncomments Grapple & Tether Guns, such that players can once again obtain them from Science.

# Changelog

:cl:
- add: Grapple & Tether Guns have been re-added.
