### PR TITLE
Show Language Names In Chat

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -880,6 +880,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         var color = DefaultSpeakColor;
         if (language.SpeechOverride.Color is { } colorOverride)
             color = Color.InterpolateBetween(color, colorOverride, colorOverride.A);
+        var languageDisplay = language.IsVisibleLanguage
+            ? $"{language.ChatName} | "
+            : "";
 
         return Loc.GetString(wrapId,
             ("color", color),
@@ -887,7 +890,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("verb", Loc.GetString(verbId)),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
             ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
-            ("message", message));
+            ("message", message),
+            ("language", languageDisplay));
     }
 
     /// <summary>

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -183,6 +183,9 @@ public sealed class RadioSystem : EntitySystem
         var languageColor = channel.Color;
         if (language.SpeechOverride.Color is { } colorOverride)
             languageColor = Color.InterpolateBetween(languageColor, colorOverride, colorOverride.A);
+        var languageDisplay = language.IsVisibleLanguage
+            ? $"{language.ChatName} | "
+            : "";
 
         return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", channel.Color),
@@ -192,7 +195,8 @@ public sealed class RadioSystem : EntitySystem
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("channel", $"\\[{channel.LocalizedName}\\]"),
             ("name", name),
-            ("message", message));
+            ("message", message),
+            ("language", languageDisplay));
     }
 
     /// <inheritdoc cref="TelecomServerComponent"/>

--- a/Content.Shared/Language/LanguagePrototype.cs
+++ b/Content.Shared/Language/LanguagePrototype.cs
@@ -7,7 +7,13 @@ namespace Content.Shared.Language;
 public sealed partial class LanguagePrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; private set;  } = default!;
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///     Whether this language will display its name in chat behind a player's name.
+    /// </summary>
+    [DataField]
+    public bool IsVisibleLanguage { get; set; }
 
     /// <summary>
     ///     Obfuscation method used by this language. By default, uses <see cref="ObfuscationMethod.Default"/>
@@ -26,6 +32,11 @@ public sealed partial class LanguagePrototype : IPrototype
     ///     The in-world name of this language, localized.
     /// </summary>
     public string Name => Loc.GetString($"language-{ID}-name");
+
+    /// <summary>
+    ///     The in-world chat abbreviation of this language, localized.
+    /// </summary>
+    public string ChatName => Loc.GetString($"chat-language-{ID}-name");
 
     /// <summary>
     ///     The in-world description of this language, localized.

--- a/Resources/Locale/en-US/chat/managers/chat-language.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-language.ftl
@@ -1,0 +1,15 @@
+chat-language-Universal-name = Universal
+chat-language-Bubblish-name = Bubblish
+chat-language-RootSpeak-name = RootSpeak
+chat-language-Nekomimetic-name = Neko
+chat-language-Draconic-name = Sinta'Unathi
+chat-language-Azaziba-name = Sinta'Azaziba
+chat-language-SolCommon-name = Sol Common
+chat-language-TauCetiBasic-name = Basic
+chat-language-Tradeband-name = Tradeband
+chat-language-Freespeak-name = Freespeak
+chat-language-Elyran-name = Elyran
+chat-language-Canilunzt-name = Canilunzt
+chat-language-Moffic-name = Moffic
+chat-language-RobotTalk-name = Binary
+chat-language-ValyrianStandard-name = Valyrian

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -21,10 +21,10 @@ chat-manager-whisper-headset-on-message = You can't whisper on the radio!
 chat-manager-server-wrap-message = [bold]{$message}[/bold]
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} Announcement:[/font][font size=12]
                                                 {$message}[/bold][/font]
-chat-manager-entity-say-wrap-message = [BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] {$verb}, "[BubbleContent][font="{$fontType}" size={$fontSize}][color={$color}]{$message}[/color][/font][/BubbleContent]"
-chat-manager-entity-say-bold-wrap-message = [BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] {$verb}, "[BubbleContent][font="{$fontType}" size={$fontSize}][color={$color}][bold]{$message}[/bold][/color][/font][/BubbleContent]"
+chat-manager-entity-say-wrap-message = [BubbleHeader][bold][Name]{ $language }{ $entityName }[/Name][/bold][/BubbleHeader] { $verb }, [font={ $fontType } size={ $fontSize } ]"[BubbleContent]{ $message }[/BubbleContent]"[/font]
+chat-manager-entity-say-bold-wrap-message = [BubbleHeader][bold][Name]{ $language }{ $entityName }[/Name][/bold][/BubbleHeader] { $verb }, [font={ $fontType } size={ $fontSize }]"[BubbleContent][bold]{ $message }[/bold][/BubbleContent]"[/font]
 
-chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] whispers, "[BubbleContent][font="{$fontType}"][color={$color}]{$message}[/color][/font][/BubbleContent]"[/italic][/font]
+chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][Name]{ $language }{ $entityName }[/Name][/BubbleHeader] шепчет,"[BubbleContent]{ $message }[/BubbleContent]"[/italic][/font]
 chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][BubbleHeader]Someone[/BubbleHeader] whispers, "[BubbleContent][font="{$fontType}"][color={$color}]{$message}[/color][/font][/BubbleContent]"[/italic][/font]
 
 # THE() is not used here because the entity and its name can technically be disconnected if a nameOverride is passed...

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,6 +1,6 @@
 # Chat window radio wrap (prefix and postfix)
-chat-radio-message-wrap = [color={$color}]{$channel} {$name} {$verb}, [font="{$fontType}" size={$fontSize}]"[/color][color={$languageColor}]{$message}[/color][color={$color}]"[/font][/color]
-chat-radio-message-wrap-bold = [color={$color}]{$channel} {$name} {$verb}, [font="{$fontType}" size={$fontSize}][bold]"[/color][color={$languageColor}]{$message}[/color][color={$color}]"[/bold][/font][/color]
+chat-radio-message-wrap = [color={ $color }]{ $channel } [bold]{ $language }{ $name }[/bold] { $verb }, [font={ $fontType } size={ $fontSize }]"{ $message }"[/font][/color]
+chat-radio-message-wrap-bold = [color={ $color }]{ $channel } [bold]{ $language }{ $name }[/bold] { $verb }, [font={ $fontType } size={ $fontSize }][bold]"{ $message }"[/bold][/font][/color]
 
 examine-headset-default-channel = Use {$prefix} for the default channel ([color={$color}]{$channel}[/color]).
 

--- a/Resources/Prototypes/Language/Species-Specific/diona.yml
+++ b/Resources/Prototypes/Language/Species-Specific/diona.yml
@@ -2,6 +2,7 @@
 # TODO: Replace this with a much better language.
 - type: language
   id: RootSpeak
+  isVisibleLanguage: true
   speech:
     color: "#ce5e14dd"
     fontId: Noganas

--- a/Resources/Prototypes/Language/Species-Specific/harpy.yml
+++ b/Resources/Prototypes/Language/Species-Specific/harpy.yml
@@ -1,5 +1,6 @@
 - type: language
   id: ValyrianStandard
+  isVisibleLanguage: true
   speech:
     fontId: Cambria
     color: "#008ecc"

--- a/Resources/Prototypes/Language/Species-Specific/marish.yml
+++ b/Resources/Prototypes/Language/Species-Specific/marish.yml
@@ -1,6 +1,7 @@
 # Spoken by shadowkins.
 - type: language
   id: Marish
+  isVisibleLanguage: true
   speech:
     color: "#be3cc5"
     fontId: Lymphatic

--- a/Resources/Prototypes/Language/Species-Specific/moth.yml
+++ b/Resources/Prototypes/Language/Species-Specific/moth.yml
@@ -2,6 +2,7 @@
 # TODO: Replace this with a much better language.
 - type: language
   id: Moffic
+  isVisibleLanguage: true
   speech:
     color: "#c7df2edd"
     fontId: Copperplate

--- a/Resources/Prototypes/Language/Species-Specific/nekomimetic.yml
+++ b/Resources/Prototypes/Language/Species-Specific/nekomimetic.yml
@@ -2,6 +2,7 @@
 # TODO: Replace this with a much better language.
 - type: language
   id: Nekomimetic
+  isVisibleLanguage: true
   speech:
     color: "#df57aaee"
     fontId: Manga

--- a/Resources/Prototypes/Language/Species-Specific/reptilian.yml
+++ b/Resources/Prototypes/Language/Species-Specific/reptilian.yml
@@ -1,6 +1,7 @@
 # Spoken by Unathi.
 - type: language
   id: Draconic
+  isVisibleLanguage: true
   speech:
     color: "#2aca2add"
   obfuscation:

--- a/Resources/Prototypes/Language/Species-Specific/slimeperson.yml
+++ b/Resources/Prototypes/Language/Species-Specific/slimeperson.yml
@@ -2,6 +2,7 @@
 # TODO: Replace this with a much better language.
 - type: language
   id: Bubblish
+  isVisibleLanguage: true
   speech:
     color: "#00a3e2dd"
     fontId: RubikBubbles

--- a/Resources/Prototypes/Language/Species-Specific/vulpkanin.yml
+++ b/Resources/Prototypes/Language/Species-Specific/vulpkanin.yml
@@ -2,6 +2,7 @@
 # TODO: Replace this with a much better language.
 - type: language
   id: Canilunzt
+  isVisibleLanguage: true
   speech:
     color: "#d69b3dcc"
   obfuscation:

--- a/Resources/Prototypes/Language/Standard/elyran.yml
+++ b/Resources/Prototypes/Language/Standard/elyran.yml
@@ -1,5 +1,6 @@
 - type: language
   id: Elyran
+  isVisibleLanguage: true
   speech:
     color: "#8282fbaa"
   obfuscation:

--- a/Resources/Prototypes/Language/Standard/freespeak.yml
+++ b/Resources/Prototypes/Language/Standard/freespeak.yml
@@ -1,5 +1,6 @@
 - type: language
   id: Freespeak
+  isVisibleLanguage: true
   speech:
     color: "#597d35"
   obfuscation:

--- a/Resources/Prototypes/Language/Standard/solcommon.yml
+++ b/Resources/Prototypes/Language/Standard/solcommon.yml
@@ -1,5 +1,6 @@
 - type: language
   id: SolCommon
+  isVisibleLanguage: true
   speech:
     color: "#8282fbaa"
   obfuscation:

--- a/Resources/Prototypes/Language/Standard/taucetibasic.yml
+++ b/Resources/Prototypes/Language/Standard/taucetibasic.yml
@@ -1,6 +1,7 @@
 # The "Default Language" other than Universal.
 - type: language
   id: TauCetiBasic
+  isVisibleLanguage: true
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1

--- a/Resources/Prototypes/Language/Standard/tradeband.yml
+++ b/Resources/Prototypes/Language/Standard/tradeband.yml
@@ -1,5 +1,6 @@
 - type: language
   id: Tradeband
+  isVisibleLanguage: true
   speech:
     color: "#597d35"
   obfuscation:

--- a/Resources/Prototypes/Language/genericlanguages.yml
+++ b/Resources/Prototypes/Language/genericlanguages.yml
@@ -3,6 +3,7 @@
 # with the Xenoglossy psionic power, as well as Ghosts, and AGhosts.
 - type: language
   id: Universal
+  isVisibleLanguage: true
   obfuscation:
     !type:ReplacementObfuscation
     replacement:
@@ -12,6 +13,7 @@
 # TODO: Replace this with much better languages. Yes, robots can have languages.
 - type: language
   id: RobotTalk
+  isVisibleLanguage: true
   speech:
     fontId: Monospace
   obfuscation:


### PR DESCRIPTION
# Description

Port of https://github.com/Lost-Paradise-Project/Lost-Paradise/pull/288 from Lost Paradise. This feature makes it so that the language you are speaking is shown in chat, preventing any confusion for players about what it is being spoken.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/25fa3e17-30bb-4ae7-8fbe-2114839c498d)

</p>
</details>

# Changelog

:cl:
- add: Languages are now shown in chat alongside character names. 
