### PR TITLE
Pirate Radio Heisentest Fix

### DIFF
--- a/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
@@ -31,10 +31,6 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
     {
         base.Started(uid, component, gameRule, args);
 
-        /// SHUT UP HEISENTESTS. DIE. 
-        if (!_mapManager.MapExists(GameTicker.DefaultMap))
-            return;
-
         var stations = _gameTicker.GetSpawnableStations();
         if (stations is null)
             return;
@@ -52,6 +48,9 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
             return;
 
         var targetStation = _random.Pick(stations);
+        if (!_mapManager.MapExists(Transform(targetStation).MapID))
+            return; /// SHUT UP HEISENTESTS. DIE.
+
         var randomOffset = _random.NextVector2(component.MinimumDistance, component.MaximumDistance);
 
         var outpostOptions = new MapLoadOptions
@@ -60,7 +59,7 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
             LoadMap = false,
         };
 
-        if (!_map.TryLoad(GameTicker.DefaultMap, _random.Pick(component.PirateRadioShuttlePath), out var outpostids, outpostOptions))
+        if (!_map.TryLoad(Transform(targetStation).MapID, _random.Pick(component.PirateRadioShuttlePath), out var outpostids, outpostOptions))
             return;
 
         SpawnDebris(component, outpostids);

--- a/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
@@ -12,6 +12,7 @@ using Content.Server.GameTicking.Components;
 using Content.Shared.CCVar;
 using Robust.Shared.Serialization.Manager;
 using Content.Shared.Parallax.Biomes;
+using Robust.Shared.Map;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -24,10 +25,15 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
     [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
 
     protected override void Started(EntityUid uid, PirateRadioSpawnRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
+
+        /// SHUT UP HEISENTESTS. DIE. 
+        if (!_mapManager.MapExists(GameTicker.DefaultMap))
+            return;
 
         var stations = _gameTicker.GetSpawnableStations();
         if (stations is null)


### PR DESCRIPTION
# Description

I hate that I have to check if the map even exists at all. How the hell is there a station even existing in the first place if the default loaded map is NULLSPACE?! GetSpawnableStations should have returned a list containing zero stations if that was the case, which would then exit out.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.
I hate these stupid tests.

# Changelog

No CL because this isn't player facing.
