### PR TITLE
Add Missing `DOTNET_ROOT` Environment Variable For Nix Devs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -51,5 +51,6 @@ in pkgs.mkShell {
     export ROBUST_SOUNDFONT_OVERRIDE=${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2
     export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath dependencies}
+    export DOTNET_ROOT=${pkgs.dotnetCorePackages.sdk_8_0}
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -51,6 +51,7 @@ in pkgs.mkShell {
     export ROBUST_SOUNDFONT_OVERRIDE=${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2
     export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath dependencies}
-    export DOTNET_ROOT=${pkgs.dotnetCorePackages.sdk_8_0}
+    export DOTNET_ROOT=${pkgs.dotnetCorePackages.sdk_8_0_1xx}
+    export PATH="$PATH:/home/$(whoami)/.dotnet/tools"
   '';
 }


### PR DESCRIPTION
# Description

Added missing environment variable for nix-shell. I don't like everytime write `export DOTNET_ROOT="/path/to/folder"`, so it should be done by post script in `shell.nix`