### PR TITLE
Cocoon Sizing Bettering

### DIFF
--- a/Content.Client/Arachne/CocoonSystem.cs
+++ b/Content.Client/Arachne/CocoonSystem.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Arachne;
+using Content.Shared.Humanoid;
+using Robust.Client.GameObjects;
+using Robust.Shared.Containers;
+using System.Diagnostics;
+using System.Numerics;
+
+namespace Content.Client.Cocoon
+{
+    public sealed class CocoonSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<CocoonComponent, EntInsertedIntoContainerMessage>(OnCocEntInserted);
+        }
+
+        private void OnCocEntInserted(EntityUid uid, CocoonComponent component, EntInsertedIntoContainerMessage args)
+        {
+            if (!TryComp<SpriteComponent>(uid, out var cocoonSprite))
+                return;
+
+            if (TryComp<HumanoidAppearanceComponent>(args.Entity, out var humanoidAppearance)) // If humanoid, use height and width
+                cocoonSprite.Scale = new Vector2(humanoidAppearance.Width, humanoidAppearance.Height);
+            else if (!TryComp<SpriteComponent>(args.Entity, out var entSprite))
+                return;
+            else if (entSprite.BaseRSI != null) // Set scale based on sprite scale + sprite dimensions. Ideally we would somehow get a bounding box from the sprite size not including transparent pixels, but FUCK figuring that out.
+                cocoonSprite.Scale = entSprite.Scale * (entSprite.BaseRSI.Size / 32);
+            else if (entSprite.Scale != cocoonSprite.Scale) // if basersi somehow not found (?) just use scale
+                cocoonSprite.Scale = entSprite.Scale;
+        }
+    }
+}

--- a/Content.Client/Arachne/CocoonSystem.cs
+++ b/Content.Client/Arachne/CocoonSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Arachne;
 using Content.Shared.Humanoid;
 using Robust.Client.GameObjects;
 using Robust.Shared.Containers;
-using System.Diagnostics;
 using System.Numerics;
 
 namespace Content.Client.Cocoon

--- a/Content.Server/Arachne/ArachneSystem.cs
+++ b/Content.Server/Arachne/ArachneSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Arachne;
-using Content.Shared.Actions;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Verbs;
 using Content.Shared.Buckle.Components;
@@ -8,20 +7,16 @@ using Content.Shared.Stunnable;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
-using Content.Shared.Inventory;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Humanoid;
-using Content.Shared.Nutrition.EntitySystems;
 using Content.Server.Buckle.Systems;
 using Content.Server.Popups;
 using Content.Server.DoAfter;
 using Content.Server.Body.Components;
 using Content.Server.Vampiric;
 using Content.Server.Speech.Components;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Containers;
-using Robust.Shared.Map;
 using Robust.Shared.Utility;
 using Robust.Server.Console;
 

--- a/Content.Server/Arachne/ArachneSystem.cs
+++ b/Content.Server/Arachne/ArachneSystem.cs
@@ -207,17 +207,14 @@ namespace Content.Server.Arachne
             if (!TryComp<ItemSlotsComponent>(cocoon, out var slots))
                 return;
 
-            // todo: our species should use scale visuals probably...
-            // TODO: We need a client-accessible notion of scale influence here.
-            /* if (spawnProto == "CocoonedHumanoid" && TryComp<SpriteComponent>(args.Args.Target.Value, out var sprite)) */
-            /* { */
-            /*     // why the fuck is this only available as a console command. */
-            /*     _host.ExecuteCommand(null, "scale " + cocoon + " " + sprite.Scale.Y); */
-            if (TryComp<PhysicsComponent>(args.Args.Target.Value, out var physics))
+            /*
+
             {
                 var scale = Math.Clamp(1 / (35 / physics.FixturesMass), 0.35, 2.5);
                 _host.ExecuteCommand(null, "scale " + cocoon + " " + scale);
             }
+            */
+
             _itemSlots.SetLock(cocoon, BodySlot, false, slots);
             _itemSlots.TryInsert(cocoon, BodySlot, args.Args.Target.Value, args.Args.User);
             _itemSlots.SetLock(cocoon, BodySlot, true, slots);

--- a/Content.Server/Arachne/ArachneSystem.cs
+++ b/Content.Server/Arachne/ArachneSystem.cs
@@ -207,14 +207,6 @@ namespace Content.Server.Arachne
             if (!TryComp<ItemSlotsComponent>(cocoon, out var slots))
                 return;
 
-            /*
-
-            {
-                var scale = Math.Clamp(1 / (35 / physics.FixturesMass), 0.35, 2.5);
-                _host.ExecuteCommand(null, "scale " + cocoon + " " + scale);
-            }
-            */
-
             _itemSlots.SetLock(cocoon, BodySlot, false, slots);
             _itemSlots.TryInsert(cocoon, BodySlot, args.Args.Target.Value, args.Args.User);
             _itemSlots.SetLock(cocoon, BodySlot, true, slots);

--- a/Content.Shared/Arachne/CocoonComponent.cs
+++ b/Content.Shared/Arachne/CocoonComponent.cs
@@ -1,4 +1,6 @@
-namespace Content.Server.Arachne
+using Content.Shared.Humanoid;
+
+namespace Content.Shared.Arachne
 {
     [RegisterComponent]
     public sealed partial class CocoonComponent : Component

--- a/Content.Shared/Arachne/CocoonComponent.cs
+++ b/Content.Shared/Arachne/CocoonComponent.cs
@@ -1,5 +1,3 @@
-using Content.Shared.Humanoid;
-
 namespace Content.Shared.Arachne
 {
     [RegisterComponent]


### PR DESCRIPTION
# Description

Cocoon size is now based on the humanoids height/width, or the sprite scale/size.
Also makes it so we aren't calling a command to change the scale.

---

<details><summary><h1>Media</h1></summary>
<p>

### Large Oni
https://github.com/user-attachments/assets/c26f6b34-39f7-437c-af86-715185855aff

### Small Felinid
https://github.com/user-attachments/assets/5a82affb-b8b7-4b79-aa39-37f5a7a2e35e

### Mouse
https://github.com/user-attachments/assets/42d7b41e-7333-4052-a1d1-698ce337706e

### Dragon
https://github.com/user-attachments/assets/210eab03-416c-4795-a384-9e502fe794a2

</p>
</details>

---

# Changelog

:cl:
- tweak: Cocoon sizing has been changed to reflect the size of the entity inside better.

