### PR TITLE
Fix Power Attacks Being Faster Than Left Clicks

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -48,16 +48,16 @@ public sealed partial class MeleeWeaponComponent : Component
      */
 
     /// <summary>
-    /// How many times we can attack per second.
+    /// How many seconds between attacks must you wait in order to swing.
     /// </summary>
     [DataField, AutoNetworkedField]
     public float AttackRate = 1f;
 
     /// <summary>
-    ///     When power attacking, the swing speed (in attacks per second) is multiplied by this amount
+    ///     When power attacking, the required cooldown between swings is multiplied by this amount.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HeavyRateModifier = 0.8f;
+    public float HeavyRateModifier = 1.2f;
     /// <summary>
     /// Are we currently holding down the mouse for an attack.
     /// Used so we can't just hold the mouse button and attack constantly.

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -364,7 +364,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
                     return false;
                 break;
             case HeavyAttackEvent:
-                fireRateSwingModifier *= weapon.HeavyRateModifier;
+                fireRateSwingModifier = weapon.HeavyRateModifier;
                 break;
             default:
                 if (!Blocker.CanAttack(user, weapon: (weaponUid, weapon)))

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -373,7 +373,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         }
 
         // Windup time checked elsewhere.
-        var fireRate = TimeSpan.FromSeconds(1f / GetAttackRate(weaponUid, user, weapon) * fireRateSwingModifier);
+        var fireRate = TimeSpan.FromSeconds(GetAttackRate(weaponUid, user, weapon) * fireRateSwingModifier);
         var swings = 0;
 
         // TODO: If we get autoattacks then probably need a shotcounter like guns so we can do timing properly.


### PR DESCRIPTION
# Description

This fixes some stupid math. Power attacks are now correctly slower than left clicks. Previously they were faster.

# Changelog

:cl:
- fix: Power Attacks now correctly apply a penalty on swing speed, and are no longer faster than left clicking.
