### PR TITLE
Give Monkeys and Kobolds a Brain.

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -31,6 +31,38 @@
   - type: Gibbable
 
 - type: entity
+  id: OrganAnimalBrain
+  parent: BaseAnimalOrgan
+  name: brain
+  noSpawn: true
+  components:
+  - type: Sprite
+    state: brain
+  - type: Organ
+    slotId: brain
+  - type: Input
+    context: "ghost"
+  - type: Brain
+  - type: InputMover
+  - type: Examiner
+  - type: BlockMovement
+  - type: BadFood
+  - type: Tag
+    tags:
+      - Meat
+  - type: SolutionContainerManager
+    solutions:
+      organ:
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: GreyMatter
+          Quantity: 5
+
+- type: entity
   id: OrganAnimalLungs
   parent: BaseAnimalOrgan
   name: lungs

--- a/Resources/Prototypes/Body/Prototypes/primate.yml
+++ b/Resources/Prototypes/Body/Prototypes/primate.yml
@@ -9,6 +9,7 @@
       - hands
       - legs
       organs:
+        brain: OrganAnimalBrain
         lungs: OrganAnimalLungs
         stomach: OrganAnimalStomach
         liver: OrganAnimalLiver

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1298,6 +1298,8 @@
       types:
         Blunt: 3
         Piercing: 3
+  - type: MindContainer
+    showExamineInfo: true
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
# Description

This Pull Request gives monkeys and kobolds a brain (and a MindContainer).
This Pull Request's changes are licensed under MIT.

---

# Media
(This is from a harpy's filtered view, but you get the idea).
![Screenshot from 2024-11-17 13-57-52](https://github.com/user-attachments/assets/e4a0703b-451d-46b3-9285-5f4b3fd75415)

---

# Changelog

:cl:
- add: Monkeys and kobolds now have brains.