### PR TITLE
Constrict Height and Width via a Size Ratio

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -128,6 +128,12 @@ public sealed partial class SpeciesPrototype : IPrototype
     public int MaxAge = 120;
 
     /// <summary>
+    ///     The minimum height and width ratio for this species
+    /// </summary>
+    [DataField]
+    public float SizeRatio = 1.2f;
+
+    /// <summary>
     ///     The minimum height for this species
     /// </summary>
     [DataField]


### PR DESCRIPTION
# Description

Title
Intended to stop players from making slender men type characters with height maxed and width at the minimum, and vice versa
The ratio can be modified via the species' prototype
---

<details><summary><h1>Media</h1></summary>
<p>

![Video](https://gyazo.com/d88dfda0bc18264689ba1fca3c6a0e86.mp4)

</p>
</details>

---

# Changelog

:cl:
- tweak: Height and width are now constricted via a ratio.

