### PR TITLE
Nerf The Shit Out Of Familiars

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -28,7 +28,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      50: Dead
   - type: Damageable
     damageContainer: CorporealSpirit
     damageModifierSet: CorporealSpirit
@@ -61,12 +61,11 @@
     attackMemoryLength: 10
     retaliateFriendlies: true
   - type: PsionicFamiliar
+  - type: Dispellable
   - type: DamageOnDispel
     damage:
       types:
         Heat: 100
-  - type: RandomMetadata
-    nameSegments: [names_golem]
 
 - type: entity
   name: Remilia
@@ -130,6 +129,10 @@
     damage:
       types:
         Piercing: 5
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      30: Dead
 
 - type: entity
   name: Cerberus
@@ -239,3 +242,5 @@
         - Opaque
         layer:
         - MobLayer
+  - type: RandomMetadata
+    nameSegments: [names_golem]


### PR DESCRIPTION
# Description

Familiars were hilariously overpowered.

# Changelog

:cl:
- fix: Familiars can now be Dispelled.
- tweak: Nerfed Remilia to have 30 HP.
- tweak: Nerfed Base Familiar to have 50 HP.
