### PR TITLE
Adds TC To Listening Post Operatives

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Fun/misc_startinggear.yml
@@ -62,6 +62,7 @@
     gloves: ClothingHandsGlovesCombat
     shoes: ClothingShoesSlippers
     id: SyndiListeningPostPDA
+    pocket1: BaseUplinkRadio20TC
   innerClothingSkirt: ClothingUniformJumpsuitPyjamaSyndicatePink
 
 # Mobsters


### PR DESCRIPTION
# Description

Spiritual successor to an old unintended interaction in Delta V, where LP ops would spawn with uplinks. Except instead of having objectives its just an uplink with 20TC.

Why? Because it turns LP Ops from a simple nuisance into a potential threat that can send support on station for you, and makes taking a trip to the outpost to cash in some TC a very viable strategy. Salvage might be more inclined to raid them too, so thats gonna be fun.

# Changelog

:cl: Mocho
- add: Added an uplink with 20TC for all Listening Post Operatives
