### PR TITLE
Chaplain Bible Loadouts

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -42,6 +42,10 @@ character-item-group-LoadoutUniformsScience = Epistemics Uniforms
 # Epistemics - Cataloguer
 character-item-group-LoadoutCataloguerUniforms = Cataloguer Uniforms
 
+# Epistemics - Chaplain
+character-item-group-LoadoutChaplainUniforms = Chaplain Uniforms
+character-item-group-LoadoutChaplainEquipment = Chaplain Equipment
+
 # Medical
 character-item-group-LoadoutEyesMedical = Medical Eyewear
 character-item-group-LoadoutGlovesMedical = Medical Gloves

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -178,11 +178,6 @@
   noSpawn: true
   parent: ClothingBackpack
   id: ClothingBackpackChaplainFilled
-  components:
-  - type: StorageFill
-    contents:
-      - id: Bible
-      - id: RubberStampChaplain
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/CharacterItemGroups/scienceGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/scienceGroups.yml
@@ -120,3 +120,25 @@
       id: LoadoutScienceJumpsuitLibrarianZav
     - type: loadout
       id: LoadoutScienceJumpsuitLibrarianZeng
+    - type: loadout
+      id: LoadoutScienceJumpsuitLibrarian
+    - type: loadout
+      id: LoadoutScienceJumpskirtLibrarian
+
+# Chaplain
+- type: characterItemGroup
+  id: LoadoutChaplainUniforms
+  items:
+    - type: loadout
+      id: LoadoutChaplainJumpsuit
+    - type: loadout
+      id: LoadoutChaplainJumpskirt
+
+- type: characterItemGroup
+  id: LoadoutChaplainEquipment
+  maxItems: 2
+  items:
+    - type: loadout
+      id: LoadoutChaplainBible
+    - type: loadout
+      id: LoadoutChaplainStamp

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -626,3 +626,88 @@
         - Librarian
   items:
     - ClothingUniformJumpsuitLibrarianZeng
+
+- type: loadout
+  id: LoadoutScienceJumpsuitLibrarian
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCataloguerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Librarian
+  items:
+    - ClothingUniformJumpsuitLibrarian
+
+- type: loadout
+  id: LoadoutScienceJumpskirtLibrarian
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCataloguerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Librarian
+  items:
+    - ClothingUniformJumpskirtLibrarian
+
+# Chaplain
+- type: loadout
+  id: LoadoutChaplainJumpsuit
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - ClothingUniformJumpsuitChaplain
+
+- type: loadout
+  id: LoadoutChaplainJumpskirt
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - ClothingUniformJumpskirtChaplain
+
+- type: loadout
+  id: LoadoutChaplainBible
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - Bible
+
+- type: loadout
+  id: LoadoutChaplainStamp
+  category: JobsScience
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - RubberStampChaplain

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -38,7 +38,7 @@
   id: ChaplainGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitChaplain
-    back: ClothingBackpackChaplainFilled
+    back: ClothingBackpack
     shoes: ClothingShoesColorBlack
     id: ChaplainPDA
     ears: ClothingHeadsetScience


### PR DESCRIPTION
# Description

Since you get your Backpack from your Loadout, Chaplain no longer gets his bible from his backpack. Actually NOBODY gets their Filled backpacks anymore. Every job that previously had a Filled backpack needs to have their shit added to Loadouts. This PR adds loadout categories for the Chaplain to get his Bible and Stamp back.

I spent literally 2 fucking hours trying to figure out why I can't add job specific categories to Science, and have nothing to show for it. So Uhh.. Fuck. I don't know why I can add job specific categories for service, but can't for Science. 

# Changelog

:cl:
- add: Chaplain's Bible and Stamp is now found in Loadouts.