### PR TITLE
Syndicate Faction Comes From IFF Tags

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -116,9 +116,9 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
             Briefing = briefing
         }, mind, true);
 
-        // Change the faction
-        _npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
-        _npcFaction.AddFaction(traitor, component.SyndicateFaction);
+        // Don't Change the faction, this was stupid.
+        //_npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
+        //_npcFaction.AddFaction(traitor, component.SyndicateFaction);
 
         RaiseLocalEvent(traitor, new MoodEffectEvent("TraitorFocused"));
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -285,7 +285,9 @@ uplink-proximity-mine-name = Proximity Mine
 uplink-proximity-mine-desc = A mine disguised as a wet floor sign.
 
 uplink-disposable-turret-name = Disposable Ballistic Turret
-uplink-disposable-turret-desc = Looks and functions like a normal electrical toolbox. Upon hitting the toolbox it will transform into a ballistic turret, theoretically shooting at anyone except members of the syndicate. Can be turned back into a toolbox using a screwdriver and repaired using a wrench.
+uplink-disposable-turret-desc =
+    Looks and functions like a normal electrical toolbox. Upon hitting the toolbox it will transform into a ballistic turret, theoretically shooting at anyone except members of the syndicate.
+    Can be turned back into a toolbox using a screwdriver and repaired using a wrench. IF YOU DO NOT HAVE AN AGENT ID IN YOUR ID SLOT, OR SYNDICATE PDA, IT WILL FIRE UPON YOU.
 
 uplink-cluster-banana-peel-name = Cluster Banana
 uplink-cluster-banana-peel-desc = Splits into 6 explosive banana peels after being thrown, the peels detonate automatically after 20 seconds if nobody slips on them.

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -883,6 +883,8 @@
       whitelist:
         components:
           - Cartridge
+  - type: ClothingAddFaction
+    faction: Syndicate
 
 - type: entity
   parent: BasePDA
@@ -1229,3 +1231,5 @@
       whitelist:
         components:
           - Cartridge
+  - type: ClothingAddFaction
+    faction: Syndicate

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -906,6 +906,8 @@
         type: AgentIDCardBoundUserInterface
       enum.ChameleonUiKey.Key:
         type: ChameleonBoundUserInterface
+  - type: ClothingAddFaction
+    faction: Syndicate
 
 - type: entity
   name: passenger ID card

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -920,6 +920,8 @@
     - Maintenance
     - SyndicateAgent
     - NuclearOperative
+  - type: ClothingAddFaction
+    faction: Syndicate
 
 - type: entity
   parent: IDCardStandard
@@ -954,6 +956,8 @@
     tags:
     - NuclearOperative
     - SyndicateAgent
+  - type: ClothingAddFaction
+    faction: Syndicate
 
 - type: entity
   parent: IDCardStandard
@@ -972,6 +976,8 @@
     tags:
     - NuclearOperative
     - SyndicateAgent
+  - type: ClothingAddFaction
+    faction: Syndicate
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
# Description

This broadly fixes a big with Familiars such that, since they inherit a player's factions, they will attack whoever you are factionally opposed to. Which means if you were a Syndicate Chaplain, you could just summon your bat for free damage. This PR flips this on its head by making it so that Syndicate Agents don't have the Syndicate faction, unless they buy a Syndicate ID. This also means that Traitors cannot enter the Listening Outpost, or Nukie Shuttle, without being fired upon by the turrets, unless they are WEARING an Agent ID. 

However this also adds a cool new interaction for CREW. If you are an NT Crewman, and you get your hands on either an Agent ID or a Syndicate PDA, now you can enter a Listening Post or Nukie Shuttle without being fired upon by the turrets.

# Changelog

:cl:
- add: Syndicate Agents no longer have the Syndicate faction. Instead, the Syndicate faction comes from your SYNDICATE ID/PDA. This means that if you steal a Syndicate PDA from nukies, and wear it, you won't be shot by their turrets. This also means that syndicate turrets will fire at syndicate agents not wearing an agent ID.
- fix: Fixed Familiars spawned by traitors attacking crew constantly.
