### PR TITLE
Pistol Ammo Counter

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -65,6 +65,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: AmmoCounter
 
 - type: entity
   name: viper


### PR DESCRIPTION
# Description

All pistols were lacking the AmmoCounterComponent, needed to display their ammo in the UI like all the rest of the guns.

# Changelog

:cl:
- fix: Handguns(Such as Mk58, Viper, Cobra, etc.) now display their ammo counter in the UI.
