### PR TITLE
Fix Too Much Food And Drink

### DIFF
--- a/Resources/Locale/en-US/mood/mood.ftl
+++ b/Resources/Locale/en-US/mood/mood.ftl
@@ -5,7 +5,7 @@ mood-effect-HungerOkay = I am feeling full.
 mood-effect-HungerPeckish = I could go for a snack right about now.
 mood-effect-HungerStarving = I NEED FOOD!
 
-mood-effect-ThirstOverHydrated = I feel dizzy after drinking too much.
+mood-effect-ThirstOverHydrated = I've had my fill of water.
 mood-effect-ThirstOkay = I'm feeling refreshed.
 mood-effect-ThirstThirsty = My lips are a little dry.
 mood-effect-ThirstParched = I NEED WATER!

--- a/Resources/Prototypes/Mood/genericNeeds.yml
+++ b/Resources/Prototypes/Mood/genericNeeds.yml
@@ -1,7 +1,7 @@
 ﻿# Hunger
 - type: moodEffect
   id: HungerOverfed
-  moodChange: -10
+  moodChange: 10
   category: "Hunger"
 
 - type: moodEffect
@@ -22,7 +22,7 @@
 # Thirst
 - type: moodEffect
   id: ThirstOverHydrated
-  moodChange: -3
+  moodChange: 10
   category: "Thirst"
 
 - type: moodEffect


### PR DESCRIPTION
# Description

Closes #1075
It was basically impossible to eat or drink without triggering the negative moodlet, and this feels entirely the wrong direction for players to be penalized for these actions. So I've simply inverted the penalty into a bonus. 

# Changelog

:cl:
- tweak: Completely satiating all hunger or thirst now provides a mood bonus instead of a penalty.
