### PR TITLE
Fix Nicotine Addiction

### DIFF
--- a/Resources/Prototypes/Mood/drugs.yml
+++ b/Resources/Prototypes/Mood/drugs.yml
@@ -4,7 +4,7 @@
 - type: moodEffect
   id: LotoTranscendence
   moodChange: 30
-  timeout: 600 #10 minutes
+  timeout: 1020 #17 minutes
   moodletOnEnd: LotoEnthrallment
   category: "LotophagoiAddiction"
 
@@ -21,7 +21,7 @@
 - type: moodEffect
   id: NicotineBenefit
   moodChange: 5
-  timeout: 600 #10 minutes
+  timeout: 1020 #17 minutes
   moodletOnEnd: NicotineWithdrawal
   category: "NicotineAddiction"
 


### PR DESCRIPTION
# Description

It takes 10 minutes to smoke a cigarette, and by the time the cigarette is done smoking, the nicotine addiction benefit wears off, meaning that the instant you stopped smoking, you would immediately suffer the need to smoke again. A better fix would be a more comprehensive refactor of addictions into its own special system, but we're currently in a state of "Rapid fire fixes" so this will do for now by bumping the benefit time up to 17 minutes. I've also done the same for Loto Enthrallment.

# Changelog

:cl:
- tweak: The mood benefit from Nicotine and Lotophagoi Oil has had its duration increased from 10 minutes to 17 minutes. You should no longer IMMEDIATELY feel a need to smoke as soon as the first cigarette is done.
