### PR TITLE
Fix Librarian Access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1905,7 +1905,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Library"]]
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -23,6 +23,7 @@
   - Research
   - Maintenance
   - Library
+  - Service
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -23,7 +23,6 @@
   - Research
   - Maintenance
   - Library
-  - Service
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
# Description

Small fix for the Curadrobe not being accessible by the Librarian/Cataloguer.

# Changelog

:cl:
- fix: Librarian/Cataloguer now correctly has access to his own clothing vendor.
