### PR TITLE
Fix Applicable Medication Stack Bug

### DIFF
--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -11,7 +11,7 @@
   name: aloe cream
   icon: { sprite: "/Textures/Objects/Specific/Hydroponics/aloe.rsi", state: cream }
   spawn: AloeCream
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 - type: stack
@@ -19,7 +19,7 @@
   name: gauze
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 - type: stack
@@ -27,7 +27,7 @@
   name: brutepack
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Brutepack
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 - type: stack
@@ -35,7 +35,7 @@
   name: bloodpack
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bloodpack }
   spawn: Bloodpack
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 - type: stack
@@ -43,7 +43,7 @@
   name: medicated-suture
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: medicated-suture }
   spawn: MedicatedSuture
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 - type: stack
@@ -51,7 +51,7 @@
   name: regenerative-mesh
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: regenerative-mesh}
   spawn: RegenerativeMesh
-  maxCount: 10
+  maxCount: 15 #Changed to 15 due to shitmed changes
   itemSize: 1
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Fixed a bug where applicable medication stacks would revert back to 10 after 1 use.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Did you know maxstacks were stored in a separate YML? Me neither, until now.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
-->
:cl:
- fix: Fixed a bug where applicable medication stacks would revert back to 10 after 1 use from full.

