### PR TITLE
Feat: Sleeping and Muzzle Block Vocal Emotes

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Actions;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Speech;
@@ -18,6 +19,10 @@ public sealed class VocalSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
+    [ValidatePrototypeId<ReplacementAccentPrototype>]
+    private const string MuzzleAccent = "mumble";
 
     public override void Initialize()
     {
@@ -53,7 +58,10 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnEmote(EntityUid uid, VocalComponent component, ref EmoteEvent args)
     {
-        if (args.Handled || !args.Emote.Category.HasFlag(EmoteCategory.Vocal))
+        if (args.Handled
+            || !args.Emote.Category.HasFlag(EmoteCategory.Vocal)
+            || !_actionBlocker.CanSpeak(uid)
+            || TryComp<ReplacementAccentComponent>(uid, out var replacement) && replacement.Accent == MuzzleAccent) // This is not ideal, but it works.
             return;
 
         // snowflake case for wilhelm scream easter egg


### PR DESCRIPTION
# Description
So you can actually muzzle a felinid to stop them from meowing. Or a vulp from barking. Or a human from screaming. You get the point.

This muzzle part of this PR is a bit hardcode-y, but it's because the muzzle simply adds a replacement accent to the entity instead of using its own system to block speech.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/0e5e4986-d2a0-471a-a119-579741265178

</p>
</details>

# Changelog
:cl:
- add: Sleeping and muzzled entities can no longer use vocal emotes (scream, meow, etc).