### PR TITLE
[Feature] Clicking on Health Alerty Now Displays Health State

### DIFF
--- a/Content.Server/Alert/Click/CheckHealth.cs
+++ b/Content.Server/Alert/Click/CheckHealth.cs
@@ -1,0 +1,44 @@
+﻿using Content.Server.Chat.Managers;
+using Content.Shared.Alert;
+using Content.Shared.Chat;
+using Content.Shared.Damage;
+using Content.Shared.HealthExaminable;
+using JetBrains.Annotations;
+using Robust.Server.Player;
+using Robust.Shared.Player;
+
+namespace Content.Server.Alert.Click;
+
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class CheckHealth : IAlertClick
+{
+    public void AlertClicked(EntityUid player)
+    {
+        var chatManager = IoCManager.Resolve<IChatManager>();
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var playerManager = IoCManager.Resolve<IPlayerManager>();
+
+        var healthExaminableSystem = entityManager.System<HealthExaminableSystem>();
+
+        if (!entityManager.TryGetComponent(player, out HealthExaminableComponent? healthExaminable) ||
+            !entityManager.TryGetComponent(player, out DamageableComponent? damageable) ||
+            !playerManager.TryGetSessionByEntity(player, out var session))
+            return;
+
+        var baseMsg = Loc.GetString("health-alert-start");
+        SendMessage(chatManager, baseMsg, session);
+        var markup = healthExaminableSystem.GetMarkup(player, (player, healthExaminable), damageable).ToMarkup();
+        SendMessage(chatManager, markup, session);
+    }
+
+    private static void SendMessage(IChatManager chatManager, string msg, ICommonSession session)
+    {
+        chatManager.ChatMessageToOne(ChatChannel.Emotes,
+            msg,
+            msg,
+            EntityUid.Invalid,
+            false,
+            session.Channel);
+    }
+}

--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -51,10 +51,9 @@ public sealed class HealthExaminableSystem : EntitySystem
         Entity<HealthExaminableComponent> examinable,
         DamageableComponent damageable)
     {
-        if (examiner == examinable.Owner && TryComp<SelfAwareComponent>(examinable, out var selfAware))
-            return CreateMarkupSelfAware(examinable, selfAware, examinable.Comp, damageable);
-
-        return CreateMarkup(examinable, examinable.Comp, damageable);
+        return examiner == examinable.Owner && TryComp<SelfAwareComponent>(examinable, out var selfAware)
+            ? CreateMarkupSelfAware(examinable, selfAware, examinable.Comp, damageable)
+            : CreateMarkup(examinable, examinable.Comp, damageable);
     }
 
     private FormattedMessage CreateMarkup(EntityUid uid, HealthExaminableComponent component, DamageableComponent damage)

--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -30,30 +30,34 @@ public sealed class HealthExaminableSystem : EntitySystem
 
         var detailsRange = _examineSystem.IsInDetailsRange(args.User, uid);
 
-        var verb = new ExamineVerb()
+        var verb = new ExamineVerb
         {
             Act = () =>
             {
-                FormattedMessage markup;
-                if (uid == args.User
-                    && TryComp<SelfAwareComponent>(uid, out var selfAware))
-                    markup = CreateMarkupSelfAware(uid, selfAware, component, damage);
-                else
-                    markup = CreateMarkup(uid, component, damage);
-
+                var markup = GetMarkup(args.User, (uid, component), damage);
                 _examineSystem.SendExamineTooltip(args.User, uid, markup, false, false);
             },
             Text = Loc.GetString("health-examinable-verb-text"),
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
             Message = detailsRange ? null : Loc.GetString("health-examinable-verb-disabled"),
-            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"))
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"))
         };
 
         args.Verbs.Add(verb);
     }
 
-    public FormattedMessage CreateMarkup(EntityUid uid, HealthExaminableComponent component, DamageableComponent damage)
+    public FormattedMessage GetMarkup(EntityUid examiner,
+        Entity<HealthExaminableComponent> examinable,
+        DamageableComponent damageable)
+    {
+        if (examiner == examinable.Owner && TryComp<SelfAwareComponent>(examinable, out var selfAware))
+            return CreateMarkupSelfAware(examinable, selfAware, examinable.Comp, damageable);
+
+        return CreateMarkup(examinable, examinable.Comp, damageable);
+    }
+
+    private FormattedMessage CreateMarkup(EntityUid uid, HealthExaminableComponent component, DamageableComponent damage)
     {
         var msg = new FormattedMessage();
 

--- a/Resources/Locale/en-US/health-examinable/health-examinable-comp.ftl
+++ b/Resources/Locale/en-US/health-examinable/health-examinable-comp.ftl
@@ -1,2 +1,4 @@
 ﻿health-examinable-verb-text = Health
 health-examinable-verb-disabled = Perform a basic health examination in close range.
+
+health-alert-start = [font size=12][color=green]Health:[/color][/font]

--- a/Resources/Locale/en-US/health-examinable/health-examinable-silicon.ftl
+++ b/Resources/Locale/en-US/health-examinable/health-examinable-silicon.ftl
@@ -1,4 +1,4 @@
-﻿health-examinable-silicon-none = There is no obvious damage to be seen.
+﻿health-examinable-silicon-none = [color=green]There is no obvious damage to be seen.[/color]
 
 health-examinable-silicon-Blunt-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor dents on { POSS-ADJ($target) } chassis.[/color]
 health-examinable-silicon-Blunt-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } chassis is severely dented![/color]

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -192,6 +192,7 @@
 - type: alert
   id: HumanHealth
   category: Health
+  onClick: !type:CheckHealth { }
   icons:
   - sprite: /Textures/Interface/Alerts/human_alive.rsi
     state: health0


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

I don't understand why it hasn't been done before tbf.

https://github.com/user-attachments/assets/6ea2a3eb-80ce-4905-b546-7b8902308533

---

# Changelog

:cl:
- add: Clicking on health alert now will print message in chat, displaying your health state.
