### PR TITLE
Fix AddTrait And ReplaceTrait Functions

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -25,14 +25,11 @@ public sealed partial class TraitReplaceComponent : TraitFunction
         IEntityManager entityManager,
         ISerializationManager serializationManager)
     {
-        foreach (var (name, data) in Components)
+        foreach (var (_, data) in Components)
         {
-            var component = (Component) factory.GetComponent(name);
 
-            var temp = (object) component;
-            serializationManager.CopyTo(data.Component, ref temp);
-            entityManager.RemoveComponent(uid, temp!.GetType());
-            entityManager.AddComponent(uid, (Component) temp, true);
+            var comp = (Component) serializationManager.CreateCopy(data.Component, notNullableOverride: true);
+            entityManager.AddComponent(uid, comp, true);
         }
     }
 }
@@ -52,11 +49,13 @@ public sealed partial class TraitAddComponent : TraitFunction
         IEntityManager entityManager,
         ISerializationManager serializationManager)
     {
-        foreach (var (name, _) in Components)
+        foreach (var entry in Components.Values)
         {
-            var component = (Component) factory.GetComponent(name);
+            if (entityManager.HasComponent(uid, entry.Component.GetType()))
+                continue;
 
-            entityManager.AddComponent(uid, component, true);
+            var comp = (Component) serializationManager.CreateCopy(entry.Component, notNullableOverride: true);
+            entityManager.AddComponent(uid, comp, false);
         }
     }
 }

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -27,8 +27,8 @@ public sealed partial class TraitReplaceComponent : TraitFunction
     {
         foreach (var (_, data) in Components)
         {
-
             var comp = (Component) serializationManager.CreateCopy(data.Component, notNullableOverride: true);
+            comp.Owner = uid;
             entityManager.AddComponent(uid, comp, true);
         }
     }
@@ -55,7 +55,8 @@ public sealed partial class TraitAddComponent : TraitFunction
                 continue;
 
             var comp = (Component) serializationManager.CreateCopy(entry.Component, notNullableOverride: true);
-            entityManager.AddComponent(uid, comp, false);
+            comp.Owner = uid;
+            entityManager.AddComponent(uid, comp);
         }
     }
 }


### PR DESCRIPTION
# Description

Maintainer suggested changes broke the AddTrait and ReplaceTrait functionality of the Version 2 Trait Functions. This restores their functionality.

# Changelog

:cl:
- fix: Fixed AddTrait and ReplaceTrait functions giving players an unmodified, completely default component. 
