### PR TITLE
Fix Gax Missing LV Cable

### DIFF
--- a/Resources/Maps/gaxstation.yml
+++ b/Resources/Maps/gaxstation.yml
@@ -29289,6 +29289,11 @@ entities:
     - type: Transform
       pos: 72.5,24.5
       parent: 2
+  - uid: 18587
+    components:
+    - type: Transform
+      pos: 69.5,22.5
+      parent: 2
   - uid: 18794
     components:
     - type: Transform
@@ -124673,7 +124678,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -79958.195
+      secondsUntilStateChange: -80064.195
       state: Opening
   - uid: 18112
     components:


### PR DESCRIPTION
# Description

Gax was missing a single LV cable, making it so that the Captain's office could be crowbarred into.

![image](https://github.com/user-attachments/assets/0718e64a-ff74-4e8e-9596-61636fd4bc70)

# Changelog

:cl:
- fix: Fixed the Captain's Office on Gax Station missing an LV cable that would power its doors.