### PR TITLE
Some Language Fixes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Chat.Systems;
 
 // Dear contributor. When I was introducing changes to this system only god and I knew what I was doing.
 // Now only god knows. Please don't touch this code ever again. If you do have to, increment this counter as a warning for others:
-// TOTAL_HOURS_WASTED_HERE_EE = 17
+// TOTAL_HOURS_WASTED_HERE_EE = 18
 
 // TODO refactor whatever active warzone this class and chatmanager have become
 /// <summary>

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -124,9 +124,7 @@ public sealed partial record PolymorphConfiguration
     {
         "LanguageKnowledge",
         "LanguageSpeaker",
-        "Muted",
-        "Grammar",
-        "Vocal"
+        "Grammar"
     };
 }
 

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -115,6 +115,19 @@ public sealed partial record PolymorphConfiguration
     [DataField(serverOnly: true)]
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan Cooldown = TimeSpan.Zero;
+
+    /// <summary>
+    /// The exact names of components to copy over when this polymorph is applied.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public HashSet<string> CopiedComponents = new()
+    {
+        "LanguageKnowledge",
+        "LanguageSpeaker",
+        "Muted",
+        "Grammar",
+        "Vocal"
+    };
 }
 
 public enum PolymorphInventoryChange : byte

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -399,6 +399,9 @@
       behaviors:
       - !type:GibBehavior { }
   - type: NonSpreaderZombie
+  - type: LanguageKnowledge
+    speaks: [Hissing]
+    understands: [Hissing]
 
 - type: entity
   name: glockroach
@@ -2104,6 +2107,9 @@
   - type: RandomBark
     barkType: penguin
     barkMultiplier: 0.6
+  - type: LanguageKnowledge
+    speaks: [Penguin]
+    understands: [Penguin]
 
 - type: entity
   name: grenade penguin
@@ -2224,6 +2230,9 @@
     minTime: 10
     maxTime: 50 # It's a sssnake...
     barkType: hissing
+  - type: LanguageKnowledge
+    speaks: [Hissing]
+    understands: [Hissing]
 
 # Code unique spider prototypes or combine them all into one spider and get a
 # random sprite state when you spawn it.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -161,3 +161,6 @@
   - type: NPCRetaliation
     attackMemoryLength: 10
   - type: NPCRangedCombat
+  # other
+  - type: LanguageSpeaker
+  - type: UniversalLanguageSpeaker # Should it speak unversal or some other language?

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -107,3 +107,5 @@
     powersToAdd:
       - XenoglossyPower
       - TelepathyPower
+  - type: LanguageSpeaker
+  - type: UniversalLanguageSpeaker

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -104,6 +104,10 @@
     - DoorBumpOpener
   - type: Input
     context: "human"
+  - type: LanguageSpeaker
+  - type: LanguageKnowledge
+    speaks: [TauCetiBasic, RobotTalk]
+    understands: [TauCetiBasic, RobotTalk]
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -48,6 +48,10 @@
   - type: GuideHelp
     guides:
       - Cyborgs
+  - type: LanguageSpeaker
+  - type: LanguageKnowledge
+    speaks: [TauCetiBasic, RobotTalk]
+    understands: [TauCetiBasic, RobotTalk]
 
 - type: entity
   parent: MMI
@@ -124,3 +128,7 @@
       guides:
       - Cyborgs
     - type: Organ # Estacao Pirata - IPCs
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks: [RobotTalk]
+      understands: [RobotTalk]

--- a/Resources/Prototypes/Language/animal.yml
+++ b/Resources/Prototypes/Language/animal.yml
@@ -184,3 +184,16 @@
     - iss
     - ss
     - is
+
+- type: language
+  id: Penguin
+  obfuscation:
+    !type:SyllableObfuscation
+    minSyllables: 2
+    maxSyllables: 3
+    replacement: # I'm out of ideas
+    - pen
+    - peng
+    - won
+    - wonk
+    - wong

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -103,6 +103,10 @@
         reagents:
         - ReagentId: Nothing
           Quantity: 1
+  - type: LanguageSpeaker
+  - type: LanguageKnowledge
+    speaks: [TauCetiBasic] # So that them foreigners can't understand what the broken mail is saying
+    understands: []
 
 # This empty parcel is allowed to exist and evade the tests for the admin
 # mailto command.


### PR DESCRIPTION
# Description
1. Adds languages to... penguins, cockroaches, snakes, mmis, pdas, mail packages. Positronic brains now only speak/understand the borg language.
2. Adds an explicitly defined universal language to revenants and wisps
3. Makes polymorphs copy over a list of components defined in the polymorph proto, thus copying languages and grammar of the original entity to its polymorphed version.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/111c3f91-f077-431f-bcd9-f60fa7a1ba26)

![image](https://github.com/user-attachments/assets/80f939d3-b615-4235-a511-82238758788e)

![image](https://github.com/user-attachments/assets/dce99b55-c8b1-4cbe-8769-b82151b3d404)

![image](https://github.com/user-attachments/assets/6b9b962d-c73c-42b9-b240-aa07601de879)



</p>
</details>

# Changelog
:cl:
- tweak: Added languages to certain entities that lacked them, including MMIs and positronic brains.
- add: Polymorphing into another entity now preserves your languages and grammar.