### PR TITLE
Fix Self-Aware Crashing Client

### DIFF
--- a/Content.Shared/Traits/Assorted/Components/SelfAwareComponent.cs
+++ b/Content.Shared/Traits/Assorted/Components/SelfAwareComponent.cs
@@ -8,19 +8,19 @@ namespace Content.Shared.Traits.Assorted.Components;
 /// <summary>
 ///     This is used for the Self-Aware trait to enhance the information received from HealthExaminableSystem.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SelfAwareComponent : Component
 {
     // <summary>
     //     Damage types that an entity is able to precisely analyze like a health analyzer when they examine themselves.
     // </summary>
-    [DataField(required: true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<DamageTypePrototype>))]
+    [DataField(required: true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<DamageTypePrototype>)), AutoNetworkedField]
     public HashSet<string> AnalyzableTypes = default!;
 
     // <summary>
     //     Damage groups that an entity is able to detect the presence of when they examine themselves.
     // </summary>
-    [DataField(required: true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<DamageGroupPrototype>))]
+    [DataField(required: true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<DamageGroupPrototype>)), AutoNetworkedField]
     public HashSet<string> DetectableGroups = default!;
 
     // <summary>


### PR DESCRIPTION
# Description
Quick fix to prevent the Self-Aware trait from crashing the client of a player when examining their character's health.

[`HealthExaminableSystem.CreateMarkupSelfAware`](https://github.com/Simple-Station/Einstein-Engines/blob/6945e3027bc14eac1de0099d30f8f35b19a3034e/Content.Shared/HealthExaminable/HealthExaminableSystem.cs#L119) attempts to access the `AnalyzableTypes` and `DetectableGroups` data fields from [`SelfAwareComponent`](https://github.com/Simple-Station/Einstein-Engines/blob/6945e3027bc14eac1de0099d30f8f35b19a3034e/Content.Shared/Traits/Assorted/Components/SelfAwareComponent.cs), but since they are only initialized in the server and `null` in the client, the client crashes. I believe this could be related to the recent trait overhauls, but not sure. I just fixed it by adding `AutoNetworkedField` to those fields to automatically propagate the initialized values. Other traits might have a similar bug to this.

## Changelog

:cl: Skubman
- fix: Examining yourself with the Self-Aware trait will no longer crash your game client.