### PR TITLE
Cargo Gifts Contraband

### DIFF
--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -2,6 +2,7 @@ cargo-gifts-event-announcement = Congratulations! { $sender } has decided to sen
 cargo-gift-default-description = A bundle of gifts
 cargo-gift-default-sender = NanoTrasen
 cargo-gift-default-dest = Logistics Dept.
+cargo-gift-default-syndicate = :ERROR: SENDER UNKNOWN!
 
 cargo-gift-dest-bar = bar
 cargo-gift-dest-eng = Engineering Dept
@@ -9,6 +10,7 @@ cargo-gift-dest-supp = Logistics Dept
 cargo-gift-dest-janitor = Service Dept
 cargo-gift-dest-med = Medical Dept
 cargo-gift-dest-sec = Security Dept
+cargo-gift-dest-error = :ERROR: DEPARTMENT NOT FOUND
 
 cargo-gift-pizza-small = a small pizza party
 cargo-gift-pizza-large = a large pizza party
@@ -21,3 +23,4 @@ cargo-gift-space-protection = space hazard protection
 cargo-gift-fire-protection = fire protection
 cargo-gift-security-guns = lethal weapons
 cargo-gift-security-riot = riot gear
+cargo-gift-contraband = :ERROR: UNKNOWN OBJECTS IN LOADING BAY

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -47,7 +47,7 @@
       startDelay: 10
       duration: 240
       earliestStart: 30
-      minimumPlayers: 10
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-eng
       sender: cargo-gift-default-sender
@@ -70,7 +70,7 @@
       startDelay: 10
       duration: 120
       minimumPlayers: 40
-      earliestStart: 30
+      earliestStart: 0
     - type: CargoGiftsRule
       description: cargo-gift-vending
       sender: cargo-gift-default-sender
@@ -93,7 +93,7 @@
       startDelay: 10
       duration: 120
       minimumPlayers: 30
-      earliestStart: 20
+      earliestStart: 0
     - type: CargoGiftsRule
       description: cargo-gift-cleaning
       sender: cargo-gift-default-sender
@@ -113,7 +113,7 @@
       startDelay: 10
       duration: 120
       earliestStart: 20
-      minimumPlayers: 30
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-medical-supply
       sender: cargo-gift-default-sender
@@ -135,7 +135,7 @@
       startDelay: 10
       duration: 120
       earliestStart: 10
-      minimumPlayers: 40
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-space-protection
       sender: cargo-gift-default-sender
@@ -157,7 +157,7 @@
       startDelay: 10
       duration: 120
       earliestStart: 20
-      minimumPlayers: 40
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-fire-protection
       sender: cargo-gift-default-sender
@@ -177,7 +177,7 @@
       startDelay: 10
       duration: 120
       earliestStart: 20
-      minimumPlayers: 50
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-security-guns
       sender: cargo-gift-default-sender
@@ -198,7 +198,7 @@
       startDelay: 10
       duration: 120
       earliestStart: 20
-      minimumPlayers: 50
+      minimumPlayers: 0
     - type: CargoGiftsRule
       description: cargo-gift-security-riot
       sender: cargo-gift-default-sender
@@ -207,3 +207,39 @@
         SecurityRiot: 2
         SecurityRestraints: 2
         SecurityNonLethal: 2
+
+- type: entity
+  id: GiftsSyndicateContraband
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      weight: 1
+      startDelay: 10
+      duration: 120
+      earliestStart: 20
+      minimumPlayers: 0
+    - type: CargoGiftsRule
+      description: cargo-gift-contraband
+      sender: cargo-gift-default-syndicate
+      dest: cargo-gift-dest-error
+      gifts:
+        CrateSyndicateSurplusBundle: 1
+
+- type: entity
+  id: GiftsSyndicateContrabandSuper
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      weight: 0.25
+      startDelay: 10
+      duration: 120
+      earliestStart: 20
+      minimumPlayers: 0
+    - type: CargoGiftsRule
+      description: cargo-gift-contraband
+      sender: cargo-gift-default-syndicate
+      dest: cargo-gift-dest-error
+      gifts:
+        CrateSyndicateSuperSurplusBundle: 1


### PR DESCRIPTION
# Description

I've been running this event manually a few times on Deepstation, so I'd like to make it official given the funny chaos it causes on rounds when people go investigate it, and get ambushed by nukie mice.

# Changelog

:cl:
- add: The Syndicate has begun occasionally smuggling contraband via the Automated Trade Station.