### PR TITLE
Mosin Rework  (#1391) Port over From Frontier 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -44,18 +44,56 @@
   name: Kardashev-Mosin
   parent: [BaseWeaponSniper, BaseGunWieldable]
   id: WeaponSniperMosin
-  description: A weapon for hunting, or endless trench warfare. Uses .30 rifle ammo.
+  description: A civilian grade weapon for hunting, or endless trench warfare. Uses .30 rifle ammo. Now with new shiny bayonet!
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+    state: base
+  - type: AmmoCounter
+  - type: Wieldable
+  - type: MeleeRequiresWield
+  - type: GunRequiresWield
+  - type: BallisticAmmoProvider
+    capacity: 5
+    proto: CartridgeLightRifle
   - type: Gun
-    fireRate: 0.75
+    useKey: true
+    fireRate: 1
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
     fireOnDropChance: 1
+  - type: MeleeWeapon
+    attackRate: .85
+    damage:
+      types:
+       Slash: 10
+       Piercing: 5
+    angle: 0
+    wideAnimationRotation: -135
+    animation: WeaponArcThrust
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    offset: 0.15,0.15
+  - type: ThrowingAngle
+    angle: -135
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 5
+        Piercing: 10
+  - type: Sharp
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+    - suitStorage
+    sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: DisarmMalus
+    malus: 0.225
 
 - type: entity
   name: Kardashev-Mosin
@@ -66,6 +104,10 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleRubber
+    whitelist:
+      tags:
+      - CartridgeLightRifle
+
 
 - type: entity
   name: Hristov


### PR DESCRIPTION
## About the PR
This is a port over from another server frontier to allow guns to have melee attacks with it 
https://github.com/new-frontiers-14/frontier-station-14/pull/1391
# Description

Rework the Mosin to allow Melee now, Butcher and Throwing 

## Why / Balance

Mosin is regarded as one of the worst weapons in the game, to the point that nearly no one uses it. Countless times, people have asked/requested to remove the bayonet from the Mosin sprite or give it the ability to be used as a melee weapon. Because Upstream changed/removed the coding for melee/range weapons, it is a bit funky, but I feel like it isn't that bad to the point where I would say it's terrible. 
1) Lower the Ammo capacity by 10 -> 5. Five is the IRL Standard ammo capacity for the mosin
2) Raised the Firing rate to 1  
3) Melee and Throw damage is the same.
    Attack rate of .85
         -  Piercing 10 (you are stabbing someone so it 
         - Slash 5  (you are pulling the bayonet out so it causes bleeding

## How to test
Spawn in the Mosin.  Shooting the rifle will now be Right click, where a  "pinpoint" melee attack is left click   however when the Ammo for the mosin runs dry the right click turns into a thrust attack  

## Media
**- [X] this PR does not require an in-game showcase**


# Changelog

Turns out the Bayonet had a sheath on it 

:cl:
- tweak: Turns out Mosin's Bayonet had a Sheath on it


