### PR TITLE
Power Attack Stamina Update

### DIFF
--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Chat;
@@ -60,6 +61,15 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         if (damageSpec * component.HeavyDamageBaseModifier != damageSpec)
             _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
+
+        if (component.HeavyStaminaCost != 0)
+        {
+            var staminaCostMarkup = FormattedMessage.FromMarkupOrThrow(
+                Loc.GetString("damage-melee-heavy-stamina-cost",
+                ("type", Loc.GetString("damage-melee-heavy")), ("cost", component.HeavyStaminaCost)));
+            args.Message.PushNewline();
+            args.Message.AddMessage(staminaCostMarkup);
+        }
     }
 
     protected override bool ArcRaySuccessful(EntityUid targetUid, Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId,

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -545,13 +545,6 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         if (targetMap.MapId != userXform.MapID)
             return false;
 
-        var userPos = TransformSystem.GetWorldPosition(userXform);
-        var direction = targetMap.Position - userPos;
-        var distance = Math.Min(component.Range * component.HeavyRangeModifier, direction.Length());
-
-        var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
-        var entities = GetEntityList(ev.Entities);
-
         if (TryComp<StaminaComponent>(user, out var stamina))
         {
             if (stamina.CritThreshold - stamina.StaminaDamage <= component.HeavyStaminaCost)
@@ -562,6 +555,13 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
 
             _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false);
         }
+
+        var userPos = TransformSystem.GetWorldPosition(userXform);
+        var direction = targetMap.Position - userPos;
+        var distance = Math.Min(component.Range * component.HeavyRangeModifier, direction.Length());
+
+        var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
+        var entities = GetEntityList(ev.Entities);
 
         if (entities.Count == 0)
         {

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -552,6 +552,17 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
         var entities = GetEntityList(ev.Entities);
 
+        if (TryComp<StaminaComponent>(user, out var stamina))
+        {
+            if (stamina.CritThreshold - stamina.StaminaDamage <= component.HeavyStaminaCost)
+            {
+                PopupSystem.PopupClient(Loc.GetString("melee-heavy-no-stamina"), meleeUid, user);
+                return false;
+            }
+
+            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false);
+        }
+
         if (entities.Count == 0)
         {
             if (meleeUid == user)
@@ -669,10 +680,6 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         {
             DoDamageEffect(targets, user, Transform(targets[0]));
         }
-
-        if (TryComp<StaminaComponent>(user, out var stamina))
-            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina);
-
 
         return true;
     }

--- a/Resources/Locale/en-US/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/damage/damage-examine.ftl
@@ -11,3 +11,5 @@ damage-throw = throw
 damage-examine = It does the following damage:
 damage-examine-type = It does the following [color=cyan]{$type}[/color] damage:
 damage-value = - [color=red]{$amount}[/color] units of [color=yellow]{$type}[/color].
+
+damage-melee-heavy-stamina-cost = A [color=cyan]{$type}[/color] costs [color=orange]{$cost}[/color] [color=yellow]Stamina[/color].

--- a/Resources/Locale/en-US/weapons/melee/melee.ftl
+++ b/Resources/Locale/en-US/weapons/melee/melee.ftl
@@ -5,3 +5,5 @@ melee-balloon-pop = {CAPITALIZE(THE($balloon))} popped!
 
 # BatteryComponent
 melee-battery-examine = It has enough charge for [color={$color}]{$count}[/color] hits.
+
+melee-heavy-no-stamina = You are too tired to perform a power attack!


### PR DESCRIPTION
# Description
QoL updates to improve the stamina management experience with power attacks:
- The stamina cost of an object's power attack can be revealed by examining its damage values. 
- Power attacks can't be done if your stamina is too low, so you can't accidentally stamcrit yourself with power attacks anymore.
- **Nerf:** Power attacks now cost stamina even without hitting anything.
- Prevent power attacks from showing a blue visual effect on the character who attacked due to stamina damage.

## Media

**Gameplay**

https://github.com/user-attachments/assets/f5031ce3-8303-475a-9c37-d8004ed55dbc

**Damage Examine**

<img src="https://github.com/user-attachments/assets/82821d5a-176b-4edf-93c4-f08f9c104c7a" width=300px>
<img src="https://github.com/user-attachments/assets/6347db9f-11e3-45fd-8317-f132a125082a" width=300px>

## Changelog

:cl: Skubman
- add: The stamina cost of an object's power attack can now be revealed by examining its damage values. 
- tweak: Power attacks can't be done if your stamina is too low, so you can't accidentally stamcrit yourself with power attacks anymore.
- tweak: Power attacks now cost stamina even without hitting anything.
- tweak: Prevent power attacks from showing a blue visual effect on the character who attacked due to stamina damage.