### PR TITLE
Fix Cryptobiolin

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -141,8 +141,8 @@
     - TemporaryBlindness
     - Pacified
     - StaminaModifier
-    - PsionicsDisabled #Nyano - Summary: PCs can have psionics disabled.
-    - PsionicallyInsulated #Nyano - Summary: PCs can be made insulated from psionic powers.
+    - PsionicsDisabled
+    - PsionicallyInsulated
   - type: Reflect
     enabled: false
     reflectProb: 0
@@ -273,6 +273,8 @@
     - Muted
     - Pacified
     - StaminaModifier
+    - PsionicsDisabled
+    - PsionicallyInsulated
   - type: Blindable
   # Other
   - type: Temperature

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -11,16 +11,20 @@
       metabolismRate: 0.1
       effects:
       - !type:GenericStatusEffect
-        key: PsionicallyInsulated #Nyano - Summary: makes the user psionically insulated from effects.
-        component: PsionicInsulation #Nyano - Summary: see above.
+        key: PsionicallyInsulated
+        component: PsionicInsulation
         type: Add
+        time: 900
       - !type:GenericStatusEffect
         key: Stutter
         component: ScrambledAccent
-      - !type:GenericStatusEffect
-        key: PsionicsDisabled #Nyano - Summary: disables psinoics from being used by the wearer.
-        component: PsionicsDisabled #Nyano - Summary: see above.
         type: Add
+        time: 900
+      - !type:GenericStatusEffect
+        key: PsionicsDisabled
+        component: PsionicsDisabled
+        type: Add
+        time: 900
       - !type:Drunk
         slurSpeech: false
         boozePower: 20
@@ -1120,7 +1124,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone


### PR DESCRIPTION
# Description

Closes #1080
This PR fixes Cryptobiolin so that it correctly adds a temporary "PsionicsDisabled" and "PsionicallyInsulated" status effect to the consumer. This effect lasts for 15 minutes, and is intended to be a highly effective means of providing protection from psionics, especially in the case of a Code White call.

# Changelog

:cl:
- fix: Fixed Cryptobiolin not providing temporary Psionic Insulation. It now provides protection from psionic abilities and events for 15 minutes.
