### PR TITLE
Fix Markup Tags in Station News (#30169)

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
         Author.Visible = true;
 
         PageName.Text = article.Title;
-        PageText.SetMarkup(article.Content);
+        PageText.SetMarkupPermissive(article.Content);
 
         PageNum.Text = $"{targetNum}/{totalNum}";
 

--- a/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
+++ b/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
@@ -76,7 +76,7 @@ public sealed partial class ArticleEditorPanel : Control
 
         TextEditPanel.Visible = !_preview;
         PreviewPanel.Visible = _preview;
-        PreviewLabel.SetMarkup(Rope.Collapse(ContentField.TextRope));
+        PreviewLabel.SetMarkupPermissive(Rope.Collapse(ContentField.TextRope));
     }
 
     private void OnCancel(BaseButton.ButtonEventArgs eventArgs)

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -5,9 +5,27 @@ namespace Content.Client.Message;
 
 public static class RichTextLabelExt
 {
+
+
+     /// <summary>
+     /// Sets the labels markup.
+     /// </summary>
+     /// <remarks>
+     /// Invalid markup will cause exceptions to be thrown. Don't use this for user input!
+     /// </remarks>
     public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
     {
         label.SetMessage(FormattedMessage.FromMarkup(markup));
+        return label;
+    }
+
+     /// <summary>
+     /// Sets the labels markup.<br/>
+     /// Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
+     /// </summary>
+    public static RichTextLabel SetMarkupPermissive(this RichTextLabel label, string markup)
+    {
+        label.SetMessage(FormattedMessage.FromMarkupPermissive(markup));
         return label;
     }
 }

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -8,10 +8,10 @@ public static class RichTextLabelExt
 
 
      /// <summary>
-     /// Sets the labels markup.
+     ///    Sets the labels markup.
      /// </summary>
      /// <remarks>
-     /// Invalid markup will cause exceptions to be thrown. Don't use this for user input!
+     ///    Invalid markup will cause exceptions to be thrown. Don't use this for user input!
      /// </remarks>
     public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
     {
@@ -20,8 +20,8 @@ public static class RichTextLabelExt
     }
 
      /// <summary>
-     /// Sets the labels markup.<br/>
-     /// Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
+     ///    Sets the labels markup.<br/>
+     ///    Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
      /// </summary>
     public static RichTextLabel SetMarkupPermissive(this RichTextLabel label, string markup)
     {

--- a/Content.Client/Tips/TippyUIController.cs
+++ b/Content.Client/Tips/TippyUIController.cs
@@ -175,7 +175,7 @@ public sealed class TippyUIController : UIController
                     sprite.LayerSetVisible("hiding", false);
                 }
                 sprite.Rotation = 0;
-                tippy.Label.SetMarkup(_currentMessage.Msg);
+                tippy.Label.SetMarkupPermissive(_currentMessage.Msg);
                 tippy.Label.Visible = false;
                 tippy.LabelPanel.Visible = false;
                 tippy.Visible = true;


### PR DESCRIPTION
* Fix (hopefully)

* Fixed Spelling Mistake and minor Code Cleanup

* Revert "Fixed Spelling Mistake and minor Code Cleanup" due to Pull Request Guidelines

This reverts commit cee3e0226b349187bd8fd8b639e161fb877e8bdb.

# Description

Fixes https://github.com/SS14-Classic/deep-station-14/issues/87

