### PR TITLE
Tweak Familiars

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -50,6 +50,13 @@
   - type: HTN
     rootTask:
       task: MeleePsionicFamiliarCompound
+    blackboard:
+      IdleRange: !type:Single
+        3.5
+      FollowCloseRange: !type:Single
+        2.0
+      FollowRange: !type:Single
+        3.0
   - type: NPCRetaliation
     attackMemoryLength: 10
     retaliateFriendlies: true


### PR DESCRIPTION
# Description

Default following distance for Psi Familiars was apparently >10 meters, making them have an extremely hard time following their Master in actual live servers. This PR tweaks them to have a maximum 3 meter following distance, the same as Rat Servants actually, so that they can more consistently follow their Master.

# Changelog

:cl:
- tweak: Changed the default "Following distance" of Psionic Familiars from 10 meters to 3 meters, so that they don't have an ungodly hard time keeping up with their Master.
