### PR TITLE
Fix High Amplification Trait Being the Wildest Scam in Human History

### DIFF
--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -150,7 +150,7 @@
         - LowAmplification
         - PowerOverwhelming
   psionicPowers:
-    - LowAmplification
+    - HighAmplification
 
 - type: trait
   id: PowerOverwhelming


### PR DESCRIPTION
# Description
Resolves #1132.

# Changelog
:cl:
- fix: Fixed the "high amplification" trait lowering your amplification instead of increasing it.