### PR TITLE
Head of Security Equipment

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -51,6 +51,7 @@ character-item-group-LoadoutOuterSecurity = Security Outerwear
 character-item-group-LoadoutShoesSecurity = Security Shoes
 character-item-group-LoadoutUniformsSecurity = Security Uniforms
 character-item-group-LoadoutWeaponSecurity = Security Duty Weapon
+character-item-group-LoadoutHoSWeapon = Head of Security's Antique Weapon Collection
 
 # Service
 character-item-group-LoadoutEquipmentService = Service Equipment

--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -174553,13 +174553,6 @@ entities:
     - type: Transform
       pos: -31.493519,10.543685
       parent: 6747
-- proto: WeaponRifleM90GrenadeLauncher
-  entities:
-  - uid: 8311
-    components:
-    - type: Transform
-      pos: -14.458499,-2.5063553
-      parent: 6747
 - proto: WeaponShotgunKammerer
   entities:
   - uid: 1624

--- a/Resources/Maps/core.yml
+++ b/Resources/Maps/core.yml
@@ -146814,13 +146814,6 @@ entities:
     - type: Transform
       pos: 2.553135,33.488186
       parent: 2
-- proto: WeaponSubMachineGunWt550
-  entities:
-  - uid: 5081
-    components:
-    - type: Transform
-      pos: -11.600864,32.694817
-      parent: 2
 - proto: WeaponTurretSyndicateBroken
   entities:
   - uid: 853

--- a/Resources/Maps/glacier.yml
+++ b/Resources/Maps/glacier.yml
@@ -109949,16 +109949,6 @@ entities:
     - type: Transform
       pos: -15.497394,9.727219
       parent: 2
-- proto: WeaponPulsePistol
-  entities:
-  - uid: 16290
-    components:
-    - type: MetaData
-      desc: A state of the art energy pistol bought by the HoS for a year's worth of pay.
-      name: head of security's prized pulse pistol
-    - type: Transform
-      pos: -12.584102,35.560688
-      parent: 2
 - proto: WeaponTurretSyndicateBroken
   entities:
   - uid: 16291

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -171025,17 +171025,6 @@ entities:
     - type: Transform
       pos: 82.52527,10.611163
       parent: 1
-- proto: WeaponShotgunBulldog
-  entities:
-  - uid: 22088
-    components:
-    - type: MetaData
-      desc: NanoTrasen's attempt at recreating the Syndicate's infamous bulldog, an automatic drum-fed shotgun. The design was rejected for full distribution because it was "More of a rip-off then a remake." Uses .50 shotgun shells.
-      name: HoS's Prototype Pitbull
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 78.53835,14.484081
-      parent: 1
 - proto: WeaponTurretSyndicateBroken
   entities:
   - uid: 9783

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -74072,13 +74072,6 @@ entities:
     - type: Transform
       pos: -13.373716,18.332554
       parent: 31
-- proto: WeaponSubMachineGunWt550
-  entities:
-  - uid: 1423
-    components:
-    - type: Transform
-      pos: -8.457573,20.768534
-      parent: 31
 - proto: WeaponWaterBlaster
   entities:
   - uid: 8127

--- a/Resources/Maps/shoukou.yml
+++ b/Resources/Maps/shoukou.yml
@@ -29615,13 +29615,6 @@ entities:
     - type: Transform
       pos: 37.28408,-33.635246
       parent: 34
-- proto: ClothingBeltKatanaSheathFilled
-  entities:
-  - uid: 11721
-    components:
-    - type: Transform
-      pos: 39.44033,-33.510246
-      parent: 34
 - proto: ClothingBeltMartialBlack
   entities:
   - uid: 143

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -315,7 +315,6 @@
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
       - id: BoxPDASecurity # Delta-V
-      - id: WeaponEnergyGunMultiphase # DeltaV - HoS Energy Gun
       - id: HoSIDCard # Delta-V
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
@@ -344,7 +343,6 @@
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
       - id: BoxPDASecurity # Delta-V
-      - id: WeaponEnergyGunMultiphase # DeltaV - HoS Energy Gun
       - id: HoSIDCard # Delta-V
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3

--- a/Resources/Prototypes/CharacterItemGroups/securityGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/securityGroups.yml
@@ -194,3 +194,22 @@
       id: LoadoutClothingBackSecuritySatchel
     - type: loadout
       id: LoadoutClothingBackSecurityDuffel
+
+- type: characterItemGroup
+  maxItems: 1
+  id: LoadoutHoSWeapon
+  items:
+    - type: loadout
+      id: LoadoutCommandHoSPulsePistol
+    - type: loadout
+      id: LoadoutCommandHoSWt550
+    - type: loadout
+      id: LoadoutCommandHoSKatanaSheath
+    - type: loadout
+      id: LoadoutCommandHoSC20r
+    - type: loadout
+      id: LoadoutCommandHoSBulldog
+    - type: loadout
+      id: LoadoutCommandHoSEnergySword
+    - type: loadout
+      id: LoadoutCommandHoSEnergyGun

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Items/Belts/belts.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Items/Belts/belts.yml
@@ -9,6 +9,16 @@
       - id: Katana
 
 - type: entity
+  id: ClothingBeltKatanaSheathFilledHoS
+  parent: ClothingBeltKatanaSheathFilled
+  suffix: Filled
+  name: antique katana sheaths
+  description: An ornate belt, wrapped in gold filigree, with a ribbon made from a stasis-field preserved swatch of linen. The history of this sheath has been lost to time.
+  components:
+    - type: StealTarget
+      stealGroup: ClothingBeltKatanaSheathFilledHoS
+
+- type: entity
   id: ClothingBeltCorpsmanWebbingFilled
   parent: ClothingBeltCorpsmanWebbing
   suffix: Filled

--- a/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
@@ -55,6 +55,13 @@
     state: e_sword
 
 - type: stealTargetGroup
+  id: ClothingBeltKatanaSheathFilledHoS
+  name: antique katana sheaths
+  sprite:
+    sprite: Nyanotrasen/Clothing/Belt/katanasheath.rsi
+    state: e_sword
+
+- type: stealTargetGroup
   id: RubberStampNotary
   name: notary stamp
   sprite:

--- a/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
@@ -59,7 +59,7 @@
   name: antique katana sheaths
   sprite:
     sprite: Nyanotrasen/Clothing/Belt/katanasheath.rsi
-    state: e_sword
+    state: sheath
 
 - type: stealTargetGroup
   id: RubberStampNotary

--- a/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/stealTargetGroups.yml
@@ -20,6 +20,41 @@
     state: base
 
 - type: stealTargetGroup
+  id: WeaponPulsePistolHoS
+  name: antique pulse pistol
+  sprite:
+    sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi
+    state: base
+
+- type: stealTargetGroup
+  id: WeaponSubMachineGunWt550HoS
+  name: antique Wt550
+  sprite:
+    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+    state: base
+
+- type: stealTargetGroup
+  id: WeaponSubMachineGunC20rHoS
+  name: antique C20r
+  sprite:
+    sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
+    state: base
+
+- type: stealTargetGroup
+  id: WeaponShotgunBulldogHoS
+  name: antique C20r
+  sprite:
+    sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
+    state: base
+
+- type: stealTargetGroup
+  id: EnergySwordHoS
+  name: antique energy sword
+  sprite:
+    sprite: Objects/Weapons/Melee/e_sword.rsi
+    state: e_sword
+
+- type: stealTargetGroup
   id: RubberStampNotary
   name: notary stamp
   sprite:

--- a/Resources/Prototypes/DeltaV/Objectives/traitor.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/traitor.yml
@@ -98,6 +98,19 @@
     stealGroup: EnergySwordHoS
     owner: job-name-hos
 
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSKatanaSheathStealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: ClothingBeltKatanaSheathFilledHoS
+    owner: job-name-hos
+
 - type: entity # Clerk steal objective.
   noSpawn: true
   parent: BaseTraitorStealObjective

--- a/Resources/Prototypes/DeltaV/Objectives/traitor.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/traitor.yml
@@ -33,6 +33,71 @@
     stealGroup: WeaponEnergyGunMultiphase
     owner: job-name-hos
 
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSPulsePistolStealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: WeaponPulsePistolHoS
+    owner: job-name-hos
+
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSWt550StealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: WeaponSubMachineGunWt550HoS
+    owner: job-name-hos
+
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSC20rStealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: WeaponSubMachineGunC20rHoS
+    owner: job-name-hos
+
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSBulldogStealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: WeaponShotgunBulldogHoS
+    owner: job-name-hos
+
+- type: entity # Head of Security steal objective.
+  noSpawn: true
+  parent: BaseTraitorStealObjective
+  id: HoSEnergySwordStealObjective
+  components:
+  - type: Objective
+    difficulty: 3 # HoS will mostly be using the gun to stop you from stealing it
+  - type: NotJobRequirement
+    job: HeadOfSecurity
+  - type: StealCondition
+    stealGroup: EnergySwordHoS
+    owner: job-name-hos
+
 - type: entity # Clerk steal objective.
   noSpawn: true
   parent: BaseTraitorStealObjective
@@ -43,5 +108,3 @@
   - type: StealCondition
     stealGroup: RubberStampNotary
     owner: job-name-clerk
-
-

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -269,6 +269,15 @@
     startingCharge: 2000
 
 - type: entity
+  name: antique pulse pistol
+  parent: WeaponPulsePistol
+  id: WeaponPulsePistolHoS
+  description: One of the many weapons belonging to the Head of Security's private collection. This pistol is engraved with the words, "Forgive Us, Mother Sol'"
+  components:
+  - type: StealTarget
+    stealGroup: WeaponPulsePistolHoS
+
+- type: entity
   name: pulse carbine
   parent: BaseWeaponBattery
   id: WeaponPulseCarbine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,7 +20,7 @@
     maxAngle: 16
     fireRate: 8
     angleIncrease: 3
-    angleDecay: 16  
+    angleDecay: 16
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -83,7 +83,7 @@
   name: C-20r sub machine gun
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunC20r
-  description: A firearm that is often used by the infamous nuclear operatives. Uses .35 auto ammo.
+  description: Manufactured by Cybersun-Armaments, the C-20r is one of the most popular personal small-arms in the Coalition of Colonies. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
@@ -110,6 +110,15 @@
     steps: 6
     zeroVisible: true
   - type: Appearance
+
+- type: entity
+  name: antique C-20r submachine gun
+  parent: WeaponSubMachineGunC20r
+  id: WeaponSubMachineGunC20rHoS
+  description: This heavily worn submachine gun is engraved with the words, "Remember Mars".
+  components:
+    - type: StealTarget
+      stealGroup: WeaponSubMachineGunC20rHoS
 
 - type: entity
   name: Drozd
@@ -234,7 +243,7 @@
     minAngle: 1
     maxAngle: 6
     angleIncrease: 1.5
-    angleDecay: 6  
+    angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
     availableModes:
@@ -265,6 +274,15 @@
     steps: 6
     zeroVisible: true
   - type: Appearance
+
+- type: entity
+  name: antique Wt550
+  id: WeaponSubMachineGunWt550HoS
+  parent: WeaponSubMachineGunWt550
+  description: A prized possession of the station's Head of Security. The smell of dried blood lingers on this weapon's muzzle. A small torch with 24 stars surrounding it has been engraved on the grip.
+  components:
+    - type: StealTarget
+      stealGroup: WeaponSubMachineGunWt550HoS
 
 # Rubber
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -104,6 +104,15 @@
     price: 500
 
 - type: entity
+  name: antique Bulldog
+  parent: WeaponShotgunBulldog
+  id: WeaponShotgunBulldogHoS
+  description: This is a seemingly ordinary shotgun, no different from those issued as standard in the Republic of Biesel Navy. A close inspection reveals that this weapon's serial number is 000000013.
+  components:
+    - type: StealTarget
+      stealGroup: WeaponShotgunBulldogHoS
+
+- type: entity
   name: double-barreled shotgun
   parent: BaseWeaponShotgun
   id: WeaponShotgunDoubleBarreled

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -82,6 +82,19 @@
     temperature: 700
 
 - type: entity
+  name: antique energy sword
+  parent: EnergySword
+  id: EnergySwordHoS
+  description: An elegant weapon fit for a prince, this otherwise plain silver hilt is engraved with, "My Love".
+  components:
+    - type: EnergySword
+      activatedColor: "#00CCFF"
+      colorOptions:
+       - "#00CCFF"
+    - type: StealTarget
+      stealGroup: EnergySwordHoS
+
+- type: entity
   name: pen
   parent: EnergySword
   id: EnergyDagger

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
@@ -214,7 +214,7 @@
       jobs:
         - HeadOfSecurity
   items:
-    - ClothingBeltKatanaSheathFilled
+    - ClothingBeltKatanaSheathFilledHoS
 
 - type: loadout
   id: LoadoutCommandHoSC20r

--- a/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Heads/headOfSecurity.yml
@@ -173,3 +173,97 @@
         - HeadOfSecurity
   items:
     - ClothingShoesBootsWinterHeadOfSecurity
+
+# Head of Security Weapon Selection
+# Most of these mirror the unique weapons that were previously map-specific items placed in the HoS Office.
+# Or are weapons that fit a similar theme of "Rare weapons not normally seen by Security"
+- type: loadout
+  id: LoadoutCommandHoSPulsePistol
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - WeaponPulsePistolHoS
+
+- type: loadout
+  id: LoadoutCommandHoSWt550
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - WeaponSubMachineGunWt550HoS
+
+- type: loadout
+  id: LoadoutCommandHoSKatanaSheath
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - ClothingBeltKatanaSheathFilled
+
+- type: loadout
+  id: LoadoutCommandHoSC20r
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - WeaponSubMachineGunC20rHoS
+
+- type: loadout
+  id: LoadoutCommandHoSBulldog
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - WeaponShotgunBulldogHoS
+
+- type: loadout
+  id: LoadoutCommandHoSEnergySword
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - EnergySwordHoS
+
+- type: loadout
+  id: LoadoutCommandHoSEnergyGun
+  category: JobsCommand
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHoSWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - WeaponEnergyGunMultiphase


### PR DESCRIPTION
# Description

This PR adds a new "Head of Security's Antique Weapon Collection" item group to loadouts, which fully replaces the weapons that were originally map-specific entries for the Head of Security. Instead of whatever map giving the HoS a unique weapon in his office(And thus, overloading him with entirely too many guns), all of these weapons(And a few new ones) have been placed in their own special loadout category for the HoS. The HoS is entitled to a single free pick from any of these weapons. 

Now here's the fun tradeoff. All of them are steal objectives. Since it turns out the game will never give a steal objective to a traitor for an item that doesn't exist, I can actually make steal objectives for items obtainable only via Loadouts. Thus, all of the special weapons that the HoS can spawn with can be targeted by traitors. 

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/f2a594aa-0aae-44b0-be5d-5bd926b43993)

![image](https://github.com/user-attachments/assets/71c77c17-4560-4e71-b078-26bd986de103)

![image](https://github.com/user-attachments/assets/191dd5a6-71ee-43db-bac3-35e7a64c6087)

![image](https://github.com/user-attachments/assets/2551aa8b-9f65-4335-9eb9-05fd5214fa28)

![image](https://github.com/user-attachments/assets/37f788bf-9313-4dda-81d8-ca3a06b3fd5f)

</p>
</details>

# Changelog

:cl:
- remove: The X-01 multiphase energy gun has been removed from the HoS locker.
- add: A new Loadout Item Group, "Head of Security's Antique Weapon Collection" has been added. Rather than being given a unique weapon by whatever map creators put in the HoS Office, each Head of Security is entitled to a single item selected from this new loadout category, free of charge. But beware, whatever item chosen from this list may potentially be used as a Steal Objective for traitors. You may have a fancy new submachine gun, but it also makes you a target.
- add: antique Bulldog, antique C-20r submachine gun, x-01 multiphase energy gun, antique energy sword, antique pulse pistol, antique Wt550, and a pair of Katana Sheaths have all been added as loadout options for the Head of Security.

