### PR TITLE
Personal Ai Languages

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -72,6 +72,22 @@
           Searching: { state: pai-searching-overlay }
           On: { state: pai-on-overlay }
   - type: StationMap
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    - SolCommon
+    - Tradeband
+    - Freespeak
+    - Elyran
+    - RobotTalk
+    understands:
+    - TauCetiBasic
+    - SolCommon
+    - Tradeband
+    - Freespeak
+    - Elyran
+    - RobotTalk
+    - Sign # It's intentional that they don't "Speak" sign language.
 
 - type: entity
   parent: PersonalAI


### PR DESCRIPTION
# Description

This PR adds Languages to Personal Ai devices, allowing them to act as an interpreter for their owner. PAIs carry knowledge of all "Common" languages(Not including anything species specific, or Rare), plus the ability to understand(but not speak) Sign language.

# Changelog

:cl:
- add: Personal Ai devices now come loaded with knowledge of all "Common" languages, including Sign language, allowing them to interpret for their owner. 
