### PR TITLE
Make Brains Not Food

### DIFF
--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -27,11 +27,12 @@
 
 - type: entity
   id: OrganDionaBrain
-  parent: [BaseDionaOrgan, OrganHumanBrain]
+  parent: OrganHumanBrain
   name: brain
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Sprite
+    sprite: Mobs/Species/Diona/organs.rsi
     state: brain
   - type: SolutionContainerManager
     solutions:
@@ -102,7 +103,7 @@
     layers:
       - state: lung-l
       - state: lung-r
-  - type: Lung 
+  - type: Lung
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false
@@ -131,7 +132,7 @@
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Brain
-  - type: Nymph # This will make the organs turn into a nymph when they're removed. 
+  - type: Nymph # This will make the organs turn into a nymph when they're removed.
     entityPrototype: OrganDionaNymphBrain
     transferMind: true
 
@@ -170,11 +171,11 @@
 
 - type: entity
   id: OrganDionaNymphStomach
-  parent: MobDionaNymphAccent 
+  parent: MobDionaNymphAccent
   noSpawn: true
   name: diona nymph
   suffix: Stomach
-  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it. 
+  description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it.
   components:
   - type: IsDeadIC
   - type: Body
@@ -186,7 +187,7 @@
   noSpawn: true
   name: diona nymph
   suffix: Lungs
-  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking. 
+  description: Contains the lungs of a formerly fully-formed Diona. Breathtaking.
   components:
   - type: IsDeadIC
   - type: Body

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -6,6 +6,13 @@
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
   - type: Organ
+
+- type: entity
+  id: BaseHumanOrgan
+  parent: BaseHumanOrganUnGibbable
+  abstract: true
+  components:
+  - type: Gibbable
   - type: Food
   - type: Extractable
     grindableSolutionName: organ
@@ -26,13 +33,6 @@
   - type: Tag
     tags:
       - Meat
-
-- type: entity
-  id: BaseHumanOrgan
-  parent: BaseHumanOrganUnGibbable
-  abstract: true
-  components:
-  - type: Gibbable
 
 - type: entity
   id: OrganHumanBrain
@@ -67,7 +67,7 @@
   - type: FlavorProfile
     flavors:
       - people
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: BaseHumanOrgan

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SentientSlimeCore
-  parent: [BaseItem, OrganHumanBrain]
+  parent: OrganHumanBrain
   name: sentient slime core
   description: "The source of incredible, unending gooeyness."
   components:
@@ -34,7 +34,7 @@
           - ReagentId: Slime
             Quantity: 10
 
-      
+
 - type: entity
   id: OrganSlimeLungs
   parent: BaseHumanOrgan


### PR DESCRIPTION
# Description

This is a fucking stupid method of irreversible round removal. Gib someone and then eat their brain instantly. This PR makes brains not food, so that they can't be eaten instantly. 

# Changelog

:cl:
- tweak: Brains now can no longer be eaten.
