### PR TITLE
Re-Add Crusher Weapons

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -303,5 +303,8 @@
       rareChance: 0.4
       prototypes:
         - CrateSalvageAssortedGoodies
+        - WeaponCrusher
+        - WeaponCrusherDagger
+        - WeaponCrusherGlaive
       chance: 0.9
       offset: 0.2

--- a/Resources/Prototypes/Loadouts/Jobs/cargo.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/cargo.yml
@@ -59,3 +59,14 @@
       min: 36000 # 10 hours
   items:
     - ClothingNeckCloakGoliathCloak
+
+- type: loadout
+  id: LoadoutCargoWeaponsCrusherDagger
+  category: JobsCargo
+  cost: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - WeaponCrusherDagger


### PR DESCRIPTION
# Description

I apparently accidentally removed the Crusher weapons from their spawner. This PR corrects that. Additionally in case this ever happens again, I've also decided to add the Crusher Dagger as a loadout option for salvage techs.

# Changelog

:cl:
- add: Salvage techs can now buy a Crusher Dagger in their loadout.
- fix: Re-Added the Crusher weapons to salvage spawners.
