### PR TITLE
Remove Pathfinder Latejoin Spawns

### DIFF
--- a/Resources/Maps/Shuttles/pathfinder.yml
+++ b/Resources/Maps/Shuttles/pathfinder.yml
@@ -341,18 +341,6 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Pathfinder
-  - uid: 357
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 3

--- a/Resources/Maps/Shuttles/pathfinder.yml
+++ b/Resources/Maps/Shuttles/pathfinder.yml
@@ -21,6 +21,7 @@ entities:
       name: Pathfinder
     - type: Transform
       pos: -0.515625,-0.515625
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/Shuttles/pathfinder.yml
+++ b/Resources/Maps/Shuttles/pathfinder.yml
@@ -21,7 +21,6 @@ entities:
       name: Pathfinder
     - type: Transform
       pos: -0.515625,-0.515625
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -341,6 +340,18 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Pathfinder
+  - uid: 357
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 3
@@ -2593,18 +2604,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-2.5
-      parent: 1
-- proto: SpawnPointLatejoin
-  entities:
-  - uid: 357
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 358
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
       parent: 1
 - proto: SubstationWallBasic
   entities:


### PR DESCRIPTION
# Description

Fixes #1099

# Changelog

:cl:
- fix: Removed latejoin spawners from the Salvage Pathfinder.