### PR TITLE
MoodSystem Crit Threshold CVar

### DIFF
--- a/Content.Server/Mood/MoodSystem.cs
+++ b/Content.Server/Mood/MoodSystem.cs
@@ -252,7 +252,8 @@ public sealed class MoodSystem : EntitySystem
         if (_debugMode)
             return;
 
-        if (TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
+        if (_config.GetCVar(CCVars.MoodModifiesThresholds)
+            && TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
             && _mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var critThreshold, mobThresholdsComponent))
             component.CritThresholdBeforeModify = critThreshold.Value;
 
@@ -345,7 +346,8 @@ public sealed class MoodSystem : EntitySystem
 
     private void SetCritThreshold(EntityUid uid, MoodComponent component, int modifier)
     {
-        if (!TryComp<MobThresholdsComponent>(uid, out var mobThresholds)
+        if (!_config.GetCVar(CCVars.MoodModifiesThresholds)
+            || !TryComp<MobThresholdsComponent>(uid, out var mobThresholds)
             || !_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var key))
             return;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2461,6 +2461,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> MoodDecreasesSpeed =
             CVarDef.Create("mood.decreases_speed", true, CVar.SERVER);
 
+        public static readonly CVarDef<bool> MoodModifiesThresholds =
+            CVarDef.Create("mood.modify_thresholds", false, CVar.SERVER);
+
         #endregion
 
         #region Lying Down System


### PR DESCRIPTION
# Description

This PR adds a CVar that allows server hosts (such as N14 who need it) to optionally disable the Crit Threshold modification part of the MoodSystem. This is useful if a server has some other system that frequently messes with Thresholds, and that a server host wishes their system to not have to fight with Mood for it.

# Changelog

No changelog because this isn't playerfacing.
