### PR TITLE
Fix Melee Contests

### DIFF
--- a/Content.Shared/Contests/ContestsSystem.Utilities.cs
+++ b/Content.Shared/Contests/ContestsSystem.Utilities.cs
@@ -30,27 +30,27 @@ public sealed partial class ContestsSystem
             return 1;
 
         if (!args.DoEveryInteraction)
-            return args.DoMassInteraction ? ((!args.MassDisadvantage
+            return args.DoMassInteraction ? ((args.MassDisadvantage
                         ? MassContest(user, args.MassBypassClamp, args.MassRangeModifier)
                         : 1 / MassContest(user, args.MassBypassClamp, args.MassRangeModifier))
                             + args.MassOffset)
                                 : 1
-                    * (args.DoStaminaInteraction ? ((!args.StaminaDisadvantage
+                    * (args.DoStaminaInteraction ? ((args.StaminaDisadvantage
                         ? StaminaContest(user, args.StaminaBypassClamp, args.StaminaRangeModifier)
                         : 1 / StaminaContest(user, args.StaminaBypassClamp, args.StaminaRangeModifier))
                             + args.StaminaOffset)
                                 : 1)
-                    * (args.DoHealthInteraction ? ((!args.HealthDisadvantage
+                    * (args.DoHealthInteraction ? ((args.HealthDisadvantage
                         ? HealthContest(user, args.HealthBypassClamp, args.HealthRangeModifier)
                         : 1 / HealthContest(user, args.HealthBypassClamp, args.HealthRangeModifier))
                             + args.HealthOffset)
                                 : 1)
-                    * (args.DoMindInteraction ? ((!args.MindDisadvantage
+                    * (args.DoMindInteraction ? ((args.MindDisadvantage
                         ? MindContest(user, args.MindBypassClamp, args.MindRangeModifier)
                         : 1 / MindContest(user, args.MindBypassClamp, args.MindRangeModifier))
                             + args.MindOffset)
                                 : 1)
-                    * (args.DoMoodInteraction ? ((!args.MoodDisadvantage
+                    * (args.DoMoodInteraction ? ((args.MoodDisadvantage
                         ? MoodContest(user, args.MoodBypassClamp, args.MoodRangeModifier)
                         : 1 / MoodContest(user, args.MoodBypassClamp, args.MoodRangeModifier))
                             + args.MoodOffset)

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -166,10 +166,7 @@ public sealed partial class MeleeWeaponComponent : Component
     {
         DoStaminaInteraction = true,
         StaminaDisadvantage = true,
-        StaminaRangeModifier = 2,
-        StaminaOffset = 0.25f,
         DoHealthInteraction = true,
-        HealthRangeModifier = 1.5f,
     };
 
     /// <summary>


### PR DESCRIPTION
# Description

Default values for melee weapon contests were causing balance issues with Mobs that interacted with it, such as Carps being able to defeat the damage threshold of reinforced walls when the intention is that they shouldn't be able to. Also the logic on ContestDisadvantages was inverted, so this fixes that.

# Changelog

:cl:
- fix: Fixed issues with Contests System that allowed mobs such as Space Carps to smash through barriers that were not intended to be breakable by said mobs.