### PR TITLE
[Fix] Cybereyes No Longer Reveal Identity.

### DIFF
--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -1,1 +1,1 @@
-examine-cybereyes-message = {$entity}'s eyes shine with a faint inner light.
+examine-cybereyes-message = {CAPITALIZE(POSS-ADJ($entity))} eyes shine with a faint inner light.


### PR DESCRIPTION
# Description

Fixes issue [reported in the discord.](https://discord.com/channels/1218698320155906090/1218698321053356060/1298139147428696095)

---
# Media
![image](https://github.com/user-attachments/assets/11bf61b5-caf0-4104-9224-f55b1c29c1b6)

---

# Changelog

:cl:
- fix: Cybereyes examine message no longer reveals person's identity.
