### PR TITLE
Fix Mech Weight

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -72,7 +72,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.45
-        density: 47157
+        density: 21390 # 15 Tonnes
         mask:
         - MobMask
         layer:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -72,7 +72,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.45
-        density: 1000
+        density: 47157
         mask:
         - MobMask
         layer:


### PR DESCRIPTION
# Description

Mechs have a more realistic weight now. :)
Fixes #666

# Changelog

:cl:
- add: Ripley now weighs a few tonnes. Good luck ever pulling it.