### PR TITLE
IPC No Longer Taking Singer 

### DIFF
--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -173,6 +173,7 @@
       inverted: true
       species:
         - Harpy
+        - IPC # because fuck IPCs I guess. TODO: Fix singer to allow IPCs to open the midi menu.
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

IPCs are no longer allowed to have the singer trait due to them not being able to open the menu. Future note: fix that.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Singer trait can no longer be taken by IPCs.