### PR TITLE
Unathi Lore Update

### DIFF
--- a/Resources/Locale/en-US/language/languages.ftl
+++ b/Resources/Locale/en-US/language/languages.ftl
@@ -10,8 +10,14 @@ language-RootSpeak-description = The strange whistling-style language spoken by 
 language-Nekomimetic-name = Nekomimetic
 language-Nekomimetic-description = To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
 
-language-Draconic-name = Draconic
-language-Draconic-description = The common language of lizard-people, composed of sibilant hisses and rattles.
+language-Draconic-name = Unathi
+language-Draconic-description =
+    The common language of Moghes - composed of sibilant hisses and rattles. Spoken natively by Unathi.
+
+language-Draconic-name = Azaziba
+language-Draconic-description =
+    A language of Moghes consisting of a combination of spoken word and gesticulation.
+    While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.
 
 language-SolCommon-name = Sol common
 language-SolCommon-description =

--- a/Resources/Locale/en-US/language/languages.ftl
+++ b/Resources/Locale/en-US/language/languages.ftl
@@ -10,11 +10,11 @@ language-RootSpeak-description = The strange whistling-style language spoken by 
 language-Nekomimetic-name = Nekomimetic
 language-Nekomimetic-description = To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
 
-language-Draconic-name = Unathi
+language-Draconic-name = Sinta'Unathi
 language-Draconic-description =
     The common language of Moghes - composed of sibilant hisses and rattles. Spoken natively by Unathi.
 
-language-Draconic-name = Azaziba
+language-Draconic-name = Sinta'Azaziba
 language-Draconic-description =
     A language of Moghes consisting of a combination of spoken word and gesticulation.
     While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.

--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -2,7 +2,7 @@
 
 species-name-human = Human
 species-name-dwarf = Dwarf
-species-name-reptilian = Reptilian
+species-name-reptilian = Unathi
 species-name-slime = Slime Person
 species-name-diona = Diona
 species-name-arachnid = Arachnid

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -348,3 +348,8 @@ trait-description-LowDampening =
 trait-name-HighDampening = kδ Proficient
 trait-description-HighDampening =
     You are skilled in the art of subtly manipulating the noösphere. Your powers are less likely to show unintended effects.
+
+trait-name-Azaziba = Azaziba
+trait-description-Azaziba =
+    A language of Moghes consisting of a combination of spoken word and gesticulation.
+    While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -349,7 +349,7 @@ trait-name-HighDampening = kδ Proficient
 trait-description-HighDampening =
     You are skilled in the art of subtly manipulating the noösphere. Your powers are less likely to show unintended effects.
 
-trait-name-Azaziba = Azaziba
+trait-name-Azaziba = Sinta'Azaziba
 trait-description-Azaziba =
     A language of Moghes consisting of a combination of spoken word and gesticulation.
     While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.

--- a/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
@@ -14,6 +14,8 @@
       id: Elyran
     - type: trait
       id: ValyrianStandard
+    - type: trait
+      id: Azaziba
 
 - type: characterItemGroup
   id: TraitsAccents

--- a/Resources/Prototypes/Entities/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translator_implants.yml
@@ -155,4 +155,4 @@
     spoken:
     - Azaziba
     requires:
-    - Unathi
+    - Draconic

--- a/Resources/Prototypes/Entities/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translator_implants.yml
@@ -141,3 +141,18 @@
     - ValyrianStandard
     requires:
     - TauCetiBasic
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: AzazibaTranslatorImplant
+  name: azaziba translator implant
+  description: An implant giving the ability to understand and speak Azaziba. # Intended for Admins Only, this item is for lore reasons not obtainable.
+  noSpawn: true
+  components:
+  - type: TranslatorImplant
+    understood:
+    - Azaziba
+    spoken:
+    - Azaziba
+    requires:
+    - Unathi

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -236,3 +236,20 @@
     requires:
     - TauCetiBasic
     - ValyrianStandard
+
+- type: entity
+  id: AzazibaTranslator
+  parent: [ TranslatorPoweredBase ]
+  name: Azaziba translator
+  description: Translates speech between Unathi and Azaziba. For Unathi to speak the Archaic form of their native tongue! # Intended for Admins Only, this item is for lore reasons not obtainable.
+  components:
+  - type: HandheldTranslator
+    spoken:
+    - Draconic
+    - Azaziba
+    understood:
+    - Draconic
+    - Azaziba
+    requires:
+    - Draconic
+    - Azaziba

--- a/Resources/Prototypes/Entities/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/translator_implanters.yml
@@ -37,9 +37,9 @@
     implant: NekomimeticTranslatorImplant
 
 - type: entity
-  id: DraconicTranslatorImplanter
+  id: DraconicTranslatorImplanter # Intended for Admins Only, this item is for lore reasons not obtainable.
   parent: [ BaseTranslatorImplanter ]
-  name: draconic translator implant
+  name: unathi translator implant
   components:
   - type: Implanter
     implant: DraconicTranslatorImplant
@@ -83,3 +83,11 @@
   components:
   - type: Implanter
     implant: ValyrianStandardTranslatorImplant
+
+- type: entity
+  id: AzazibaTranslatorImplanter
+  parent: [ BaseTranslatorImplanter ]
+  name: azaziba translator implant
+  components:
+  - type: Implanter
+    implant: AzazibaTranslatorImplant

--- a/Resources/Prototypes/Language/Species-Specific/reptilian.yml
+++ b/Resources/Prototypes/Language/Species-Specific/reptilian.yml
@@ -1,5 +1,4 @@
-# Spoken by the Lizard race.
-# TODO: Replace this with a much better language.
+# Spoken by Unathi.
 - type: language
   id: Draconic
   speech:
@@ -93,3 +92,26 @@
     - u
     - s
     - s
+
+# Reptilian-Specific "Rare" Language
+# !Do Not Make A Translator For This Language.
+- type: language
+  id: Azaziba
+  speech:
+    color: "#2aca2add"
+  obfuscation:
+    !type:SyllableObfuscation
+    minSyllables: 2
+    maxSyllables: 4
+    replacement:
+    - azs
+    - zis
+    - zau
+    - azua
+    - skiu
+    - zuakz
+    - izo
+    - aei
+    - ki
+    - kut
+    - zo

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -77,3 +77,18 @@
     - ValyrianStandard
   languagesUnderstood:
     - ValyrianStandard
+
+- type: trait
+  id: Azaziba
+  category: TraitsSpeechLanguages
+  points: 1
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Reptilian
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesBasic
+  languagesSpoken:
+    - Azaziba
+  languagesUnderstood:
+    - Azaziba

--- a/Resources/ServerInfo/Guidebook/Mobs/Harpy.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Harpy.xml
@@ -1,5 +1,6 @@
 <Document>
   # Harpy (Homo-Aves sapiens)
+  All Information included in this document is licensed under CC BY-SA 4.0, and is written by VMSolidus(Github), also known as raistlin_jag(Discord)
 
   <Box>
     <GuideEntityEmbed Entity="MobHarpyDummy" Caption=""/>

--- a/Resources/ServerInfo/Guidebook/Mobs/Reptilian.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Reptilian.xml
@@ -1,16 +1,131 @@
 <Document>
-  # Reptilians
-
+  # Unathi
+All Information included in this document is licensed under CC BY-SA 4.0, and is taken from https://wiki.aurorastation.org/index.php?title=Unathi with some modifications by VMSolidus(Github).
   <Box>
     <GuideEntityEmbed Entity="MobReptilian" Caption=""/>
   </Box>
 
-  They can ONLY eat fruits and meat, but can eat raw meat and drink blood without any ill effects.
-  They prefer a somewhat higher temperature range than humans.
-  They can drag objects with their tail, keeping both their hands free.
+  The Unathi (direct plural: Unathi – You-NAWH-thee both singular and multiple) (adjective: Unathite - You-NAWH-thit) are a race of tall humanoid reptiles standing from six to seven feet tall on average, with females slightly smaller in stature. They possess a mixture of snake-like and crocodile-like features, resulting in hard and plate-like scales.
+  Unathi live in their home system of Uueoa-Esa with their homeworld being Moghes. The planet's history can be summarized as being divided up between various Hegemonies, names they give the most powerful Clans on Moghes throughout time.
+  The Clan system is deeply entrenched in Unathi society with everything else revolving around it. It forms a major part of their code of honor, which stresses the importance of martial abilities and loyalty to the Clan.
 
-  Their unarmed claw attacks deal Slash damage instead of Blunt.
+  Religion and spirituality play a major role in a Unathi society, and religious differences are the main dividing factor.
+  Conflict between the Sk'akh Church and the various Th'akh faiths of Moghes, as well as the various communes and cults, have caused conflict and wars between the Izweski Hegemony and the kingdoms that eventually comprised the Traditionalist Coalition.
+  This conflict hit a peak when they entered the intergalactic stage, which is now known as the Contact War. After this conflict, some Unathi fled the planet through Hephaestus or NanoTrasen shuttle ports.
+  Unathi fleeing to megacorporations like NanoTrasen find themselves working in security and engineering roles, but recently many have been proving themselves as competent surgeons and brilliant scientists, earning opportunities that Moghes would deny them because of its strict feudal hierarchy.
+  However, others are slipping through the cracks and becoming slavers, raiders, or pirates. As the ability for spaceship construction increases in the Unathi home system, so too does space piracy and smuggling.
 
-  They take [color=#ffa500]30% more Cold damage.[/color]
+  Moghes has two different biomes after the Contact War. The fertile Untouched Lands with its great jungles, vast swamps, and lush forests; all of which are protected by massive terraforming equipment kept secure by the Hegemony's wealth and power.
+  Contrast to that are the bombarded Wasteland kingdoms in the ashes of plains and forests, burnt into a massive planet-spanning desert rampant with punished kingdoms raiding to survive and part scavengers living in cities on treads.
+
+  ## Megacorporate Relations
+
+  Prior to 2465, Moghean Unathi that were not members of trade guilds were almost exclusively employed with Hephaestus Industries.
+  Unathi with guild memberships would primarily take contracts with NanoTrasen or Orion Express, depending on their career choice. Unathi living in Dominia, like most of their countrymen, seek employment with Zavodskoi Interstellar.
+
+  After the Merchant's Guild declared bankruptcy, Hephaestus Industries bailed out all Hegemonic guilds and reorganised them under the banner of the company.
+  Since then, nearly all residents of Moghes are employed by Hephaestus in some way.
+
+  # Biology
+
+  Their average life expectancy is around sixty years for most Unathi. However, they tend to live for well past sixty years when given advanced medical care available to the other space-faring species.
+  As a cold-blooded species, they suffer fatigue and even short comas when exposed to extremely low temperatures.
+
+  Humans and Unathi share a lot of similar internal biology with some notable exceptions.
+  Since they are a carnivorous species, their diet mostly consists of meat and animal products, though they do have a tolerance to some plants and fruits.
+  While Unathi do receive minor benefits for eating certain fruits, they do not get any nutrition from plants.
+  Due to their carnivorous nature, they also have an increased stomach capacity to help eat larger meals at a time.
+  The typical Unathi usually only eats one meal a day, and for the poorer sinta, perhaps once every two days.
+  They tend towards lethargic and sluggish movements more often than not because of their evolutionary history, so they move slower than most organic species.
+  However, the cyclical period of work for Unathi compared to other species is much faster. Unathi are polyphasic sleepers: creatures that sleep in shorter naps rather than at one time during the night.
+  While they tend towards sluggishness, sinta are often capable of incredible bursts of energy and speed, and their ability to work in three or four hour periods of time compensates for their more sporadic schedules.
+
+  The reproductive system of a Sinta'Unathi is very similar to that of Earth reptiles. Females lay eggs, with the average clutch being somewhere between one and three.
+  They have a six-month gestation period, after which they are laid in a humid, warm area. After two months, the fetus is fully developed and hatches from the egg.
+  Unathi are born with their claws and the ability to walk within hours of hatching. A Sinta'Unathi is considered an adult when they are 16 years old.
+
+  # Physical Appearance
+
+  The Unathi as a species show a great deal of variation within body types as well as clusters of smaller physical traits passed down through clans.
+  Facial and body features range in size and shape with some having raptor-like aesthetics, serpentine looks, or a more draconic body.
+  Tail length is often genetic; conversely, tail girth is defined by a Unathi's diet as it stores most of the body's fat— nobles grow some of the largest tails.
+
+  Unathi scales are somewhat tougher than human skin, though they shed off sporadically rather than all at once.
+  More vulnerable and hidden spots, such as the stomach and waist, the backs of joints, and inner thighs are all leathery skin and aren't covered in scales.
+
+  The typical healthy adult male Unathi weighs roughly 280 pounds. Female sinta differ from males as they generally have a shorter and more rounded snout.
+  The typical healthy Unathi female weighs roughly 250 pounds. Female Unathi grow to about 5'9" to 6'8, while male Unathi grow to about 6'0" to 7'0".
+  Unusual heights tend to be smaller in scale, as the taller a Unathi is, the more likely it will be marred with health problems and not live as long as others.
+
+  Both sexes stand on digitigrade legs, with three toes on each foot and a hooked dewclaw, and have clawed feet and hands.
+  They also have very long tongues, typically black or extremely dark red in color, which may stretch up to a foot and a half long and are forked just like a serpent's.
+  In much the same manner as snakes, Unathi can sample the air around them using their tongue. They blink and have tear ducts similar to humans.
+
+  Unathi horns do not naturally regrow, and serious damage tends to remain permanent.
+  Ancient recipes using native herbs known as "horn paste" are commonly made and sold by herbalists and can counter cosmetic scratches or minor chipping.
+  More modern synthetic Horn Gel (based on Bone Gel), developed largely by Zeng-Hu Pharmaceuticals, can regenerate an entire lost horn, but it tends to be stratified to the upper classes and noblemen due to cost.
+
+  ## Coloration
+
+  Unathi are also often born into one of four major scale colour categories: red, black, orange-brown and "sand-colored", and green.
+  Alternative colours are rare, with dark blue and even albino Unathi being reported in very small numbers. Albinos are sometimes slightly tinted in colour while remaining predominantly white. Traditionally these off-coloured Unathi are met with prejudice, though some clans outside the Izweski may feel different.
+
+  It has been noticed that scale colourations were more represented in some areas than other, and thus, many shades of these colours were, in Unathi culture, named after the places they tend to be seen in more often, in many cases.
+
+  Modern red-coloured Unathi are thought to originate from a large nomadic clan that settled South of the Moghresian Sea around modern Skalamar. Nowadays, red-scaled Sinta tend to be seen on the entire Southern coast of the Moghresian Sea and the mountain ranges near it.
+  Today’s green-coloured Unathi hail from the Southern side of the Moghresian sea, and they are seen more often throughout this side of the coast and down to the colder lands even further South. Surprisingly, there is also a large batch of green-coloured Unathi located around Sahl lake, indicating that an old nomadic clan of mostly green Sinta settled there centuries ago.
+  Orange-brown and sand-yellow Unathi comprises a wide range of colours. They are a more common colour to be seen in a large area, and it is believed that their origins come from displacement in ancient conflicts that forced them to migrate and find new homelands. More precisely, Unathi harbouring such colours tend to be more represented in a large area defined between Darakath, Bahard, Mudki, and Yu’kal.
+  Black or “dark-scaled’ Unathi do not seem to originate from any precise area, and instead, tend to be more often seen around colder areas of Moghes, both North and South. A popular theory is that black scales are actually a consequence of exposure to the cold for generations— something that has yet to be proven.
+  All colours, barring albino, do not mix; if a brown Unathi and a light red Unathi have a child, the red scales the child has might be a little darker, but the colours do not blend to make something new.
+
+  ## Genetic Variety
+
+  Besides scale colouration, many other physical aspects of Unathi bodies can vary widely.
+  From horns and frills, to even extra scale crests and different structures in a Unathi’s very skeleton (namely, the skull).
+  While anatomical differences within a species are natural, Unathi are noteworthy for how wide these differences can get and how fast they come to be.
+  The exact science behind this has been lost after the Contact War, and most of the research behind such a phenomena is idly handled by Nanotrasen and Zeng-Hu specialists.
+  However it is assumed that Sinta simply evolve and adapt to their surroundings much faster than most of the other sentient species of the Spur, leading to such large physical discrepancies between Unathi alone.
+  From this, it is also assumed that, with Unathi populations moving between planets, and Moghes on its way to changing considerably (may the consequences of the of the Contact War be the of the Sinta homeworld, or may terraforming efforts save it), said biological differences between different groups will only get larger and more exotic in the next few centuries.
+
+  # History
+
+  The history of the Unathi is predominately a history of each Hegemony that has existed throughout their history. There have only been three clans that have managed to create an empire worthy of the title 'Hegemon.'
+
+  The Kres’ha’nor Hegemony lasted from roughly 920 CE - 1500 CE. It is most famous for being the first empire to dominate Moghes and creating what was then a modern feudal state.
+  Their empire saw rise of walled cities, steel weapons, centralized taxation, and other innovations. It ended in a brutal succession war, with Moghes once again being shattered into hundreds of individual Kingdoms with no true global power.
+
+  In the 16th century the power of Guilds began to grow, forming an early form of mercantilism. Guilds formed for bakers, butchers, grocers, millers, smiths, carpenters, weavers, mason, shoemakers, in fact, nearly every trade had its own guild.
+  Standards such as just weights and measures evolved from the guilds, and guild inspectors would inspect shops to ensure rules were being followed.
+  Guilds would help members that were sick, or in trouble, and would sometimes take care of families after the member died.
+  This time also saw Guilds building the first major universities. While incredibly exclusive, these universities began to create a new era of specialized labor and intellectuals.
+
+  The 19th century saw rise of the Second Hegemony, ruled by the Sarakus Clan.
+  Their clan ruled harshly, and forced technological advances into the cities and towns.
+  In the 1930's they ruthlessly modernized their empire in The Great Endeavor, spreading electricity, radio, paved roads, modern plumbing, and other modern innovations.
+
+  In 1994 the Izweski Clan violently deposed the Sarakus and slaughtered the entire surviving dynasty, declaring the Third Hegemony.
+  After they won an incredibly destructive global war to defend their claim, the Izweski have ruled Moghes until modern times.
+
+  In 2403, a human exploration team discovered Moghes. Shortly after, first contact with the Izweski Hegemony was made.
+  Sol Alliance merchants and scientists flocked to Moghes, living under very careful observation and guard in Izweski cities.
+  Skalamar, the second largest city in Izweski, became the first Unathite city to have a shuttle port constructed. Owned by NanoTrasen, it served to transport people to and from the planet’s surface.
+
+  The Contact War, which has more information here, was a cataclysmic global war that lasted from 2438 to 2449.
+  The fighting was between two global powers, the Izweski Hegemony, and the Traditionalist Coalition.
+  The war was fought over the very future of the Unathi and their relationship with the rest of the galaxy.
+  The Izweski demanded Moghes submit to a one-world government ran by themselves and embrace the influence of humanity.
+  The Traditionalist Coalition rejected this. The war went nuclear on September 5th, 2439, causing immense suffering across Moghes and directly leading to the creation of The Wasteland, which is set to engulf Moghes within a hundred years.
+
+  # Species Traits
+
+  - [color=#1e90ff]Reptilian Diet[/color]: Unathi can ONLY eat fruits and meat, but can eat raw meat and drink blood without any ill effects.
+
+  - [color=#1e90ff]High Temperature Tolerance[/color]: Unathi prefer a somewhat higher temperature range than humans.
+
+  - [color=#1e90ff]Grasping Tail[/color]: Unathi can drag objects with their tail, keeping both their hands free.
+
+  - [color=#1e90ff]Claws[/color]: Unath unarmed claw attacks deal Slash damage instead of Blunt.
+
+  - [color=#ffa500]Cold Intolerance[/color]: Unathi take [color=#ffa500]30% more Cold damage.[/color]
 
 </Document>


### PR DESCRIPTION
# Description

This PR updates the Localizations relevant to the Reptilian species by significantly expanding upon them as Unathi, which is how they are typically referred to as in both /tg/station and Baystation12 derived codebases in SS13. I have added a new "Rare" language taken from Aurora, called Azaziba, which can only be taken by Unathi as a bonus language trait. 

Translators for this new language Azaziba are intentionally not obtainable ingame except as spawned by Admins. This is a "Rare" language, and shouldn't be accessible to players outside of Unathi obtaining the trait. 

The biggest change in this update however is a massive expansion upon the Unathi Guidebook entry, providing a significant volume of Lore, which is largely taken(with slight modifications) from https://wiki.aurorastation.org/index.php?title=Unathi (Which, I can do this since their wiki has a Creative Commons license). This is probably the best way to get good quality lore for them, other than by writing it myself.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/842d9c40-3cf3-41ab-a9fe-f0aac81c1bce)

![image](https://github.com/user-attachments/assets/f1ef8090-97a4-46f9-8548-9389606d4e3b)

![image](https://github.com/user-attachments/assets/870ab41c-fe00-45cf-8440-51cfe3f0b164)

![image](https://github.com/user-attachments/assets/09a8548a-cb98-4158-b0a8-e641078ecf80)

</p>
</details>

# Changelog

:cl:
- add: Localizations for Reptilians that acknowledge them now as Unathi.
- add: Azaziba has been added as a new "Rare" language that can only be taken by Unathi. Translators between Azaziba and Tau-Ceti Basic do not exist, please do not make them.
- add: SIGNIFICANTLY expanded upon the Guidebook for Unathi by including a large volume of lore taken from the Aurora Station Wiki. 