### PR TITLE
Update PirateRadioSpawnRule.cs

### DIFF
--- a/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
@@ -48,9 +48,6 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
             return;
 
         var targetStation = _random.Pick(stations);
-        if (!_mapManager.MapExists(Transform(targetStation).MapID))
-            return; /// SHUT UP HEISENTESTS. DIE.
-
         var randomOffset = _random.NextVector2(component.MinimumDistance, component.MaximumDistance);
 
         var outpostOptions = new MapLoadOptions


### PR DESCRIPTION
# Description

Pirate radio wasn't spawning. My "Shut the fuck up Heisentests" bug apparently is under the hood secretly just checking if the station was on "THE FIRST MAP IN THE LIST", and not actually Nullspace. Which is extremely fucking stupid and I hate this shit.

# Changelog

:cl:
- fix: Fixed Listening Posts not correctly spawning.
