### PR TITLE
Psionic Potential Trait Fixes

### DIFF
--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -27,6 +27,10 @@
       inverted: true
       species:
         - Oni
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - LowPotential
   components:
     - type: PotentiaModifier
       potentiaMultiplier: 1.25
@@ -60,6 +64,10 @@
       inverted: true
       species:
         - Oni
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - HighPotential
   components:
     - type: PotentiaModifier
       potentiaMultiplier: 0.75


### PR DESCRIPTION
# Description

The two Psi-Potential traits are mutually exclusive(Due to adding the same component), but I forgot to add a condition that prevents you from taking both.

# Changelog

:cl:
- fix: Fixed High & Low Psi-Potential traits lacking a requirement that you don't have the opposite trait. The two were mutually exclusive, so taking both caused issues.
