### PR TITLE
Stop Harpy Singing On Disconnect

### DIFF
--- a/Content.Shared/Traits/Assorted/Systems/SharedSingerSystem.cs
+++ b/Content.Shared/Traits/Assorted/Systems/SharedSingerSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Instruments;
 using Content.Shared.Traits.Assorted.Components;
 using Content.Shared.Traits.Assorted.Prototypes;
 using Content.Shared.Zombies;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Traits.Assorted.Systems;
@@ -15,7 +16,6 @@ public abstract class SharedSingerSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedInstrumentSystem _instrument = default!;
-    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
     public override void Initialize()
     {
@@ -26,6 +26,7 @@ public abstract class SharedSingerSystem : EntitySystem
         SubscribeLocalEvent<SingerComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<SingerComponent, BoundUIClosedEvent>(OnBoundUIClosed);
         SubscribeLocalEvent<SingerComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+        SubscribeLocalEvent<SingerComponent, PlayerDetachedEvent>(OnPlayerDetached);
     }
 
     private void OnStartup(Entity<SingerComponent> ent, ref ComponentStartup args)
@@ -67,6 +68,11 @@ public abstract class SharedSingerSystem : EntitySystem
 
         TryComp(uid, out AppearanceComponent? appearance);
         _appearance.SetData(uid, HarpyVisualLayers.Singing, SingingVisualLayer.True, appearance);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, SingerComponent component, PlayerDetachedEvent args)
+    {
+        CloseMidiUi(uid);
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

This fixes a bug reported by @Durk over discord, whereby if a Harpy's player disconnects, their midi player does not correctly close, causing the song to perpetually play.

# Changelog

:cl:
- fix: Fixed Harpies not ceasing with their singing when a player disconnects.