### PR TITLE
Rename "Pierce" Typo to "Piercing"

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Targeting.cs
@@ -31,7 +31,7 @@ public partial class SharedBodySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
 
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    private readonly string[] _severingDamageTypes = { "Slash", "Pierce", "Blunt" };
+    private readonly string[] _severingDamageTypes = { "Slash", "Piercing", "Blunt" };
     private const double IntegrityJobTime = 0.005;
     private readonly JobQueue _integrityJobQueue = new(IntegrityJobTime);
     public sealed class IntegrityJob : Job<object>

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -43,7 +43,7 @@
     attackRate: 0.8
     damage:
       types:
-        Pierce: 7
+        Piercing: 7
     heavyRateModifier: 0.9
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -21,7 +21,7 @@
     damage:
       types:
         Blunt: 6
-        Pierce: 3
+        Piercing: 3
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
     maxTargets: 5


### PR DESCRIPTION
# Description

Oops. Some files refer to the non-existent **Pierce** damage type when the proper name is **Piercing**.

# Changelog

:cl: Skubman
- fix: Piercing damage can now dismember body parts, just like Blunt and Slash damage.
