### PR TITLE
Add Uranium, Gold, And Silver To Cargo Menu

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -107,3 +107,33 @@
   cost: 1000
   category: cargoproduct-category-name-materials
   group: market
+
+- type: cargoProduct
+  id: MaterialUranium
+  icon:
+    sprite: Objects/Materials/Sheets/other.rsi
+    state: uranium_3
+  product: CrateMaterialUranium
+  cost: 3000
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialGold
+  icon:
+    sprite: Objects/Materials/ingots.rsi
+    state: gold_3
+  product: CrateMaterialGold
+  cost: 3000
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialSilver
+  icon:
+    sprite: Objects/Materials/ingots.rsi
+    state: silver_3
+  product: CrateMaterialSilver
+  cost: 3000
+  category: cargoproduct-category-name-materials
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -127,3 +127,33 @@
 #    contents:
 #      - id: WaterTankFull
 #        amount: 1
+
+- type: entity
+  id: CrateMaterialUranium
+  name: uranium crate
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: SheetUranium
+        amount: 3
+
+- type: entity
+  id: CrateMaterialGold
+  name: gold crate
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: IngotGold
+        amount: 3
+
+- type: entity
+  id: CrateMaterialSilver
+  name: gold crate
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: IngotSilver
+        amount: 3


### PR DESCRIPTION
# Description

This is but a small update in the campaign to, "Make people hate Salvage less". This time, by adding Gold, Silver, and Uranium to the list of raw materials that can be ordered by Logi. This serves as an extremely useful failsafe for in the event that Salvage is Unwilling/Dead/Incompetent/Shitters and failing to provide these raw materials to the station. Now Logi can throw away station money at getting these valuable materials.

This is also extremely useful, since by ordering Uranium, it's possible for Logi to provide spare fuel for Engineering on the newly updated Saltern map. https://github.com/Simple-Station/Einstein-Engines/pull/1170
Which no longer has an AME, and instead contains a dedicated Generator Room to serve as backup power. One crate of Uranium can provide Saltern with power for up to 30 minutes. Longer if Engineering correctly sets up the Solar arrays. 

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/04d94031-955e-4d8d-b5f7-c677c353c4e9)

</p>
</details>

# Changelog

:cl:
- add: Cargo can now order crates of Uranium, Gold, and Silver. This is still far more expensive than getting the materials from Salvage, but serves as an incredibly useful failsafe in the event Salvage is Unwilling/Dead/Incompetent/Shitters.
