### PR TITLE
Feat: Anomaly Scanner Data Copying

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -87,17 +87,24 @@ public sealed partial class AnomalySystem
 
     private void OnScannerAfterInteract(EntityUid uid, AnomalyScannerComponent component, AfterInteractEvent args)
     {
-        if (args.Target is not { } target)
-            return;
-        if (!HasComp<AnomalyComponent>(target))
-            return;
-        if (!args.CanReach)
+        if (args.Target is not { } target || !args.CanReach)
             return;
 
-        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.ScanDoAfterDuration, new ScannerDoAfterEvent(), uid, target: target, used: uid)
+        // If interacting with an anomaly, start a scan do-after
+        if (HasComp<AnomalyComponent>(target))
+            _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.ScanDoAfterDuration, new ScannerDoAfterEvent(), uid, target: target, used: uid)
+            {
+                DistanceThreshold = 2f
+            });
+
+        // If interacting with another scanner, copy the anomaly data
+        if (component.ScannedAnomaly is not { Valid: true }
+            && TryComp<AnomalyScannerComponent>(args.Target, out var otherScanner)
+            && otherScanner.ScannedAnomaly is {} otherAnomaly)
         {
-            DistanceThreshold = 2f
-        });
+            UpdateScannerWithNewAnomaly(uid, otherAnomaly, component);
+            Popup.PopupEntity(Loc.GetString("anomaly-scanner-scan-copied"), uid);
+        }
     }
 
     private void OnDoAfter(EntityUid uid, AnomalyScannerComponent component, DoAfterEvent args)

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -12,6 +12,7 @@ anomaly-particles-omega = Omega particles
 anomaly-particles-sigma = Sigma particles
 
 anomaly-scanner-component-scan-complete = Scan complete!
+anomaly-scanner-scan-copied = Copied anomaly scan data!
 
 anomaly-scanner-ui-title = anomaly scanner
 anomaly-scanner-no-anomaly = No anomaly currently scanned.
@@ -79,7 +80,7 @@ anomaly-generator-flavor-right = v1.1
 anomaly-behavior-unknown = [color=red]ERROR. Cannot be read.[/color]
 
 anomaly-behavior-title = behavior deviation analysis:
-anomaly-behavior-point =[color=gold]Anomaly produces {$mod}% of the points[/color] 
+anomaly-behavior-point =[color=gold]Anomaly produces {$mod}% of the points[/color]
 
 anomaly-behavior-safe = [color=forestgreen]The anomaly is extremely stable. Extremely rare pulsations.[/color]
 anomaly-behavior-slow = [color=forestgreen]The frequency of pulsations is much less frequent.[/color]


### PR DESCRIPTION
# Description
Makes it so that using one anomaly scanner on another transfers the anomaly data onto the used scanner.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b212e6e8-58a3-4a64-a216-3ba496a81d4a)

</p>
</details>

# Changelog
:cl:
- add: You can now touch one anomaly scanner with another to copy the anomaly scan data from it.