### PR TITLE
Day/Night Time Cycle For Maps

### DIFF
--- a/Content.Server/TimeCycle/TimeCycleSystem.cs
+++ b/Content.Server/TimeCycle/TimeCycleSystem.cs
@@ -1,0 +1,105 @@
+using Robust.Shared.Timing;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Map.Components;
+using Content.Shared.TimeCycle;
+
+namespace Content.Server.TimeCycle;
+
+public sealed partial class TimeCycleSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+    }
+
+    public override void Update(float frameTime)
+    {
+        var curTime = _gameTiming.CurTime;
+        var query = EntityQueryEnumerator<TimeCycleComponent, MapLightComponent>();
+
+        while (query.MoveNext(out var mapid, out var timeComp, out var mapLightComp))
+        {
+            if (timeComp.Paused)
+                continue;
+            if (curTime < timeComp.DelayTime)
+                continue;
+
+            // Should be used for developing time palletes or for debuging
+            // O-o-or... You can cosplay pucchi from JoJo 6 with his 'Made In Heaven'
+            if (timeComp.SpeedUp)
+                timeComp.DelayTime = curTime + timeComp.SpeedUpMinuteLength;
+            else
+                timeComp.DelayTime = curTime + timeComp.MinuteLength;
+
+            // Pass minute of map time
+            timeComp.CurrentTime += TimeSpan.FromMinutes(1);
+
+            // Change ambient color
+            UpdateAmbientColor(mapid, timeComp, mapLightComp);
+        }
+
+        base.Update(frameTime);
+    }
+
+    private void UpdateAmbientColor(EntityUid mapid, TimeCycleComponent timeComp, MapLightComponent mapLightComp)
+    {
+        if (!_prototypeManager.TryIndex(timeComp.Palette, out TimeCyclePalettePrototype? timeEntries))
+            return;
+        if (timeEntries is null)
+            return;
+
+        var timeInCycle = GetTimeInCycle(timeComp.CurrentTime);
+        mapLightComp.AmbientLightColor = GetInterpolatedColor(timeEntries, timeInCycle);
+        Dirty(mapid, mapLightComp);
+    }
+
+    // We should convert current 'TimeSpan' (with days) time into one day cycle time (in 24 hours)
+    private TimeSpan GetTimeInCycle(TimeSpan timeSpan)
+    {
+        double timeCycleMilliseconds = TimeSpan.FromHours(24).TotalMilliseconds;
+        double totalMilliseconds = timeSpan.TotalMilliseconds;
+        double timeInCycleMilliseconds = totalMilliseconds % timeCycleMilliseconds;
+
+        return TimeSpan.FromMilliseconds(timeInCycleMilliseconds);;
+    }
+
+    private Color GetInterpolatedColor(TimeCyclePalettePrototype proto, TimeSpan timeInCycle)
+    {
+        // If there is no one any time entries of palette - return black
+        if (proto.TimeEntries is null)
+            return Color.Black;
+
+        var currentTime = timeInCycle.TotalHours;
+        var startTime = -1;
+        var endTime = -1;
+
+        foreach (KeyValuePair<int, Color> kvp in proto.TimeEntries)
+        {
+            var hour = kvp.Key;
+            var color = kvp.Value;
+
+            if (hour <= currentTime)
+                startTime = hour;
+            else if (hour >= currentTime && endTime == -1)
+                endTime = hour;
+        }
+
+        if (startTime == -1)
+            startTime = 0;
+        else if (endTime == -1)
+            endTime = 23;
+
+        var entryStart = proto.TimeEntries[startTime];
+        var entryEnd = proto.TimeEntries[endTime];
+        var entryProgress = GetEntryProgress(TimeSpan.FromHours(startTime), TimeSpan.FromHours(endTime), timeInCycle);
+
+        return Color.InterpolateBetween(entryStart, entryEnd, entryProgress);
+    }
+
+    private float GetEntryProgress(TimeSpan startTime, TimeSpan endTime, TimeSpan currentTime) =>
+        ((float)(currentTime.TotalMinutes - startTime.TotalMinutes) / (float)(endTime.TotalMinutes - startTime.TotalMinutes));
+
+}

--- a/Content.Server/TimeCycle/TimeCycleSystem.cs
+++ b/Content.Server/TimeCycle/TimeCycleSystem.cs
@@ -30,9 +30,9 @@ public sealed partial class TimeCycleSystem : EntitySystem
             // Should be used for developing time palletes or for debuging
             // O-o-or... You can cosplay pucchi from JoJo 6 with his 'Made In Heaven'
             if (timeComp.SpeedUp)
-                timeComp.DelayTime = curTime + timeComp.SpeedUpMinuteLength;
+                timeComp.DelayTime = curTime + timeComp.SpeedUpMinuteDuration;
             else
-                timeComp.DelayTime = curTime + timeComp.MinuteLength;
+                timeComp.DelayTime = curTime + timeComp.MinuteDuration;
 
             // Pass minute of map time
             timeComp.CurrentTime += TimeSpan.FromMinutes(1);
@@ -46,7 +46,7 @@ public sealed partial class TimeCycleSystem : EntitySystem
 
     private void UpdateAmbientColor(EntityUid mapid, TimeCycleComponent timeComp, MapLightComponent mapLightComp)
     {
-        if (!_prototypeManager.TryIndex(timeComp.Palette, out TimeCyclePalettePrototype? timeEntries))
+        if (!_prototypeManager.TryIndex(timeComp.PalettePrototype, out TimeCyclePalettePrototype? timeEntries))
             return;
         if (timeEntries is null)
             return;

--- a/Content.Server/Toolshed/Commands/VisualizeCommand.cs
+++ b/Content.Server/Toolshed/Commands/VisualizeCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Administration;
 using Content.Server.EUI;
 using Content.Shared.Administration;

--- a/Content.Shared/TimeCycle/TimeCycleComponent.cs
+++ b/Content.Shared/TimeCycle/TimeCycleComponent.cs
@@ -1,0 +1,27 @@
+namespace Content.Shared.TimeCycle;
+
+[RegisterComponent]
+public sealed partial class TimeCycleComponent : Component
+{
+    // Delayed time, before minute have been passed
+    public TimeSpan? DelayTime;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool SpeedUp = false;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Paused = false;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string Palette = "DefaultTimeCycle";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan MinuteLength { get; set; } = TimeSpan.FromSeconds(4);
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan SpeedUpMinuteLength { get; set; } = TimeSpan.FromMilliseconds(10);
+
+    // NOTE: Default time should be is noon
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan CurrentTime { get; set; } = TimeSpan.FromHours(12);
+}

--- a/Content.Shared/TimeCycle/TimeCycleComponent.cs
+++ b/Content.Shared/TimeCycle/TimeCycleComponent.cs
@@ -13,15 +13,15 @@ public sealed partial class TimeCycleComponent : Component
     public bool Paused = false;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string Palette = "DefaultTimeCycle";
+    public TimeSpan MinuteDuration { get; set; } = TimeSpan.FromSeconds(4);
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan MinuteLength { get; set; } = TimeSpan.FromSeconds(4);
-
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan SpeedUpMinuteLength { get; set; } = TimeSpan.FromMilliseconds(10);
+    public TimeSpan SpeedUpMinuteDuration { get; set; } = TimeSpan.FromMilliseconds(10);
 
     // NOTE: Default time should be is noon
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan CurrentTime { get; set; } = TimeSpan.FromHours(12);
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string PalettePrototype = "DefaultTimeCycle";
 }

--- a/Content.Shared/TimeCycle/TimeCycleComponent.cs
+++ b/Content.Shared/TimeCycle/TimeCycleComponent.cs
@@ -6,22 +6,22 @@ public sealed partial class TimeCycleComponent : Component
     // Delayed time, before minute have been passed
     public TimeSpan? DelayTime;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool SpeedUp = false;
+    [DataField]
+    public bool SpeedUp;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool Paused = false;
+    [DataField]
+    public bool Paused;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan MinuteDuration { get; set; } = TimeSpan.FromSeconds(4);
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan SpeedUpMinuteDuration { get; set; } = TimeSpan.FromMilliseconds(10);
 
     // NOTE: Default time should be is noon
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan CurrentTime { get; set; } = TimeSpan.FromHours(12);
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public string PalettePrototype = "DefaultTimeCycle";
 }

--- a/Content.Shared/TimeCycle/TimeCyclePalettePrototype.cs
+++ b/Content.Shared/TimeCycle/TimeCyclePalettePrototype.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.TimeCycle;
+
+/// <summary>
+///
+/// </summary>
+[Prototype("timeCyclePalette")]
+public sealed partial class TimeCyclePalettePrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public Dictionary<int, Color> TimeEntries = default!;
+}

--- a/Resources/Prototypes/time_cycle_palletes.yml
+++ b/Resources/Prototypes/time_cycle_palletes.yml
@@ -1,0 +1,11 @@
+- type: timeCyclePalette
+  id: DefaultTimeCycle
+  timeEntries:
+    0:  "#000000"   # Night
+    2:  "#000000"   # Late night
+    6:  "#11122c"   # Sunrise
+    12: "#d8b059"   # Noon
+    18: "#73586b"   # Sunset
+    20: "#11122c"   # Dusk
+    21: "#000000"   # Early night
+    24: "#000000"   # Night

--- a/Resources/Prototypes/time_cycle_palletes.yml
+++ b/Resources/Prototypes/time_cycle_palletes.yml
@@ -3,22 +3,10 @@
   timeEntries:
     0:  "#000000"   # Night
     2:  "#000000"   # Late night
-    6:  "#11122c"   # Sunrise
-    12: "#d8b059"   # Noon
-    18: "#73586b"   # Sunset
-    20: "#11122c"   # Dusk
-    21: "#000000"   # Early night
-    24: "#000000"   # Night
-
-- type: timeCyclePalette
-  id: Fallout
-  timeEntries:
-    0:  "#000000"   # Night
-    2:  "#000000"   # Late night
     4:  "#02020b"   # Very-Early-Morning
-    5:  "#312716"   # Early-Dawn
-    6:  "#4E3D23"   # Dawn
-    7:  "#58372d"   # Sunrise
+    6:  "#312716"   # Early-Dawn
+    7:  "#4E3D23"   # Dawn
+    8:  "#58372d"   # Sunrise
     9:  "#876A42"   # Early-Morning
     10: "#A08042"   # Mid-Morning
     12: "#A88F73"   # Noon
@@ -27,4 +15,16 @@
     18: "#8C6130"   # Sunset
     20: "#543521"   # Dusk
     22: "#02020b"   # Early night
+    24: "#000000"   # Night
+
+- type: timeCyclePalette
+  id: Gothic
+  timeEntries:
+    0:  "#000000"   # Night
+    2:  "#000000"   # Late night
+    6:  "#11122c"   # Sunrise
+    12: "#d8b059"   # Noon
+    18: "#73586b"   # Sunset
+    20: "#11122c"   # Dusk
+    21: "#000000"   # Early night
     24: "#000000"   # Night

--- a/Resources/Prototypes/time_cycle_palletes.yml
+++ b/Resources/Prototypes/time_cycle_palletes.yml
@@ -9,3 +9,22 @@
     20: "#11122c"   # Dusk
     21: "#000000"   # Early night
     24: "#000000"   # Night
+
+- type: timeCyclePalette
+  id: Fallout
+  timeEntries:
+    0:  "#000000"   # Night
+    2:  "#000000"   # Late night
+    4:  "#02020b"   # Very-Early-Morning
+    5:  "#312716"   # Early-Dawn
+    6:  "#4E3D23"   # Dawn
+    7:  "#58372d"   # Sunrise
+    9:  "#876A42"   # Early-Morning
+    10: "#A08042"   # Mid-Morning
+    12: "#A88F73"   # Noon
+    14: "#C1A78A"   # Early-Afternoon
+    16: "#7D6244"   # Afternoon
+    18: "#8C6130"   # Sunset
+    20: "#543521"   # Dusk
+    22: "#02020b"   # Early night
+    24: "#000000"   # Night


### PR DESCRIPTION
# Description

Add real world Day/Night cycle changing, with Ambient color interpolation and some configurable features for mappers. 
High inspired by [Nuclear-14](https://github.com/Vault-Overseers/nuclear-14.git) and [Crystall Punk 14](https://github.com/crystallpunk-14/)

TimeCycle use 24h day calculation, instead coefficient, like in N14. 

---

# TODO

[ ] - Add more examples/prepared map palettes for Day/Night ambient.
[ ] - (Optional) Move all palette description into List of variables, instead calling `IPrototypeManager` every minute passing.

---

https://github.com/user-attachments/assets/cc5d1b8c-bd25-4042-8cee-e2edfa0d9acc

![image](https://github.com/user-attachments/assets/abcdc11d-fdb1-4b48-8599-0116a5797f8b)

---

# Changelog

:cl:
- add: Added Day/Night time cycle for admins and mapers.