### PR TITLE
Fix Custom Specie Name

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -639,6 +639,7 @@ namespace Content.Client.Lobby.UI
             UpdateGenderControls();
             UpdateSkinColor();
             UpdateSpawnPriorityControls();
+            UpdateFlavorTextEdit();
             UpdateAgeEdit();
             UpdateEyePickers();
             UpdateSaveButton();

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -640,6 +640,7 @@ namespace Content.Client.Lobby.UI
             UpdateSkinColor();
             UpdateSpawnPriorityControls();
             UpdateFlavorTextEdit();
+            UpdateCustomSpecieNameEdit();
             UpdateAgeEdit();
             UpdateEyePickers();
             UpdateSaveButton();
@@ -1206,15 +1207,8 @@ namespace Content.Client.Lobby.UI
 
         private void UpdateCustomSpecieNameEdit()
         {
-            if (Profile == null)
-                return;
-
-            _customspecienameEdit.Text = Profile.Customspeciename ?? "";
-
-            if (!_prototypeManager.TryIndex<SpeciesPrototype>(Profile.Species, out var speciesProto))
-                return;
-
-            _ccustomspecienamecontainerEdit.Visible = speciesProto.CustomName;
+            var species = _species.Find(x => x.ID == Profile?.Species) ?? _species.First();
+            _ccustomspecienamecontainerEdit.Visible = species.CustomName;
         }
 
         private void UpdateFlavorTextEdit()

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1208,6 +1208,7 @@ namespace Content.Client.Lobby.UI
         private void UpdateCustomSpecieNameEdit()
         {
             var species = _species.Find(x => x.ID == Profile?.Species) ?? _species.First();
+            _customspecienameEdit.Text = string.IsNullOrEmpty(Profile?.Customspeciename) ? Loc.GetString(species.Name) : Profile.Customspeciename;
             _ccustomspecienamecontainerEdit.Visible = species.CustomName;
         }
 


### PR DESCRIPTION
# Description

Custom specie name wouldn't properly update when a different race was selected, or when you changed profiles.
This fixes that.
Also makes it so the text field is automatically filled with the default name instead of an empty space.
(and makes the species check less bad 😺 )

Solves #1101

---

<details><summary><h1>Media</h1></summary>
<p>

https://gyazo.com/63ba2d8a3456c19c70f25164ae42078d

</p>
</details>

---

# Changelog

:cl:
- fix: Custom specie name doesn't disappear in the editor anymore.
