### PR TITLE
[Fix] Fixed Icons In Radial Menus

### DIFF
--- a/Content.Client/RadialSelector/RadialSelectorMenuBUI.cs
+++ b/Content.Client/RadialSelector/RadialSelectorMenuBUI.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Linq;
+using System.Numerics;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.RadialSelector;
@@ -6,6 +7,7 @@ using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
+using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
@@ -19,8 +21,9 @@ public sealed class RadialSelectorMenuBUI : BoundUserInterface
 {
     [Dependency] private readonly IClyde _displayManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
-    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IResourceCache _resources = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
 
     private readonly SpriteSystem _spriteSystem;
 
@@ -30,6 +33,7 @@ public sealed class RadialSelectorMenuBUI : BoundUserInterface
     private readonly HashSet<RadialContainer> _cachedContainers = new();
 
     private bool _openCentered;
+    private readonly Vector2 ItemSize = Vector2.One * 64;
 
     public RadialSelectorMenuBUI(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
@@ -95,10 +99,7 @@ public sealed class RadialSelectorMenuBUI : BoundUserInterface
             else if (entry.Prototype != null)
             {
                 var name = GetName(entry.Prototype);
-                var icon = GetIcon(entry);
-                if (icon is null)
-                    return;
-
+                var icon = GetTextures(entry);
                 var button = CreateButton(name, icon);
                 button.OnButtonUp += _ =>
                 {
@@ -115,42 +116,75 @@ public sealed class RadialSelectorMenuBUI : BoundUserInterface
     {
         if (_protoManager.TryIndex(proto, out var prototype))
             return prototype.Name;
+
         if (_protoManager.TryIndex(proto, out ConstructionPrototype? constructionPrototype))
             return constructionPrototype.Name;
+
         return proto;
     }
 
-    private Texture? GetIcon(RadialSelectorEntry entry)
+    private List<Texture> GetTextures(RadialSelectorEntry entry)
     {
+        var result = new List<Texture>();
+        if (entry.Icon is not null)
+        {
+            result.Add(_spriteSystem.Frame0(entry.Icon));
+            return result;
+        }
+
         if (_protoManager.TryIndex(entry.Prototype!, out var prototype))
-            return _spriteSystem.Frame0(prototype);
+        {
+            result.AddRange(SpriteComponent.GetPrototypeTextures(prototype, _resources).Select(o => o.Default));
+            return result;
+        }
 
         if (_protoManager.TryIndex(entry.Prototype!, out ConstructionPrototype? constructionProto))
-            return _spriteSystem.Frame0(constructionProto.Icon);
-
-        if (entry.Icon is not null)
-            return _spriteSystem.Frame0(entry.Icon);
+        {
+            result.Add(_spriteSystem.Frame0(constructionProto.Icon));
+            return result;
+        }
 
         // No icons provided and no icons found in prototypes. There's nothing we can do.
-        return null;
+        return result;
     }
 
     private RadialMenuTextureButton CreateButton(string name, Texture icon)
     {
-        var itemSize = new Vector2(64f, 64f);
         var button = new RadialMenuTextureButton
         {
             ToolTip = Loc.GetString(name),
             StyleClasses = { "RadialMenuButton" },
-            SetSize = itemSize
+            SetSize = ItemSize
         };
 
-        var iconScale = itemSize / icon.Size;
+        var iconScale = ItemSize / icon.Size;
         var texture = new TextureRect
         {
             VerticalAlignment = Control.VAlignment.Center,
             HorizontalAlignment = Control.HAlignment.Center,
             Texture = icon,
+            TextureScale = iconScale
+        };
+
+        button.AddChild(texture);
+        return button;
+    }
+
+    private RadialMenuTextureButton CreateButton(string name, List<Texture> icons)
+    {
+        var button = new RadialMenuTextureButton
+        {
+            ToolTip = Loc.GetString(name),
+            StyleClasses = { "RadialMenuButton" },
+            SetSize = ItemSize
+        };
+
+        var iconScale = ItemSize / icons[0].Size;
+        var texture = new LayeredTextureRect
+        {
+            VerticalAlignment = Control.VAlignment.Center,
+            HorizontalAlignment = Control.HAlignment.Center,
+            Textures = icons,
             TextureScale = iconScale
         };
 


### PR DESCRIPTION
# Description
Some of the icons consist of multiple layers so they were incorrectly displayed in radial selector menus. Now this system uses the same method PrototypeSelectorMenu uses.

![image](https://github.com/user-attachments/assets/49de1798-e909-4e0a-8495-ca52c227b121)
---

# Changelog

:cl:
- fix: Layered icons are now properly displayed in radial menus.
