### PR TITLE
Fix Asterisk

### DIFF
--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -64,6 +64,25 @@ entities:
     - type: OccluderTree
     - type: Parallax
       parallax: Snow
+    - type: MapAtmosphere
+      space: False
+      mixture:
+        volume: 2500
+        immutable: True
+        temperature: 213.15
+        moles:
+        - 21.824879
+        - 82.10312
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: Gravity
       enabled: true
       inherent: true

--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -63,7 +63,10 @@ entities:
     - type: Broadphase
     - type: OccluderTree
     - type: Parallax
-      parallax: AngleStation
+      parallax: Snow
+    - type: Gravity
+      enabled: true
+      inherent: true
     - type: LoadedMap
   - uid: 2
     components:
@@ -71,6 +74,9 @@ entities:
     - type: Transform
       pos: -0.5104167,-0.4739367
       parent: 1
+    - type: PassiveDampening
+      linearDampening: 1
+      angularDampening: 1
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -8,8 +8,6 @@
     Asterisk:
       stationProto: StandardNanotrasenStation
       components:
-        - type: StationBiome
-          biome: Snow
         - type: StationRandomTransform
           enableStationRotation: false
           maxStationOffset: null


### PR DESCRIPTION
# Description

This fixes Asterisk so that it works like the new Glacier, with a pseudoplanet instead of the currently non-functional planet biome. We can return to proper planet biomes whenever they're better supported. 

# Changelog

:cl:
- fix: Asterisk Station no longer spawns entombed in snow, and is now on top of an ice sheet.