### PR TITLE
Remove LPO Shuttle Recalling

### DIFF
--- a/Resources/Maps/Shuttles/pirateradio.yml
+++ b/Resources/Maps/Shuttles/pirateradio.yml
@@ -5775,6 +5775,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 1
+    - type: CommunicationsConsole
+      color: gold
+      title: "Pirate Broadcast"
+      canShuttle: false
 - proto: SyndicateMonitoringServer
   entities:
   - uid: 338


### PR DESCRIPTION
# Description

The listening post being able to recall the shuttle was a little too much for people, but luckily it and a few other things are datafields. This PR removes the "Shuttle Recall" functionality for the communications console on the Listening Post, while also giving a custom broadcast announcement to the comms console so that it isn't just using the Nuclear Operative Announcement. This way the listening post isn't forcing people to call red alert by faking a nukie threat every round.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/97e0ca52-893b-4dd5-bc3b-bbb2a601236b)

</p>
</details>

# Changelog

:cl:
- tweak: The Syndicate Listening Post now has a custom communications console, which no longer can recall Nanotrasen shuttles, and doesn't sign its messages as Nuclear Operatives. 
