### PR TITLE
Fix Breath Of Life Locale

### DIFF
--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -69,7 +69,7 @@ revivify-power-initialization-feedback =
     The Secret of Life in its fullness. I feel my entire existence burning out from within, merely by knowing it.
     Power flows through me as a mighty river, begging to be released with a simple spoken word.
 revivify-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the Greater Secret of Life.
-revivify-word-begin = {CAPITALIZE($entity)} enunciates a word of such divine power, that those who hear it weep from joy.
+revivify-start = {CAPITALIZE($entity)} enunciates a word of such divine power, that those who hear it weep from joy.
 
 # Telegnosis
 telegnosis-power-description = Create a telegnostic projection to remotely observe things.


### PR DESCRIPTION
# Description

Fixes #1107
A pretty simple single-line fix that makes Breath of Life have its correct text popup.

# Changelog

:cl:
- fix: Breath of Life now correctly displays its esoteric text popup if the right conditions are met.
