### PR TITLE
Respawn System CVar

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -157,7 +157,7 @@ namespace Content.Server.GameTicking
             }
 
             //Ghost system return to round, check for whether the character isn't the same.
-            if (lateJoin && !_adminManager.IsAdmin(player) && !CheckGhostReturnToRound(player, character, out var checkAvoid))
+            if (!_cfg.GetCVar(CCVars.GhostAllowSameCharacter) && lateJoin && !_adminManager.IsAdmin(player) && !CheckGhostReturnToRound(player, character, out var checkAvoid))
             {
                 var message = checkAvoid
                     ? Loc.GetString("ghost-respawn-same-character-slightly-changed-name")

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2509,14 +2509,17 @@ namespace Content.Shared.CCVar
 
         #endregion
 
-    #region GhostRespawn
+        #region GhostRespawn
 
-    public static readonly CVarDef<double> GhostRespawnTime =
-        CVarDef.Create("ghost.respawn_time", 15d, CVar.SERVERONLY);
+        public static readonly CVarDef<double> GhostRespawnTime =
+            CVarDef.Create("ghost.respawn_time", 15d, CVar.SERVERONLY);
 
-    public static readonly CVarDef<int> GhostRespawnMaxPlayers =
-        CVarDef.Create("ghost.respawn_max_players", 40, CVar.SERVERONLY);
+        public static readonly CVarDef<int> GhostRespawnMaxPlayers =
+            CVarDef.Create("ghost.respawn_max_players", 40, CVar.SERVERONLY);
 
-    #endregion
+        public static readonly CVarDef<bool> GhostAllowSameCharacter =
+            CVarDef.Create("ghost.allow_same_character", false, CVar.SERVERONLY);
+
+        #endregion
     }
 }


### PR DESCRIPTION
# Description

This PR adds a CVar to the Respawn System that optionally allows players to respawn as the same character.

# Changelog

This isn't player facing, so none.
