### PR TITLE
Nerf Lotophagoi Oil Addiction

### DIFF
--- a/Resources/Prototypes/Mood/drugs.yml
+++ b/Resources/Prototypes/Mood/drugs.yml
@@ -4,14 +4,14 @@
 - type: moodEffect
   id: LotoTranscendence
   moodChange: 30
-  timeout: 900 #15 minutes
+  timeout: 600 #10 minutes
   moodletOnEnd: LotoEnthrallment
   category: "LotophagoiAddiction"
 
 - type: moodEffect
   id: LotoEnthrallment
   moodChange: -30
-  timeout: 7200 #2 hours
+  timeout: 600 #10 minutes
   category: "LotophagoiAddiction"
 
 - type: moodCategory


### PR DESCRIPTION
# Description

This PR nerfs the Lotophagoi Oil addiction so that the bonus only lasts 10 minutes, and the withdrawl only 10 minutes as well. 

# Changelog

:cl:
- tweak: Nerfed Lotophagoi Moodlets so that both the positive and negative moodlets only last for 10 minutes. The total mood modification has been left untouched. 
