### PR TITLE
Blood Regeneration Affects Hunger/Thirst

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Traits;
 using Content.Server.Traits.Assorted;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -82,6 +83,13 @@ namespace Content.Server.Body.Components
         /// </summary>
         [DataField]
         public FixedPoint2 BloodRefreshAmount = 1.0f;
+
+        /// <summary>
+        ///     How much hunger/thirst is used to regenerate one unit of blood. Set to zero to disable.
+        ///     The actual thirst/hunger rate will scale with <see cref="BloodRefreshAmount"/>.
+        /// </summary>
+        /// <remarks>Those will have no effect if the entity has no hunger/thirst components.</remarks>
+        public float BloodRegenerationHunger = 0.4f, BloodRegenerationThirst = 0.9f;
 
         /// <summary>
         ///     How much blood needs to be in the temporary solution in order to create a puddle?
@@ -172,18 +180,5 @@ namespace Content.Server.Body.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public TimeSpan StatusTime;
-
-        /// <summary>
-        ///     If this is true, the entity will not passively regenerate blood,
-        ///     and instead will slowly lose blood.
-        /// </summary>
-        [DataField]
-        public bool HasBloodDeficiency = false;
-
-        /// <summary>
-        ///     How much percentage of max blood volume should be removed with blood deficiency in each update interval?
-        /// </summary>
-        [DataField]
-        public float BloodDeficiencyLossPercentage;
     }
 }

--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -89,7 +89,7 @@ namespace Content.Server.Body.Components
         ///     The actual thirst/hunger rate will scale with <see cref="BloodRefreshAmount"/>.
         /// </summary>
         /// <remarks>Those will have no effect if the entity has no hunger/thirst components.</remarks>
-        public float BloodRegenerationHunger = 0.4f, BloodRegenerationThirst = 0.9f;
+        public float BloodRegenerationHunger = 1f, BloodRegenerationThirst = 1f;
 
         /// <summary>
         ///     How much blood needs to be in the temporary solution in order to create a puddle?

--- a/Content.Server/Body/Events/NaturalBloodRegenerationAttemptEvent.cs
+++ b/Content.Server/Body/Events/NaturalBloodRegenerationAttemptEvent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Server.Body.Events;
+
+/// <summary>
+///     Raised on a mob when its bloodstream tries to perform natural blood regeneration.
+/// </summary>
+[ByRefEvent]
+public sealed class NaturalBloodRegenerationAttemptEvent : CancellableEntityEventArgs
+{
+    /// <summary>
+    ///     How much blood the mob will regenerate on this tick. Can be negative.
+    /// </summary>
+    public FixedPoint2 Amount;
+}

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -513,8 +513,8 @@ public sealed class BloodstreamSystem : EntitySystem
         // First, check if the entity has enough hunger/thirst
         var hungerComp = CompOrNull<HungerComponent>(ent);
         var thirstComp = CompOrNull<ThirstComponent>(ent);
-        if (usedHunger > 0 && hungerComp is not null && hungerComp.CurrentHunger < usedHunger
-            ||  usedThirst > 0 && thirstComp is not null && thirstComp.CurrentThirst < usedThirst)
+        if (usedHunger > 0 && hungerComp is not null && (hungerComp.CurrentHunger < usedHunger || hungerComp.CurrentThreshold <= HungerThreshold.Starving)
+            ||  usedThirst > 0 && thirstComp is not null && (thirstComp.CurrentThirst < usedThirst || thirstComp.CurrentThirstThreshold <= ThirstThreshold.Parched))
             return false;
 
         // Then actually expend hunger and thirst (if necessary) and regenerate blood.

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Components;
+using Content.Server.Body.Events;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Chemistry.ReactionEffects;
 using Content.Server.Fluids.EntitySystems;
@@ -14,6 +15,8 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.Drunk;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Speech.EntitySystems;
@@ -39,6 +42,8 @@ public sealed class BloodstreamSystem : EntitySystem
     [Dependency] private readonly SharedStutteringSystem _stutteringSystem = default!;
     [Dependency] private readonly AlertsSystem _alertsSystem = default!;
     [Dependency] private readonly ForensicsSystem _forensicsSystem = default!;
+    [Dependency] private readonly HungerSystem _hunger = default!;
+    [Dependency] private readonly ThirstSystem _thirst = default!;
 
     public override void Initialize()
     {
@@ -118,17 +123,9 @@ public sealed class BloodstreamSystem : EntitySystem
             if (!_solutionContainerSystem.ResolveSolution(uid, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
                 continue;
 
-            // Removes blood for Blood Deficiency constantly.
-            if (bloodstream.HasBloodDeficiency)
-            {
-                if (!_mobStateSystem.IsDead(uid))
-                    RemoveBlood(uid, bloodstream.BloodMaxVolume * bloodstream.BloodDeficiencyLossPercentage, bloodstream);
-            }
-            // Adds blood to their blood level if it is below the maximum.
-            else if (bloodSolution.Volume < bloodSolution.MaxVolume && !_mobStateSystem.IsDead(uid))
-            {
-                TryModifyBloodLevel(uid, bloodstream.BloodRefreshAmount, bloodstream);
-            }
+            // Try to apply natural blood regeneration/bloodloss
+            if (!_mobStateSystem.IsDead(uid))
+                TryDoNaturalRegeneration((uid, bloodstream), bloodSolution);
 
             // Removes blood from the bloodstream based on bleed amount (bleed rate)
             // as well as stop their bleeding to a certain extent.
@@ -497,5 +494,36 @@ public sealed class BloodstreamSystem : EntitySystem
             return;
 
         bloodSolution.RemoveReagent(component.BloodReagent, amount);
+    }
+
+    /// <summary>
+    ///     Tries to apply natural blood regeneration/loss to the entity. Returns true if succesful.
+    /// </summary>
+    private bool TryDoNaturalRegeneration(Entity<BloodstreamComponent> ent, Solution bloodSolution)
+    {
+        var ev = new NaturalBloodRegenerationAttemptEvent { Amount = ent.Comp.BloodRefreshAmount };
+        RaiseLocalEvent(ent, ref ev);
+
+        if (ev.Cancelled || (ev.Amount > 0 && bloodSolution.Volume >= bloodSolution.MaxVolume))
+            return false;
+
+        var usedHunger = ev.Amount * ent.Comp.BloodRegenerationHunger;
+        var usedThirst = ev.Amount * ent.Comp.BloodRegenerationThirst;
+
+        // First, check if the entity has enough hunger/thirst
+        var hungerComp = CompOrNull<HungerComponent>(ent);
+        var thirstComp = CompOrNull<ThirstComponent>(ent);
+        if (usedHunger > 0 && hungerComp is not null && hungerComp.CurrentHunger < usedHunger
+            ||  usedThirst > 0 && thirstComp is not null && thirstComp.CurrentThirst < usedThirst)
+            return false;
+
+        // Then actually expend hunger and thirst (if necessary) and regenerate blood.
+        if (usedHunger > 0 && hungerComp is not null)
+            _hunger.ModifyHunger(ent, (float) -usedHunger, hungerComp);
+
+        if (usedThirst > 0 && thirstComp is not null)
+            _thirst.ModifyThirst(ent, thirstComp, (float) -usedThirst);
+
+        return TryModifyBloodLevel(ent, ev.Amount, ent.Comp);
     }
 }

--- a/Content.Server/Traits/BloodDeficiencyComponent.cs
+++ b/Content.Server/Traits/BloodDeficiencyComponent.cs
@@ -11,4 +11,10 @@ public sealed partial class BloodDeficiencyComponent : Component
     // </summary>
     [DataField(required: true)]
     public float BloodLossPercentage;
+
+    /// <summary>
+    ///     Whether the effects of this trait should be active.
+    /// </summary>
+    [DataField]
+    public bool Active = true;
 }

--- a/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
@@ -108,7 +108,7 @@
     - DoorBumpOpener
   - type: Bloodstream
     bloodReagent: DemonsBlood
-    bloodRegenerationThirst: 5 # 1 unit of demon's blood satiates 4 thirst
+    bloodRegenerationThirst: 4 # 1 unit of demon's blood satiates 4 thirst
   - type: BloodSucker
     webRequired: true
   - type: Arachne

--- a/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
@@ -108,6 +108,7 @@
     - DoorBumpOpener
   - type: Bloodstream
     bloodReagent: DemonsBlood
+    bloodRegenerationThirst: 5 # 1 unit of demon's blood satiates 4 thirst
   - type: BloodSucker
     webRequired: true
   - type: Arachne

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -33,8 +33,8 @@
         amount: 5
   - type: Bloodstream
     bloodReagent: Sap
-    bloodRegenerationHunger: 2
-    bloodRegenerationThirst: 2 # 1 unit of sap satiates 2 hunger and thirst
+    bloodRegenerationHunger: 1
+    bloodRegenerationThirst: 1 # 1 unit of sap satiates 1 hunger and thirst
   - type: Reactive
     groups:
       Flammable: [ Touch ]

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -33,6 +33,8 @@
         amount: 5
   - type: Bloodstream
     bloodReagent: Sap
+    bloodRegenerationHunger: 2
+    bloodRegenerationThirst: 2 # 1 unit of sap satiates 2 hunger and thirst
   - type: Reactive
     groups:
       Flammable: [ Touch ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -39,6 +39,8 @@
       amount: 5
   - type: Bloodstream
     bloodReagent: InsectBlood
+    bloodRegenerationHunger: 1.5
+    bloodRegenerationThirst: 1.5 # insect blood does not regenerate thirst or hunger, so keeping it quite low
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -39,8 +39,6 @@
       amount: 5
   - type: Bloodstream
     bloodReagent: InsectBlood
-    bloodRegenerationHunger: 1.5
-    bloodRegenerationThirst: 1.5 # insect blood does not regenerate thirst or hunger, so keeping it quite low
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -35,6 +35,8 @@
         color: "#2cf274"
   - type: Bloodstream
     bloodReagent: Slime # TODO Color slime blood based on their slime color or smth
+    bloodRegenerationHunger: 4
+    bloodRegenerationThirst: 2.5 # 1 of slime satiates 3 hunger
   - type: Barotrauma
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -35,8 +35,8 @@
         color: "#2cf274"
   - type: Bloodstream
     bloodReagent: Slime # TODO Color slime blood based on their slime color or smth
-    bloodRegenerationHunger: 4
-    bloodRegenerationThirst: 2.5 # 1 of slime satiates 3 hunger
+    bloodRegenerationHunger: 2
+    bloodRegenerationThirst: 2 # 1 of slime satiates 2 hunger
   - type: Barotrauma
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -233,3 +233,5 @@
     bloodlossHealDamage:
       types:
         Bloodloss: -1
+    bloodRegenerationHunger: 2.5
+    bloodRegenerationThirst: 3 # 1 unit of normal blood satiates 3 thirst and 1 hunger for vampires and satiates 1 hunger and restores 1 blood for others

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -233,5 +233,5 @@
     bloodlossHealDamage:
       types:
         Bloodloss: -1
-    bloodRegenerationHunger: 2.5
-    bloodRegenerationThirst: 3 # 1 unit of normal blood satiates 3 thirst and 1 hunger for vampires and satiates 1 hunger and restores 1 blood for others
+    bloodRegenerationHunger: 1
+    bloodRegenerationThirst: 1.5 # 1 unit of normal blood satiates 1t, 0.3t for vampires, 0.75h, and restores 0.25 blood for non-humans...

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -18,7 +18,7 @@
     Drink:
       effects:
       - !type:SatiateThirst
-        factor: 1.5
+        factor: 0.5
         conditions:
           - !type:OrganType
             type: Human
@@ -39,7 +39,7 @@
         - !type:OrganType
           type: Vampiric
         reagent: Protein
-        amount: 0.15
+        amount: 0.125 # See below
       - !type:AdjustReagent
         conditions:
         - !type:OrganType
@@ -50,7 +50,11 @@
       effects:
         - !type:AdjustReagent
           reagent: UncookedAnimalProteins
-          amount: 0.5
+          amount: 0.125 # 0.25 proteins for 1u of blood - restores 0.75 hunger, adds 0.25 blood per unit
+          conditions:
+          - !type:OrganType
+            type: Vampiric
+            shouldHave: false
     Medicine:
       effects:
       - !type:HealthChange
@@ -99,7 +103,7 @@
       # Delicious!
       effects:
       - !type:SatiateHunger
-        factor: 1.5
+        factor: 1
   footstepSound:
     collection: FootstepBlood
     params:
@@ -123,9 +127,9 @@
       # Sweet!
       effects:
       - !type:SatiateHunger
-        factor: 1
+        factor: 0.5
       - !type:SatiateThirst
-        factor: 1
+        factor: 0.5
   footstepSound:
     collection: FootstepBlood
     params:


### PR DESCRIPTION
# Description
Makes natural blood regeneration use up some hunger and thirst, and halt completely when you are starving/dying of thirst.

This is necessary to fix two issues:
1. It being possible to feed off of your own blood, by repeatedly drawing your blood and injecting it back with a syringe. (I actually know a few people on floof who do that on a daily basis)
2. Hunger and thirst having no real impact on gameplay, besides giving you a mildly annoying depression overlay when low.

This PR also slightly refactors the blood deficiency trait so that it's no longer completely hardcoded in the bloodstream system.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/f8634de5-19bd-44a5-ada2-62f4504bf3d4

</p>
</details>

# Changelog
:cl:
- add: Blood regeneration now uses up hunger and thirst, and comes to a halt when you are very hungry or thirst.
- fix: It is no longer feasible to drink your own blood to satiate your own hunger.
