### PR TITLE
Nerf Shadeskip

### DIFF
--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -235,16 +235,10 @@
     event: !type:AnomalyPowerActionEvent
             settings:
               powerName: "Shadeskip"
-              overchargeFeedback: "shadeskip-overcharge-feedback"
-              overchargeCooldown: 120
-              overchargeRecoil:
-                groups:
-                  Burn: -100 #This will be divided by the caster's Dampening.
               minGlimmer: 6
               maxGlimmer: 8
-              supercriticalGlimmerMultiplier: 3
               glimmerSoundThreshold: 50
-              supercriticalThreshold: 500
+              doSupercritical: false
             entitySpawnEntries:
               - settings:
                   spawnOnPulse: true
@@ -254,13 +248,6 @@
                   maxRange: 1.5
                 spawns:
                 - ShadowKudzuWeak
-              - settings:
-                  spawnOnSuperCritical: true
-                  minAmount: 30
-                  maxAmount: 50
-                  maxRange: 50
-                spawns:
-                - ShadowKudzu
               - settings:
                   spawnOnPulse: true
                   spawnOnSuperCritical: true


### PR DESCRIPTION
# Description

This PR removes the Supercrit mechanic from the standard Shadeskip. The Supercrit version will return as a WIZARD POWER. 

# Changelog

:cl:
- add: Shadeskip no longer creates Stationwide Shadow Kudzu when casting at high glimmer.
