### PR TITLE
Cherry Pick "Fix Latejoin Antag Preferences Not Being Respected"

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
 using Content.Shared.Chat;
 using Content.Shared.Mind;
+using Content.Shared.Preferences;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.Enums;
@@ -154,6 +155,36 @@ public sealed partial class AntagSelectionSystem
             return new();
 
         return ent.Comp.SelectedMinds.Select(p => p.Item1).ToList();
+    }
+
+    /// <summary>
+    /// Checks if a given session has the primary antag preferences for a given definition
+    /// </summary>
+    public bool HasPrimaryAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
+    {
+        if (session == null)
+            return true;
+
+        if (def.PrefRoles.Count == 0)
+            return false;
+
+        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        return pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p));
+    }
+
+    /// <summary>
+    /// Checks if a given session has the fallback antag preferences for a given definition
+    /// </summary>
+    public bool HasFallbackAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
+    {
+        if (session == null)
+            return true;
+
+        if (def.FallbackRoles.Count == 0)
+            return false;
+
+        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        return pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p));
     }
 
     /// <summary>

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -17,7 +17,6 @@ using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Content.Shared.Humanoid;
 using Content.Shared.Players;
-using Content.Shared.Whitelist;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -41,7 +40,6 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
-    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     // arbitrary random number to give late joining some mild interest.
     public const float LateJoinRandomChance = 0.5f;
@@ -406,13 +404,13 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (def.Whitelist != null)
         {
-            if (!_whitelist.IsValid(def.Whitelist, entity.Value))
+            if (!def.Whitelist.IsValid(entity.Value))
                 return false;
         }
 
         if (def.Blacklist != null)
         {
-            if (_whitelist.IsValid(def.Blacklist, entity.Value))
+            if (def.Blacklist.IsValid(entity.Value))
                 return false;
         }
 

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -17,7 +17,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Content.Shared.Humanoid;
 using Content.Shared.Players;
-using Content.Shared.Preferences;
+using Content.Shared.Whitelist;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -41,6 +41,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     // arbitrary random number to give late joining some mild interest.
     public const float LateJoinRandomChance = 0.5f;
@@ -118,12 +119,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         // something to figure out later.
 
         var query = QueryActiveRules();
+        var rules = new List<(EntityUid, AntagSelectionComponent)>();
         while (query.MoveNext(out var uid, out _, out var antag, out _))
         {
-            // TODO ANTAG
-            // what why aasdiuhasdopiuasdfhksad
-            // stop this insanity please
-            // probability of antag assignment shouldn't depend on the order in which rules are returned by the query.
+            rules.Add((uid, antag));
+        }
+        RobustRandom.Shuffle(rules);
+
+        foreach (var (uid, antag) in rules)
+        {
             if (!RobustRandom.Prob(LateJoinRandomChance))
                 continue;
 
@@ -221,13 +225,13 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     /// <summary>
     /// Tries to makes a given player into the specified antagonist.
     /// </summary>
-    public bool TryMakeAntag(Entity<AntagSelectionComponent> ent, ICommonSession? session, AntagSelectionDefinition def, bool ignoreSpawner = false)
+    public bool TryMakeAntag(Entity<AntagSelectionComponent> ent, ICommonSession? session, AntagSelectionDefinition def, bool ignoreSpawner = false, bool checkPref = true)
     {
-        if (!IsSessionValid(ent, session, def) ||
-            !IsEntityValid(session?.AttachedEntity, def))
-        {
+        if (checkPref && !HasPrimaryAntagPreference(session, def))
             return false;
-        }
+
+        if (!IsSessionValid(ent, session, def) || !IsEntityValid(session?.AttachedEntity, def))
+            return false;
 
         MakeAntag(ent, session, def, ignoreSpawner);
         return true;
@@ -324,16 +328,14 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         var fallbackList = new List<ICommonSession>();
         foreach (var session in sessions)
         {
-            if (!IsSessionValid(ent, session, def) ||
-                !IsEntityValid(session.AttachedEntity, def))
+            if (!IsSessionValid(ent, session, def) || !IsEntityValid(session.AttachedEntity, def))
                 continue;
 
-            var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
-            if (def.PrefRoles.Count != 0 && pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p)))
+            if (HasPrimaryAntagPreference(session, def))
             {
                 preferredList.Add(session);
             }
-            else if (def.FallbackRoles.Count != 0 && pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p)))
+            else if (HasFallbackAntagPreference(session, def))
             {
                 fallbackList.Add(session);
             }
@@ -404,13 +406,13 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (def.Whitelist != null)
         {
-            if (!def.Whitelist.IsValid(entity.Value, EntityManager))
+            if (!_whitelist.IsValid(def.Whitelist, entity.Value))
                 return false;
         }
 
         if (def.Blacklist != null)
         {
-            if (def.Blacklist.IsValid(entity.Value, EntityManager))
+            if (_whitelist.IsValid(def.Blacklist, entity.Value))
                 return false;
         }
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

meow. 
Project compiles and starts. Is the bug gone? I hope so.

---

# Changelog

:cl:
- fix: Latejoin antag selection should respect player's antag preferences.