### PR TITLE
Glacier Pseudo Planet

### DIFF
--- a/Resources/Maps/glacier.yml
+++ b/Resources/Maps/glacier.yml
@@ -72,7 +72,10 @@ entities:
     - type: GridTree
     - type: MovedGrids
     - type: Parallax
-      parallax: Sky
+      parallax: Snow
+    - type: Gravity
+      enabled: true
+      inherent: true
     - type: MapAtmosphere
       space: False
       mixture:
@@ -69876,13 +69879,6 @@ entities:
     components:
     - type: Transform
       pos: 63.191357,-49.411076
-      parent: 2
-- proto: GravityGenerator
-  entities:
-  - uid: 9482
-    components:
-    - type: Transform
-      pos: 27.5,54.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:


### PR DESCRIPTION
# Description

This PR changes Glacier so that instead of spawning in a no-gravity Nukieworld, it instead spawns in a frozen wasteland that people can actually walk on, AND ships will work on it too.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/d7c00fd5-4053-4939-be30-81bb72cca865)

</p>
</details>

# Changelog

:cl:
- add: Glacier is now on a planetary surface