### PR TITLE
Feat: Togglable Under-Table Crawling

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -74,6 +74,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.OfferItem);
             human.AddFunction(ContentKeyFunctions.ToggleStanding);
+            human.AddFunction(ContentKeyFunctions.ToggleCrawlingUnder);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -102,7 +102,7 @@ namespace Content.Client.Options.UI.Tabs
             _cfg.SetCVar(CCVars.HoldLookUp, args.Pressed);
             _cfg.SaveToFile();
         }
-        
+
         private void HandleDefaultWalk(BaseButton.ButtonToggledEventArgs args)
         {
             _cfg.SetCVar(CCVars.DefaultWalk, args.Pressed);
@@ -205,6 +205,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.OfferItem);
             AddButton(ContentKeyFunctions.SaveItemLocation);
             AddButton(ContentKeyFunctions.ToggleStanding);
+            AddButton(ContentKeyFunctions.ToggleCrawlingUnder);
             AddButton(ContentKeyFunctions.LookUp);
             AddCheckBox("ui-options-function-auto-get-up", _cfg.GetCVar(CCVars.AutoGetUp), HandleToggleAutoGetUp);
             AddCheckBox("ui-options-function-hold-look-up", _cfg.GetCVar(CCVars.HoldLookUp), HandleHoldLookUp);

--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -30,12 +30,13 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
         var query = EntityQueryEnumerator<LayingDownComponent, StandingStateComponent, SpriteComponent>();
         while (query.MoveNext(out var uid, out var layingDown, out var standing, out var sprite))
         {
-            var desiredDrawDepth = standing.CurrentState is StandingState.Lying && layingDown.IsCrawlingUnder
+            // Do not modify the entities draw depth if it's modified externally
+            if (sprite.DrawDepth != layingDown.NormalDrawDepth && sprite.DrawDepth != layingDown.CrawlingUnderDrawDepth)
+                continue;
+
+            sprite.DrawDepth = standing.CurrentState is StandingState.Lying && layingDown.IsCrawlingUnder
                 ? layingDown.CrawlingUnderDrawDepth
                 : layingDown.NormalDrawDepth;
-
-            if (sprite.DrawDepth != desiredDrawDepth)
-                sprite.DrawDepth = desiredDrawDepth;
         }
 
         query.Dispose();

--- a/Content.Client/Standing/LayingDownSystem.cs
+++ b/Content.Client/Standing/LayingDownSystem.cs
@@ -31,7 +31,7 @@ public sealed class LayingDownSystem : SharedLayingDownSystem
         while (query.MoveNext(out var uid, out var layingDown, out var standing, out var sprite))
         {
             var desiredDrawDepth = standing.CurrentState is StandingState.Lying && layingDown.IsCrawlingUnder
-                ? layingDown.CrawlingDrawDepth
+                ? layingDown.CrawlingUnderDrawDepth
                 : layingDown.NormalDrawDepth;
 
             if (sprite.DrawDepth != desiredDrawDepth)

--- a/Content.Server/Standing/LayingDownSystem.cs
+++ b/Content.Server/Standing/LayingDownSystem.cs
@@ -1,6 +1,11 @@
 using Content.Shared.Standing;
 using Content.Shared.CCVar;
+using Content.Shared.Input;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
 using Robust.Shared.Configuration;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
 
 namespace Content.Server.Standing;
 

--- a/Content.Server/Traits/Assorted/LayingDownModifierSystem.cs
+++ b/Content.Server/Traits/Assorted/LayingDownModifierSystem.cs
@@ -17,6 +17,6 @@ public sealed class LayingDownModifierSystem : EntitySystem
             return;
 
         layingDown.StandingUpTime *= component.LayingDownCooldownMultiplier;
-        layingDown.SpeedModify *= component.DownedSpeedMultiplierMultiplier;
+        layingDown.LyingSpeedModifier *= component.DownedSpeedMultiplierMultiplier;
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2475,11 +2475,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("rest.hold_look_up", false, CVar.CLIENT | CVar.ARCHIVE);
 
         /// <summary>
-        ///     When true, entities that fall to the ground will be able to crawl under tables and
-        ///     plastic flaps, allowing them to take cover from gunshots.
+        ///     When true, players can choose to crawl under tables while laying down, using the designated keybind.
         /// </summary>
         public static readonly CVarDef<bool> CrawlUnderTables =
-            CVarDef.Create("rest.crawlundertables", false, CVar.REPLICATED);
+            CVarDef.Create("rest.crawlundertables", true, CVar.SERVER | CVar.ARCHIVE);
 
         #endregion
 

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -57,6 +57,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction ResetZoom = "ResetZoom";
         public static readonly BoundKeyFunction OfferItem = "OfferItem";
         public static readonly BoundKeyFunction ToggleStanding = "ToggleStanding";
+        public static readonly BoundKeyFunction ToggleCrawlingUnder = "ToggleCrawlingUnder";
         public static readonly BoundKeyFunction LookUp = "LookUp";
 
         public static readonly BoundKeyFunction ArcadeUp = "ArcadeUp";

--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -1,6 +1,5 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
-using Content.Shared.DrawDepth;
 
 namespace Content.Shared.Standing;
 
@@ -8,10 +7,11 @@ namespace Content.Shared.Standing;
 public sealed partial class LayingDownComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float StandingUpTime = 1f;
+    public TimeSpan StandingUpTime = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
-    public float SpeedModify = 0.4f, CrawlingUnderSpeedModifier = 0.4f;
+    public float LyingSpeedModifier = 0.35f,
+                 CrawlingUnderSpeedModifier = 0.5f;
 
     [DataField, AutoNetworkedField]
     public bool AutoGetUp;
@@ -23,10 +23,8 @@ public sealed partial class LayingDownComponent : Component
     public bool IsCrawlingUnder = false;
 
     [DataField, AutoNetworkedField]
-    public int NormalDrawDepth = (int) DrawDepth.DrawDepth.Mobs;
-
-    [DataField, AutoNetworkedField]
-    public int CrawlingDrawDepth = (int) DrawDepth.DrawDepth.SmallMobs;
+    public int NormalDrawDepth = (int) DrawDepth.DrawDepth.Mobs,
+               CrawlingUnderDrawDepth = (int) DrawDepth.DrawDepth.SmallMobs;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Standing/LayingDownComponent.cs
+++ b/Content.Shared/Standing/LayingDownComponent.cs
@@ -8,13 +8,19 @@ namespace Content.Shared.Standing;
 public sealed partial class LayingDownComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float StandingUpTime { get; set; } = 1f;
+    public float StandingUpTime = 1f;
 
     [DataField, AutoNetworkedField]
-    public float SpeedModify { get; set; } = 0.4f;
+    public float SpeedModify = 0.4f, CrawlingUnderSpeedModifier = 0.4f;
 
     [DataField, AutoNetworkedField]
     public bool AutoGetUp;
+
+    /// <summary>
+    ///     If true, the entity is choosing to crawl under furniture. This is purely visual and has no effect on physics.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IsCrawlingUnder = false;
 
     [DataField, AutoNetworkedField]
     public int NormalDrawDepth = (int) DrawDepth.DrawDepth.Mobs;
@@ -30,16 +36,4 @@ public sealed class ChangeLayingDownEvent : CancellableEntityEventArgs;
 public sealed class CheckAutoGetUpEvent(NetEntity user) : CancellableEntityEventArgs
 {
     public NetEntity User = user;
-}
-
-[Serializable, NetSerializable]
-public sealed class DrawDownedEvent(NetEntity uid) : EntityEventArgs
-{
-    public NetEntity Uid = uid;
-}
-
-[Serializable, NetSerializable]
-public sealed class DrawStoodEvent(NetEntity uid) : EntityEventArgs
-{
-    public NetEntity Uid = uid;
 }

--- a/Content.Shared/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/Standing/SharedLayingDownSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.ActionBlocker;
 using Content.Shared.CCVar;
 using Content.Shared.DoAfter;
 using Content.Shared.Gravity;
@@ -22,6 +23,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly SharedPopupSystem _popups = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -58,11 +60,12 @@ public abstract class SharedLayingDownSystem : EntitySystem
     private void HandleCrawlUnderRequest(ICommonSession? session)
     {
         if (session == null
-            || !TryComp<StandingStateComponent>(session.AttachedEntity, out var standingState)
-            || !TryComp<LayingDownComponent>(session.AttachedEntity, out var layingDown))
+            || session.AttachedEntity is not {} uid
+            || !TryComp<StandingStateComponent>(uid, out var standingState)
+            || !TryComp<LayingDownComponent>(uid, out var layingDown)
+            || !_actionBlocker.CanInteract(uid, null))
             return;
 
-        var uid = session.AttachedEntity.Value;
         var newState = !layingDown.IsCrawlingUnder;
         if (standingState.CurrentState is StandingState.Standing)
             newState = false; // If the entity is already standing, this function only serves a fallback method to fix its draw depth

--- a/Content.Shared/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/Standing/SharedLayingDownSystem.cs
@@ -85,11 +85,6 @@ public abstract class SharedLayingDownSystem : EntitySystem
             return;
 
         var uid = args.SenderSession.AttachedEntity.Value;
-
-        // TODO: Wizard
-        //if (HasComp<FrozenComponent>(uid))
-        //   return;
-
         if (!TryComp(uid, out StandingStateComponent? standing)
             || !TryComp(uid, out LayingDownComponent? layingDown))
             return;
@@ -122,10 +117,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
         if (!_standing.IsDown(uid))
             return;
 
-        var modifier = component.IsCrawlingUnder
-            ? component.CrawlingUnderSpeedModifier
-            : component.SpeedModify;
-
+        var modifier = component.LyingSpeedModifier * (component.IsCrawlingUnder ? component.CrawlingUnderSpeedModifier : 1);
         args.ModifySpeed(modifier, modifier);
     }
 
@@ -159,6 +151,7 @@ public abstract class SharedLayingDownSystem : EntitySystem
             return false;
 
         standingState.CurrentState = StandingState.GettingUp;
+        layingDown.IsCrawlingUnder = false;
         return true;
     }
 

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -1,15 +1,12 @@
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
-using Content.Shared.CCVar;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Rotation;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Configuration;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Standing;
 
@@ -20,7 +17,6 @@ public sealed class StandingStateSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
 
     // If StandingCollisionLayer value is ever changed to more than one layer, the logic needs to be edited.
     private const int StandingCollisionLayer = (int) CollisionGroup.MidImpassable;
@@ -67,11 +63,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         standingState.CurrentState = StandingState.Lying;
         Dirty(standingState);
-        RaiseLocalEvent(uid, new DownedEvent(), false);
-
-        // Raising this event will lower the entity's draw depth to the same as a small mob.
-        if (_config.GetCVar(CCVars.CrawlUnderTables) && setDrawDepth)
-            RaiseNetworkEvent(new DrawDownedEvent(GetNetEntity(uid)));
+        RaiseLocalEvent(uid, new DownedEvent { UpdateDrawDepth = setDrawDepth }, false);
 
         // Seemed like the best place to put it
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
@@ -127,11 +119,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         standingState.CurrentState = StandingState.Standing;
         Dirty(uid, standingState);
-        RaiseLocalEvent(uid, new StoodEvent(), false);
-
-        // Raising this event will increase the entity's draw depth to a normal mob's.
-        if (_config.GetCVar(CCVars.CrawlUnderTables))
-            RaiseNetworkEvent(new DrawStoodEvent(GetNetEntity(uid)));
+        RaiseLocalEvent(uid, new StoodEvent { UpdateDrawDepth = true }, false);
 
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Vertical, appearance);
 
@@ -165,9 +153,15 @@ public sealed class StandAttemptEvent : CancellableEntityEventArgs { }
 /// <summary>
 ///     Raised when an entity becomes standing
 /// </summary>
-public sealed class StoodEvent : EntityEventArgs { }
+public sealed class StoodEvent : EntityEventArgs
+{
+    public bool UpdateDrawDepth = false;
+}
 
 /// <summary>
 ///     Raised when an entity is not standing
 /// </summary>
-public sealed class DownedEvent : EntityEventArgs { }
+public sealed class DownedEvent  : EntityEventArgs
+{
+    public bool UpdateDrawDepth = false;
+}

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -153,15 +153,9 @@ public sealed class StandAttemptEvent : CancellableEntityEventArgs { }
 /// <summary>
 ///     Raised when an entity becomes standing
 /// </summary>
-public sealed class StoodEvent : EntityEventArgs
-{
-    public bool UpdateDrawDepth = false;
-}
+public sealed class StoodEvent : EntityEventArgs { }
 
 /// <summary>
 ///     Raised when an entity is not standing
 /// </summary>
-public sealed class DownedEvent  : EntityEventArgs
-{
-    public bool UpdateDrawDepth = false;
-}
+public sealed class DownedEvent  : EntityEventArgs { }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -63,7 +63,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         standingState.CurrentState = StandingState.Lying;
         Dirty(standingState);
-        RaiseLocalEvent(uid, new DownedEvent { UpdateDrawDepth = setDrawDepth }, false);
+        RaiseLocalEvent(uid, new DownedEvent(), false);
 
         // Seemed like the best place to put it
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
@@ -119,7 +119,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         standingState.CurrentState = StandingState.Standing;
         Dirty(uid, standingState);
-        RaiseLocalEvent(uid, new StoodEvent { UpdateDrawDepth = true }, false);
+        RaiseLocalEvent(uid, new StoodEvent(), false);
 
         _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Vertical, appearance);
 

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -147,6 +147,7 @@ ui-options-function-rotate-stored-item = Rotate stored item
 ui-options-function-offer-item = Offer something
 ui-options-function-save-item-location = Save item location
 ui-options-function-toggle-standing = Toggle standing
+ui-options-function-toggle-crawling-under = Toggle crawling under furniture
 ui-options-static-storage-ui = Lock storage window to hotbar
 
 ui-options-function-smart-equip-backpack = Smart-equip to backpack

--- a/Resources/Locale/en-US/movement/laying.ftl
+++ b/Resources/Locale/en-US/movement/laying.ftl
@@ -1,3 +1,6 @@
+crawling-under-tables-disabled-popup = Crawling under tables is disabled on this server.
+
+# TODO either remove those, or make use of them
 laying-comp-lay-success-self = You lay down.
 laying-comp-lay-success-other = {THE($entity)} lays down.
 laying-comp-lay-fail-self = You can't lay down right now.

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -264,6 +264,10 @@ binds:
 - function: ToggleStanding
   type: State
   key: R
+- function: ToggleCrawlingUnder
+  type: State
+  mod1: Shift
+  key: R
 - function: ShowDebugConsole
   type: State
   key: Tilde


### PR DESCRIPTION
# Description
This reverts most code changes done by https://github.com/Simple-Station/Einstein-Engines/pull/939 and re-implements them in a better way:
- Players can now toggle under-furniture crawling with a keybind (shift-R by default)
- Crawling that way is 50% slower for obvious balancing reasons
- The respective cvar for it is now true by default and prevents players from beginning the "crawl under furniture" thing

Also cleaned up a few methods I was seriously pissed off by. There is still a lot to clean up and fix, but I will leave it for a dedicated PR in the future.

# Why (balancing)
Let me lie on the bed instead of under it!!!!!!!

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/5f04c82a-b88b-4005-8052-a1a6f011bcc9

</p>
</details>

# Changelog
:cl:
- add: You can now toggle crawling under furniture! The default keybind is Shift-R, you can change it in settings.
