### PR TITLE
[QoL] Show Oni Damage Bonus In Damage Examine

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.Tools.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Nyanotrasen.Abilities.Oni;
+using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Containers;
@@ -19,8 +20,7 @@ namespace Content.Server.Abilities.Oni
             base.Initialize();
             SubscribeLocalEvent<OniComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
             SubscribeLocalEvent<OniComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
-            SubscribeLocalEvent<OniComponent, MeleeHitEvent>(OnOniMeleeHit);
-            SubscribeLocalEvent<HeldByOniComponent, MeleeHitEvent>(OnHeldMeleeHit);
+            SubscribeLocalEvent<MeleeWeaponComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
             SubscribeLocalEvent<HeldByOniComponent, TakeStaminaDamageEvent>(OnStamHit);
         }
 
@@ -55,17 +55,12 @@ namespace Content.Server.Abilities.Oni
             RemComp<HeldByOniComponent>(args.Entity);
         }
 
-        private void OnOniMeleeHit(EntityUid uid, OniComponent component, MeleeHitEvent args)
+        private void OnGetMeleeDamage(EntityUid uid, MeleeWeaponComponent component, ref GetMeleeDamageEvent args)
         {
-            args.ModifiersList.Add(component.MeleeModifiers);
-        }
-
-        private void OnHeldMeleeHit(EntityUid uid, HeldByOniComponent component, MeleeHitEvent args)
-        {
-            if (!TryComp<OniComponent>(component.Holder, out var oni))
+            if (!TryComp<OniComponent>(args.User, out var oni))
                 return;
 
-            args.ModifiersList.Add(oni.MeleeModifiers);
+            args.Modifiers.Add(oni.MeleeModifiers);
         }
 
         private void OnStamHit(EntityUid uid, HeldByOniComponent component, TakeStaminaDamageEvent args)


### PR DESCRIPTION
# Description

Examining an item's damage values as an Oni now calculates your bonus damage, and it also works with all of the Oni combat traits.

## Technical details

`OniSystem`, instead of adding melee damage through `MeleeHitEvent`, now adds damage through `GetMeleeDamageEvent`, the same event that examining melee weapon damage raises through `GetDamage`. 

## Media

**Normal damage values**

<img src="https://github.com/user-attachments/assets/9de255ef-29e6-4119-93cc-356349812a6f" width=300px>

**Oni damage values**

<img src="https://github.com/user-attachments/assets/18d44aaf-5a70-4ba9-a8c8-be29e92d7267" width=300px>


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Skubman
- tweak: As an Oni, examining the damage values of weapons now takes into account the melee damage bonus from your species or trait.
