### PR TITLE
Shitmed Surgery Popups

### DIFF
--- a/Content.Shared/Medical/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/Medical/Surgery/SharedSurgerySystem.Steps.cs
@@ -9,6 +9,7 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Medical.Surgery.Conditions;
 using Content.Shared.Medical.Surgery.Effects.Step;
 using Content.Shared.Medical.Surgery.Steps;
@@ -622,7 +623,21 @@ public abstract partial class SharedSurgerySystem
             BreakOnHandChange = true,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+        {
+            var userName = Identity.Entity(user, EntityManager);
+            var targetName = Identity.Entity(ent.Owner, EntityManager);
+
+            var locName = $"surgery-popup-procedure-{args.Surgery}-step-{args.Step}";
+            var locResult = Loc.GetString(locName,
+                ("user", userName), ("target", targetName), ("part", part));
+
+            if (locResult == locName)
+                locResult = Loc.GetString($"surgery-popup-step-{args.Step}",
+                    ("user", userName), ("target", targetName), ("part", part));
+
+            _popup.PopupEntity(locResult, user);
+        }
     }
 
     private (Entity<SurgeryComponent> Surgery, int Step)? GetNextStep(EntityUid body, EntityUid part, Entity<SurgeryComponent?> surgery, List<EntityUid> requirements)

--- a/Resources/Locale/en-US/surgery/surgery-popup.ftl
+++ b/Resources/Locale/en-US/surgery/surgery-popup.ftl
@@ -1,0 +1,52 @@
+surgery-popup-step-SurgeryStepOpenIncisionScalpel = {$user} is making an incision on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepClampBleeders = {$user} is clamping the bleeders on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRetractSkin = {$user} is retracting the skin on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepSawBones = {$user} is sawing through the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepPriseOpenBones = {$user} is prising the bones open on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepCloseBones = {$user} is closing the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepMendRibcage = {$user} is mending the ribcage on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepCloseIncision = {$user} is closing the incision on {$target}'s {$part}.
+
+surgery-popup-step-SurgeryStepInsertFeature = {$user} is inserting something onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachHead-step-SurgeryStepInsertFeature = {$user} is attaching a head onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftArm-step-SurgeryStepInsertFeature = {$user} is attaching a left arm onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightArm-step-SurgeryStepInsertFeature = {$user} is attaching a right arm onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftLeg-step-SurgeryStepInsertFeature = {$user} is attaching a left leg onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightLeg-step-SurgeryStepInsertFeature = {$user} is attaching a right leg onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftHand-step-SurgeryStepInsertFeature = {$user} is attaching a left hand onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightHand-step-SurgeryStepInsertFeature = {$user} is attaching a right hand onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftFoot-step-SurgeryStepInsertFeature = {$user} is attaching a left foot onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightFoot-step-SurgeryStepInsertFeature = {$user} is attaching a right foot onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLegs-step-SurgeryStepInsertFeature = {$user} is attaching legs onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachHands-step-SurgeryStepInsertFeature = {$user} is attaching hands onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachFeet-step-SurgeryStepInsertFeature = {$user} is attaching feet onto {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepSealWounds = {$user} is sealing the wounds on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepSawFeature = {$user} is sawing through the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepClampInternalBleeders = {$user} is clamping the internal bleeders on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRemoveFeature = {$user} is amputating {$target}'s {$part}!
+surgery-popup-step-SurgeryStepCarefulIncisionScalpel = {$user} is carefully making an incision on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRepairBruteTissue = {$user} is repairing the damaged tissues on {$target}'s {$part}!
+surgery-popup-step-SurgeryStepRepairBurnTissue = {$user} is repairing the burnt tissues on {$target}'s {$part}!
+surgery-popup-step-SurgeryStepSealTendWound = {$user} is sealing the wounds on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepInsertItem = {$user} is inserting something into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepRemoveItem = {$user} is removing something from {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepRemoveOrgan = {$user} is removing an organ from {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertOrgan = {$user} is inserting an organ into {$target}'s {$part}!
+
+surgery-popup-procedure-SurgeryRemoveBrain-step-SurgeryStepRemoveOrgan = {$user} is removing the brain from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveHeart-step-SurgeryStepRemoveOrgan = {$user} is removing the heart from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveLiver-step-SurgeryStepRemoveOrgan = {$user} is removing the liver from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveLungs-step-SurgeryStepRemoveOrgan = {$user} is removing the lungs from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveEyes-step-SurgeryStepRemoveOrgan = {$user} is removing the eyes from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveStomach-step-SurgeryStepRemoveOrgan = {$user} is removing the stomach from {$target}'s {$part}!
+
+surgery-popup-procedure-SurgeryInsertBrain-step-SurgeryStepInsertOrgan = {$user} is inserting a brain into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertLungs = {$user} is inserting lungs into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertLiver = {$user} is inserting a liver into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertEyes = {$user} is inserting eyes into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertHeart = {$user} is inserting a heart into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertStomach = {$user} is inserting a stomach into {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepSealOrganWound = {$user} is sealing the wounds on {$target}'s {$part}.


### PR DESCRIPTION
# Description

Adds popups for surgery steps in Shitmed that every player within PVS range can see. This allows other players to see if the correct procedure is being performed. This PR also includes locale text for the new procedures and steps in #1240.

## Media

**Remove Brain / Insert Brain**

https://github.com/user-attachments/assets/ac20afa1-df74-48ab-b1d5-2e9a273dfba2

<details><summary>See more</summary>

**Amputate Right Arm**

https://github.com/user-attachments/assets/17f78683-6d3b-44ee-aea3-bb6987844fdc

**Attach Right Arm**

https://github.com/user-attachments/assets/584d4da2-d8b0-4c82-a323-26636e7fa4b8

</details>

## Changelog

:cl: Skubman
- add: Surgery step descriptions (like making an incision, removing/attaching limbs and organs) are now shown as popups to everyone in range upon the start of the step. This makes it clear which surgical procedure is being done and to which body part. No more stealthy brain-stealing in front of everyone!
