### PR TITLE
More Loadout Equipment

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -379,6 +379,7 @@ character-item-group-LoadoutSalvageSpecialistMask = Salvage Specialist Masks
 character-item-group-LoadoutSalvageSpecialistOuter = Salvage Specialist Outerwear
 character-item-group-LoadoutSalvageSpecialistShoes = Salvage Specialist Shoes
 character-item-group-LoadoutSalvageSpecialistUniforms = Salvage Specialist Uniforms
+character-item-group-LoadoutSalvageSpecialistWeapons = Salvage Specialist Weapons
 
 # Medical
 character-item-group-LoadoutMedicalBackpacks = Medical Backpacks

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/atmosphericTechnician.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/atmosphericTechnician.yml
@@ -33,6 +33,29 @@
       id: LoadoutAtmosphericTechnicianEquipmentMedkitOxygen
     - type: loadout
       id: LoadoutAtmosphericTechnicianEquipmentRCD
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentPowerDrill
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetSteel
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetSteel10
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel10
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetGlass
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetGlass10
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank10
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic
+    - type: loadout
+      id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic10
+
 
 #- type: characterItemGroup
 #  id: LoadoutAtmosphericTechnicianEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -17,6 +17,24 @@
       id: LoadoutChiefEngineerBelt
     - type: loadout
       id: LoadoutChiefEngineerBeltFilled
+
+#- type: characterItemGroup
+#  id: LoadoutChiefEngineerEars
+#  maxItems: 1
+#  items:
+
+- type: characterItemGroup
+  id: LoadoutChiefEngineerEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentBoxInflatable
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentMedkitOxygen
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentRCD
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentRCDAmmoSpare
     - type: loadout
       id: LoadoutChiefEngineerEquipmentSheetSteel
     - type: loadout
@@ -61,24 +79,6 @@
       id: LoadoutChiefEngineerEquipmentSheetPlastic
     - type: loadout
       id: LoadoutChiefEngineerEquipmentSheetPlastic10
-
-#- type: characterItemGroup
-#  id: LoadoutChiefEngineerEars
-#  maxItems: 1
-#  items:
-
-- type: characterItemGroup
-  id: LoadoutChiefEngineerEquipment
-  maxItems: 2
-  items:
-    - type: loadout
-      id: LoadoutChiefEngineerEquipmentBoxInflatable
-    - type: loadout
-      id: LoadoutChiefEngineerEquipmentMedkitOxygen
-    - type: loadout
-      id: LoadoutChiefEngineerEquipmentRCD
-    - type: loadout
-      id: LoadoutChiefEngineerEquipmentRCDAmmoSpare
 
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -17,6 +17,50 @@
       id: LoadoutChiefEngineerBelt
     - type: loadout
       id: LoadoutChiefEngineerBeltFilled
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetSteel
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetSteel10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPlasteel
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPlasteel10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentMaterialWoodPlank
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentMaterialWoodPlank10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetUGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetUGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRUGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRUGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRPGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetRPGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetClockworkGlass
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetClockworkGlass10
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPlastic
+    - type: loadout
+      id: LoadoutChiefEngineerEquipmentSheetPlastic10
 
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerEars

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/seniorEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/seniorEngineer.yml
@@ -21,7 +21,7 @@
 
 - type: characterItemGroup
   id: LoadoutSeniorEngineerEquipment
-  maxItems: 2
+  maxItems: 3
   items:
     - type: loadout
       id: LoadoutSeniorEngineerEquipmentBoxInflatable
@@ -29,6 +29,56 @@
       id: LoadoutSeniorEngineerEquipmentMedkitOxygen
     - type: loadout
       id: LoadoutSeniorEngineerEquipmentRCD
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentRCDAmmo1
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentRCDAmmo2
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentPowerDrill
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetSteel
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetSteel10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPlasteel
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPlasteel10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetUGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetUGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRUGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRUGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRPGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetRPGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass10
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPlastic
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentSheetPlastic10
 
 #- type: characterItemGroup
 #  id: LoadoutSeniorEngineerEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/stationEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/stationEngineer.yml
@@ -15,12 +15,34 @@
 
 - type: characterItemGroup
   id: LoadoutStationEngineerEquipment
-  maxItems: 2
+  maxItems: 3
   items:
     - type: loadout
       id: LoadoutStationEngineerEquipmentBoxInflatable
     - type: loadout
       id: LoadoutStationEngineerEquipmentRCD
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentPowerDrill
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetSteel
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetSteel10
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetPlasteel
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetPlasteel10
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetGlass
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetGlass10
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentMaterialWoodPlank
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentMaterialWoodPlank10
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetPlastic
+    - type: loadout
+      id: LoadoutStationEngineerEquipmentSheetPlastic10
 
 #- type: characterItemGroup
 #  id: LoadoutStationEngineerEyes
@@ -62,7 +84,11 @@
 #  maxItems: 1
 #  items:
 
-#- type: characterItemGroup
-#  id: LoadoutStationEngineerUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutStationEngineerUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutStationEngineerUniformsSuit
+    - type: loadout
+      id: LoadoutStationEngineerUniformsSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/technicalAssistant.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/technicalAssistant.yml
@@ -13,10 +13,22 @@
 #  maxItems: 1
 #  items:
 
-#- type: characterItemGroup
-#  id: LoadoutTechnicalAssistantEquipment
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutTechnicalAssistantEquipment
+  maxItems: 2
+  items:
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentBoxInflatable
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentSheetSteel10
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentSheetPlasteel10
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentSheetGlass10
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentMaterialWoodPlank10
+    - type: loadout
+      id: LoadoutTechnicalAssistantEquipmentSheetPlastic10
 
 #- type: characterItemGroup
 #  id: LoadoutTechnicalAssistantEyes
@@ -58,7 +70,11 @@
 #  maxItems: 1
 #  items:
 
-#- type: characterItemGroup
-#  id: LoadoutTechnicalAssistantUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutTechnicalAssistantUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutTechnicalAssistantSuit
+    - type: loadout
+      id: LoadoutTechnicalAssistantSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
@@ -58,7 +58,11 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutAcolyteUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutAcolyteUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutAcolyteUniformSuit
+    - type: loadout
+      id: LoadoutAcolyteUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
@@ -13,11 +13,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutAcolyteEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutAcolyteEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutAcolyteEquipmentCandles
+    - type: loadout
+      id: LoadoutAcolyteEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutAcolyteEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/acolyte.yml
@@ -21,6 +21,8 @@
       id: LoadoutAcolyteEquipmentCandles
     - type: loadout
       id: LoadoutAcolyteEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutAcolytePillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutAcolyteEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/cataloger.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/cataloger.yml
@@ -22,6 +22,8 @@
       id: LoadoutCatalogerEquipmentCandles
     - type: loadout
       id: LoadoutCatalogerEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutCatalogerPillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutCatalogerEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/cataloger.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/cataloger.yml
@@ -14,11 +14,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutCatalogerEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutCatalogerEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutCatalogerEquipmentCandles
+    - type: loadout
+      id: LoadoutCatalogerEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutCatalogerEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
@@ -26,6 +26,8 @@
       id: LoadoutChaplainEquipmentCandles
     - type: loadout
       id: LoadoutChaplainEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutChaplainPillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutChaplainEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
@@ -16,12 +16,16 @@
 #
 - type: characterItemGroup
   id: LoadoutChaplainEquipment
-  maxItems: 2
+  maxItems: 3
   items:
     - type: loadout
       id: LoadoutChaplainBible
     - type: loadout
       id: LoadoutChaplainStamp
+    - type: loadout
+      id: LoadoutChaplainEquipmentCandles
+    - type: loadout
+      id: LoadoutChaplainEquipmentCandlesSmall
 
 #- type: characterItemGroup
 #  id: LoadoutChaplainEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
@@ -1,9 +1,15 @@
 # Golemancer
-#- type: characterItemGroup
-#  id: LoadoutGolemancerBackpacks
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutGolemancerBackpacks
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutBackpackRobotics
+    - type: loadout
+      id: LoadoutBackpackSatchelRobotics
+    - type: loadout
+      id: LoadoutBackpackDuffelRobotics
+
 #- type: characterItemGroup
 #  id: LoadoutGolemancerBelt
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
@@ -22,6 +22,8 @@
       id: LoadoutGolemancerEquipmentCandles
     - type: loadout
       id: LoadoutGolemancerEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutGolemancerPillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutGolemancerEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/golemancer.yml
@@ -14,11 +14,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutGolemancerEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutGolemancerEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutGolemancerEquipmentCandles
+    - type: loadout
+      id: LoadoutGolemancerEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutGolemancerEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystagogue.yml
@@ -28,6 +28,8 @@
       id: LoadoutMystagogueEquipmentCandles
     - type: loadout
       id: LoadoutMystagogueEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutMystagoguePillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutMystagogueEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystagogue.yml
@@ -20,11 +20,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutMystagogueEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutMystagogueEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutMystagogueEquipmentCandles
+    - type: loadout
+      id: LoadoutMystagogueEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutMystagogueEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
@@ -22,6 +22,8 @@
       id: LoadoutMysticEquipmentCandles
     - type: loadout
       id: LoadoutMysticEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutMysticPillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutMysticEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
@@ -14,11 +14,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutMysticEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutMysticEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutMysticEquipmentCandles
+    - type: loadout
+      id: LoadoutMysticEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutMysticEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
@@ -59,7 +59,11 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutNoviciateUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutNoviciateUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutNoviciateUniformSuit
+    - type: loadout
+      id: LoadoutNoviciateUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
@@ -22,6 +22,8 @@
       id: LoadoutNoviciateEquipmentCandles
     - type: loadout
       id: LoadoutNoviciateEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutNoviciatePillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutNoviciateEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/noviciate.yml
@@ -14,11 +14,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutNoviciateEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutNoviciateEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutNoviciateEquipmentCandles
+    - type: loadout
+      id: LoadoutNoviciateEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutNoviciateEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
@@ -22,6 +22,8 @@
       id: LoadoutPsionicMantisEquipmentCandles
     - type: loadout
       id: LoadoutPsionicMantisEquipmentCandlesSmall
+    - type: loadout
+      id: LoadoutPsionicMantisPillCanisterSpaceDrugs
 
 #- type: characterItemGroup
 #  id: LoadoutPsionicMantisEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
@@ -14,11 +14,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutPsionicMantisEquipment
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutPsionicMantisEquipment
+  maxItems: 3
+  items:
+    - type: loadout
+      id: LoadoutPsionicMantisEquipmentCandles
+    - type: loadout
+      id: LoadoutPsionicMantisEquipmentCandlesSmall
+
 #- type: characterItemGroup
 #  id: LoadoutPsionicMantisEyes
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
@@ -61,7 +61,11 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutPsionicMantisUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutPsionicMantisUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutPsionicMantisUniformSuit
+    - type: loadout
+      id: LoadoutPsionicMantisUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/psionicMantis.yml
@@ -24,6 +24,8 @@
       id: LoadoutPsionicMantisEquipmentCandlesSmall
     - type: loadout
       id: LoadoutPsionicMantisPillCanisterSpaceDrugs
+    - type: loadout
+      id: LoadoutPsionicMantisPillCanisterCryptobiolin
 
 #- type: characterItemGroup
 #  id: LoadoutPsionicMantisEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/uncategorized.yml
@@ -1,9 +1,15 @@
 # All Epistemics
-#- type: characterItemGroup
-#  id: LoadoutEpistemicsBackpacks
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutEpistemicsBackpacks
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutBackpackScience
+    - type: loadout
+      id: LoadoutBackpackSatchelScience
+    - type: loadout
+      id: LoadoutBackpackDuffelScience
+
 #- type: characterItemGroup
 #  id: LoadoutEpistemicsBelt
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/cargoTechnician.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/cargoTechnician.yml
@@ -63,7 +63,11 @@
     - type: loadout
       id: LoadoutCargoShoesBootsWinterCargo
 
-#- type: characterItemGroup
-#  id: LoadoutCargoTechnicianUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutCargoTechnicianUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutCargoTechnicianUniformSuit
+    - type: loadout
+      id: LoadoutCargoTechnicianUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/courier.yml
@@ -59,7 +59,11 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutCourierUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutCourierUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutCourierUniformSuit
+    - type: loadout
+      id: LoadoutCourierUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/courier.yml
@@ -29,11 +29,13 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutCourierHead
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutCourierHead
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutCourierHeadMail
+
 #- type: characterItemGroup
 #  id: LoadoutCourierId
 #  maxItems: 1
@@ -49,11 +51,13 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutCourierOuter
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutCourierOuter
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutCourierOuterMail
+
 #- type: characterItemGroup
 #  id: LoadoutCourierShoes
 #  maxItems: 1
@@ -67,3 +71,7 @@
       id: LoadoutCourierUniformSuit
     - type: loadout
       id: LoadoutCourierUniformSkirt
+    - type: loadout
+      id: LoadoutCourierUniformMailSuit
+    - type: loadout
+      id: LoadoutCourierUniformMailSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
@@ -10,11 +10,17 @@
     - type: loadout
       id: LoadoutSalvageBackpackDuffel
 
-#- type: characterItemGroup
-#  id: LoadoutSalvageSpecialistBelt
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutSalvageSpecialistBelt
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutSalvageBeltMercWebbing
+    - type: loadout
+      id: LoadoutSalvageBeltSalvageWebbing
+    - type: loadout
+      id: LoadoutSalvageBeltMilitaryWebbing
+
 #- type: characterItemGroup
 #  id: LoadoutSalvageSpecialistEars
 #  maxItems: 1
@@ -76,6 +82,8 @@
   items:
     - type: loadout
       id: LoadoutCargoNeckGoliathCloak
+    - type: loadout
+      id: LoadoutSalvageNeckCloakMiner
 
 #- type: characterItemGroup
 #  id: LoadoutSalvageSpecialistMask

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
@@ -31,6 +31,24 @@
   items:
     - type: loadout
       id: LoadoutCargoWeaponsCrusherDagger
+    - type: loadout
+      id: LoadoutSalvageWeaponsCombatKnife
+    - type: loadout
+      id: LoadoutSalvageWeaponsKitchenKnife
+    - type: loadout
+      id: LoadoutSalvageWeaponsSurvivalKnife
+    - type: loadout
+      id: LoadoutSalvageWeaponsKukriKnife
+    - type: loadout
+      id: LoadoutSalvageWeaponsCleaver
+    - type: loadout
+      id: LoadoutSalvageWeaponsThrowingKnife
+    - type: loadout
+      id: LoadoutSalvageWeaponsMachete
+    - type: loadout
+      id: LoadoutSalvageWeaponsCutlass
+    - type: loadout
+      id: LoadoutSalvageWeaponsKatana
 
 #- type: characterItemGroup
 #  id: LoadoutSalvageSpecialistEyes
@@ -81,4 +99,4 @@
   maxItems: 1
   items:
     - type: loadout
-      id: LoadoutSalvageTechnicianUniformSuit
+      id: LoadoutSalvageSpecialistUniformSuit

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
@@ -76,7 +76,9 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutSalvageSpecialistUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutSalvageSpecialistUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutSalvageTechnicianUniformSuit

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Logistics/salvageSpecialist.yml
@@ -55,6 +55,8 @@
       id: LoadoutSalvageWeaponsCutlass
     - type: loadout
       id: LoadoutSalvageWeaponsKatana
+    - type: loadout
+      id: LoadoutSalvageWeaponsWakizashi
 
 #- type: characterItemGroup
 #  id: LoadoutSalvageSpecialistEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/mime.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/mime.yml
@@ -1,9 +1,15 @@
 # Mime
-#- type: characterItemGroup
-#  id: LoadoutMimeBackpacks
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutMimeBackpacks
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutBackpackMime
+    - type: loadout
+      id: LoadoutBackpackSatchelMime
+    - type: loadout
+      id: LoadoutBackpackDuffelMime
+
 #- type: characterItemGroup
 #  id: LoadoutMimeBelt
 #  maxItems: 1

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -631,6 +631,7 @@
       - id: Stunbaton
       - id: Handcuffs
       - id: Handcuffs
+
 - type: entity
   parent: ClothingBeltStorageBase
   id: ClothingBeltMercWebbing
@@ -657,7 +658,7 @@
   parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltMilitaryWebbing
   name: chest rig
-  description: A set of tactical webbing worn by Syndicate boarding parties.
+  description: A set of tactical webbing worn by boarding parties.
   components:
   - type: Sprite
     sprite: Clothing/Belt/militarywebbing.rsi

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -236,6 +236,18 @@
         canReact: false
 
 - type: entity
+  parent: SheetRGlass
+  id: SheetRGlass10
+  name: reinforced glass
+  suffix: Single
+  components:
+  - type: Sprite
+    state: rglass
+  - type: Stack
+    stackType: ReinforcedGlass
+    count: 10
+
+- type: entity
   parent: SheetGlassBase
   id: SheetPGlass
   name: plasma glass
@@ -326,6 +338,18 @@
 
 - type: entity
   parent: SheetPGlass
+  id: SheetPGlass10
+  name: plasma glass
+  suffix: 10
+  components:
+  - type: Sprite
+    state: pglass
+  - type: Stack
+    stackType: PlasmaGlass
+    count: 10
+
+- type: entity
+  parent: SheetPGlass
   id: SheetRPGlass
   name: reinforced plasma glass
   description: A reinforced sheet of translucent plasma.
@@ -391,6 +415,18 @@
   - type: Stack
     stackType: ReinforcedPlasmaGlass
     count: 1
+
+- type: entity
+  parent: SheetRPGlass
+  id: SheetRPGlass10
+  name: reinforced plasma glass
+  suffix: Single
+  components:
+  - type: Sprite
+    state: rpglass
+  - type: Stack
+    stackType: ReinforcedPlasmaGlass
+    count: 10
 
 - type: entity
   parent: SheetGlassBase
@@ -483,6 +519,18 @@
 
 - type: entity
   parent: SheetUGlass
+  id: SheetUGlass10
+  name: uranium glass
+  suffix: 10
+  components:
+  - type: Sprite
+    state: uglass
+  - type: Stack
+    stackType: UraniumGlass
+    count: 10
+
+- type: entity
+  parent: SheetUGlass
   id: SheetRUGlass
   name: reinforced uranium glass
   description: A reinforced sheet of uranium.
@@ -547,6 +595,18 @@
   - type: Stack
     stackType: ReinforcedUraniumGlass
     count: 1
+
+- type: entity
+  parent: SheetRUGlass
+  id: SheetRUGlass10
+  name: reinforced uranium glass
+  suffix: 10
+  components:
+  - type: Sprite
+    state: ruglass
+  - type: Stack
+    stackType: ReinforcedUraniumGlass
+    count: 10
 
 - type: entity
   parent: SheetGlassBase
@@ -624,3 +684,15 @@
   - type: Stack
     stackType: ClockworkGlass
     count: 1
+
+- type: entity
+  parent: SheetClockworkGlass
+  id: SheetClockworkGlass10
+  name: clockwork glass
+  suffix: 10
+  components:
+  - type: Sprite
+    state: cglass
+  - type: Stack
+    stackType: ClockworkGlass
+    count: 10

--- a/Resources/Prototypes/Loadouts/Generic/backpacks.yml
+++ b/Resources/Prototypes/Loadouts/Generic/backpacks.yml
@@ -3,25 +3,12 @@
   category: Backpacks
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpack
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBackpacks
-
-- type: loadout
-  id: LoadoutBackpackMime
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackMime
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Mime
 
 - type: loadout
   id: LoadoutBackpackHydroponics
@@ -36,34 +23,6 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Civilian
-
-- type: loadout
-  id: LoadoutBackpackScience
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackScience
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
-
-- type: loadout
-  id: LoadoutBackpackRobotics
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackRobotics
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
 
 - type: loadout
   id: LoadoutBackpackMerc

--- a/Resources/Prototypes/Loadouts/Generic/duffelbags.yml
+++ b/Resources/Prototypes/Loadouts/Generic/duffelbags.yml
@@ -3,39 +3,12 @@
   category: Backpacks
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpackDuffel
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBackpacks
-
-- type: loadout
-  id: LoadoutBackpackDuffelSecurity
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackDuffelSecurity
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-
-- type: loadout
-  id: LoadoutBackpackDuffelMime
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackDuffelMime
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Mime
 
 - type: loadout
   id: LoadoutBackpackDuffelHydroponics
@@ -50,31 +23,3 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Civilian
-
-- type: loadout
-  id: LoadoutBackpackDuffelScience
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackDuffelScience
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
-
-- type: loadout
-  id: LoadoutBackpackDuffelRobotics
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackDuffelRobotics
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -73,6 +73,7 @@
   id: LoadoutItemLighter
   category: Items
   cost: 1
+  customColorTint: true
   items:
     - Lighter
   requirements:
@@ -83,6 +84,7 @@
   id: LoadoutItemLighterCheap
   category: Items
   cost: 0
+  customColorTint: true
   items:
     - CheapLighter
   requirements:
@@ -93,6 +95,7 @@
   id: LoadoutItemLighterFlippo
   category: Items
   cost: 2
+  customColorTint: true
   items:
     - FlippoLighter
   requirements:
@@ -743,6 +746,7 @@
   id: LoadoutItemDrinkShinyFlask
   category: Items
   cost: 1
+  customColorTint: true
   canBeHeirloom: true
   items:
     - DrinkShinyFlask
@@ -751,6 +755,7 @@
   id: LoadoutItemDrinkLithiumFlask
   category: Items
   cost: 1
+  customColorTint: true
   items:
     - DrinkLithiumFlask
 
@@ -758,5 +763,6 @@
   id: LoadoutItemDrinkVacuumFlask
   category: Items
   cost: 1
+  customColorTint: true
   items:
     - DrinkVacuumFlask

--- a/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
@@ -2,6 +2,7 @@
   id: LoadoutOuterCoatBomberjacket
   category: Outer
   cost: 1
+  customColorTint: true
   items:
     - ClothingOuterCoatBomber
   requirements:
@@ -33,6 +34,7 @@
   id: LoadoutOuterCoatWinterCoat
   category: Outer
   cost: 1
+  customColorTint: true
   items:
     - ClothingOuterWinterCoat
   requirements:

--- a/Resources/Prototypes/Loadouts/Generic/satchels.yml
+++ b/Resources/Prototypes/Loadouts/Generic/satchels.yml
@@ -3,6 +3,7 @@
   category: Backpacks
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpackSatchel
   requirements:
@@ -23,34 +24,6 @@
          - Prisoner
 
 - type: loadout
-  id: LoadoutBackpackSatchelSecurity
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackSatchelSecurity
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-
-- type: loadout
-  id: LoadoutBackpackSatchelMime
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackSatchelMime
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Mime
-
-- type: loadout
   id: LoadoutBackpackSatchelHydroponics
   category: Backpacks
   cost: 0
@@ -63,31 +36,3 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Civilian
-
-- type: loadout
-  id: LoadoutBackpackSatchelScience
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackSatchelScience
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
-
-- type: loadout
-  id: LoadoutBackpackSatchelRobotics
-  category: Backpacks
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackSatchelRobotics
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics

--- a/Resources/Prototypes/Loadouts/Generic/shoes.yml
+++ b/Resources/Prototypes/Loadouts/Generic/shoes.yml
@@ -248,6 +248,7 @@
   category: Shoes
   cost: 0
   exclusive: true
+  customColorTint: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutShoes

--- a/Resources/Prototypes/Loadouts/Generic/uniform.yml
+++ b/Resources/Prototypes/Loadouts/Generic/uniform.yml
@@ -1317,6 +1317,7 @@
   category: Uniform
   cost: 1
   exclusive: true
+  customColorTint: true
   items:
     - ClothingUniformMNKOfficeSkirt
   requirements:
@@ -1348,6 +1349,7 @@
   category: Uniform
   cost: 1
   exclusive: true
+  customColorTint: true
   items:
     - ClothingUniformMNKGymBra
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
@@ -114,6 +114,149 @@
     - RCD
     - RCDAmmo
 
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentPowerDrill
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - PowerDrill
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetSteel
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetSteel
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetSteel10
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetSteel10
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetPlasteel
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel10
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetPlasteel10
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetGlass
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetGlass
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetGlass10
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetGlass10
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - MaterialWoodPlank
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank10
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - MaterialWoodPlank10
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetPlastic
+
+- type: loadout
+  id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic10
+  category: JobsEngineeringAtmosphericTechnician
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAtmosphericTechnicianEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - AtmosphericTechnician
+  items:
+    - SheetPlastic10
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -128,6 +128,292 @@
     - RCDAmmo
     - RCDAmmo
 
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetSteel
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetSteel
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetSteel10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetSteel10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPlasteel
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPlasteel
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPlasteel10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPlasteel10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentMaterialWoodPlank
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - MaterialWoodPlank
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentMaterialWoodPlank10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - MaterialWoodPlank10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetUGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetUGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetUGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetUGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRUGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRUGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRUGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRUGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRPGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRPGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetRPGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetRPGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetClockworkGlass
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetClockworkGlass
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetClockworkGlass10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetClockworkGlass10
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPlastic
+  category: JobsEngineeringChiefEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPlastic
+
+- type: loadout
+  id: LoadoutChiefEngineerEquipmentSheetPlastic10
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+  items:
+    - SheetPlastic10
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
@@ -113,6 +113,305 @@
   items:
     - RCDAmmo
 
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentPowerDrill
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - PowerDrill
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetSteel
+  category: JobsEngineeringSeniorEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetSteel
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetSteel10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetSteel10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPlasteel
+  category: JobsEngineeringSeniorEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPlasteel
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPlasteel10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPlasteel10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank
+  category: JobsEngineeringSeniorEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - MaterialWoodPlank
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - MaterialWoodPlank10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetUGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetUGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetUGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetUGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRUGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRUGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRUGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRUGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRPGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRPGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetRPGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetRPGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetClockworkGlass
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetClockworkGlass10
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPlastic
+  category: JobsEngineeringSeniorEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPlastic
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentSheetPlastic10
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSeniorEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorEngineer
+  items:
+    - SheetPlastic10
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/stationEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/stationEngineer.yml
@@ -28,10 +28,153 @@
       group: LoadoutStationEngineerEquipment
     - !type:CharacterJobRequirement
       jobs:
-        - SeniorEngineer
+        - StationEngineer
   items:
     - RCD
     - RCDAmmo
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentPowerDrill
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - PowerDrill
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetSteel
+  category: JobsEngineeringStationEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetSteel
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetSteel10
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetSteel10
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetPlasteel
+  category: JobsEngineeringStationEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetPlasteel
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetPlasteel10
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetPlasteel10
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetGlass
+  category: JobsEngineeringStationEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetGlass
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetGlass10
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetGlass10
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentMaterialWoodPlank
+  category: JobsEngineeringStationEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - MaterialWoodPlank
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentMaterialWoodPlank10
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - MaterialWoodPlank10
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetPlastic
+  category: JobsEngineeringStationEngineer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetPlastic
+
+- type: loadout
+  id: LoadoutStationEngineerEquipmentSheetPlastic10
+  category: JobsEngineeringStationEngineer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - SheetPlastic10
 
 # Eyes
 
@@ -50,3 +193,28 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutStationEngineerUniformsSuit
+  category: JobsEngineeringStationEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - ClothingUniformJumpsuitEngineering
+
+- type: loadout
+  id: LoadoutStationEngineerUniformsSkirt
+  category: JobsEngineeringStationEngineer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutStationEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - StationEngineer
+  items:
+    - ClothingUniformJumpskirtEngineering

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/technicalAssistant.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/technicalAssistant.yml
@@ -6,6 +6,84 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentBoxInflatable
+  category: JobsEngineeringTechnicalAssistant
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - BoxInflatable
+
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentSheetSteel10
+  category: JobsEngineeringTechnicalAssistant
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - SheetSteel10
+
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentSheetPlasteel10
+  category: JobsEngineeringTechnicalAssistant
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - SheetPlasteel10
+
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentSheetGlass10
+  category: JobsEngineeringTechnicalAssistant
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - SheetGlass10
+
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentMaterialWoodPlank10
+  category: JobsEngineeringTechnicalAssistant
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - MaterialWoodPlank10
+
+
+- type: loadout
+  id: LoadoutTechnicalAssistantEquipmentSheetPlastic10
+  category: JobsEngineeringTechnicalAssistant
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - SheetPlastic10
 
 # Eyes
 
@@ -24,3 +102,30 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutTechnicalAssistantSuit
+  category: JobsEngineeringTechnicalAssistant
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - ClothingUniformJumpsuitColorYellow
+
+- type: loadout
+  id: LoadoutTechnicalAssistantSkirt
+  category: JobsEngineeringTechnicalAssistant
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutTechnicalAssistantUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - TechnicalAssistant
+  items:
+    - ClothingUniformJumpskirtColorYellow

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
@@ -6,6 +6,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutAcolyteEquipmentCandles
+  category: JobsEpistemicsAcolyte
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAcolyteEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Scientist
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutAcolyteEquipmentCandlesSmall
+  category: JobsEpistemicsAcolyte
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAcolyteEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Scientist
+  items:
+    - BoxCandleSmall
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
@@ -34,9 +34,9 @@
       group: LoadoutAcolyteUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - ResearchAssistant
+        - Scientist
   items:
-    - ClothingUniformJumpsuitColorWhite
+    - ClothingUniformJumpsuitScientist
 
 - type: loadout
   id: LoadoutAcolyteUniformSkirt
@@ -48,6 +48,6 @@
       group: LoadoutAcolyteUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - ResearchAssistant
+        - Scientist
   items:
-    - ClothingUniformJumpskirtColorWhite
+    - ClothingUniformJumpskirtScientist

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
@@ -24,3 +24,30 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutAcolyteUniformSuit
+  category: JobsEpistemicsAcolyte
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAcolyteUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - ClothingUniformJumpsuitColorWhite
+
+- type: loadout
+  id: LoadoutAcolyteUniformSkirt
+  category: JobsEpistemicsAcolyte
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAcolyteUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - ClothingUniformJumpskirtColorWhite

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/acolyte.yml
@@ -32,6 +32,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutAcolytePillCanisterSpaceDrugs
+  category: JobsEpistemicsAcolyte
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutAcolyteEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Scientist
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
@@ -45,6 +45,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutCatalogerPillCanisterSpaceDrugs
+  category: JobsEpistemicsCataloger
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCatalogerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Librarian
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
@@ -19,6 +19,32 @@
 #  items:
 #    - PsiPotentiometerHandheld
 
+- type: loadout
+  id: LoadoutCatalogerEquipmentCandles
+  category: JobsEpistemicsCataloger
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCatalogerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Librarian
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutCatalogerEquipmentCandlesSmall
+  category: JobsEpistemicsCataloger
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCatalogerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Librarian
+  items:
+    - BoxCandleSmall
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -60,6 +60,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutChaplainPillCanisterSpaceDrugs
+  category: JobsEpistemicsChaplain
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -34,6 +34,32 @@
   items:
     - RubberStampChaplain
 
+- type: loadout
+  id: LoadoutChaplainEquipmentCandles
+  category: JobsEpistemicsChaplain
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutChaplainEquipmentCandlesSmall
+  category: JobsEpistemicsChaplain
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChaplainEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chaplain
+  items:
+    - BoxCandleSmall
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
@@ -1,5 +1,47 @@
 # Golemancer
 # Backpacks
+- type: loadout
+  id: LoadoutBackpackRobotics
+  category: JobsEpistemicsGolemancer
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackRobotics
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+
+- type: loadout
+  id: LoadoutBackpackSatchelRobotics
+  category: JobsEpistemicsGolemancer
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSatchelRobotics
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+
+- type: loadout
+  id: LoadoutBackpackDuffelRobotics
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDuffelRobotics
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+
 
 # Belt
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
@@ -32,6 +32,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutGolemancerPillCanisterSpaceDrugs
+  category: JobsEpistemicsGolemancer
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
@@ -6,6 +6,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutGolemancerEquipmentCandles
+  category: JobsEpistemicsGolemancer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutGolemancerEquipmentCandlesSmall
+  category: JobsEpistemicsGolemancer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutGolemancerEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
+  items:
+    - BoxCandleSmall
 
 # Eyes
 
@@ -32,9 +57,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutGolemancerUniforms
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
   items:
     - ClothingUniformJumpskirtRoboticist
 
@@ -46,8 +71,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutGolemancerUniforms
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Epistemics
+    - !type:CharacterJobRequirement
+      jobs:
+        - Roboticist
   items:
     - ClothingUniformJumpsuitRoboticist

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
@@ -47,6 +47,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutMystagogueEquipmentCandles
+  category: JobsEpistemicsMystagogue
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMystagogueEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchDirector
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutMystagogueEquipmentCandlesSmall
+  category: JobsEpistemicsMystagogue
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMystagogueEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchDirector
+  items:
+    - BoxCandleSmall
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
@@ -73,6 +73,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutMystagoguePillCanisterSpaceDrugs
+  category: JobsEpistemicsMystagogue
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMystagogueEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchDirector
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
@@ -32,6 +32,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutMysticPillCanisterSpaceDrugs
+  category: JobsEpistemicsMystic
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMysticEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorResearcher
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
@@ -6,6 +6,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutMysticEquipmentCandles
+  category: JobsEpistemicsMystic
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMysticEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorResearcher
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutMysticEquipmentCandlesSmall
+  category: JobsEpistemicsMystic
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMysticEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - SeniorResearcher
+  items:
+    - BoxCandleSmall
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
@@ -6,6 +6,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutNoviciateEquipmentCandles
+  category: JobsEpistemicsNoviciate
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNoviciateEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutNoviciateEquipmentCandlesSmall
+  category: JobsEpistemicsNoviciate
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNoviciateEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - BoxCandleSmall
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
@@ -32,6 +32,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutNoviciatePillCanisterSpaceDrugs
+  category: JobsEpistemicsNoviciate
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNoviciateEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/noviciate.yml
@@ -24,3 +24,30 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutNoviciateUniformSuit
+  category: JobsEpistemicsNoviciate
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNoviciateUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - ClothingUniformJumpsuitColorWhite
+
+- type: loadout
+  id: LoadoutNoviciateUniformSkirt
+  category: JobsEpistemicsNoviciate
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNoviciateUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ResearchAssistant
+  items:
+    - ClothingUniformJumpskirtColorWhite

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -6,6 +6,31 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutPsionicMantisEquipmentCandles
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - BoxCandle
+
+- type: loadout
+  id: LoadoutPsionicMantisEquipmentCandlesSmall
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - BoxCandleSmall
 
 # Eyes
 
@@ -22,7 +47,7 @@
 # Outer
 - type: loadout
   id: LoadoutScienceOuterWinterCoatMantis
-  category: JobsEpistemicsAAUncategorized
+  category: JobsEpistemicsPsionicMantis
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -45,6 +45,19 @@
   items:
     - PillCanisterSpaceDrugs
 
+- type: loadout
+  id: LoadoutPsionicMantisPillCanisterCryptobiolin
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - PillCanisterCryptobiolin
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -32,6 +32,19 @@
   items:
     - BoxCandleSmall
 
+- type: loadout
+  id: LoadoutPsionicMantisPillCanisterSpaceDrugs
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisEquipment
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - PillCanisterSpaceDrugs
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -38,3 +38,30 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutPsionicMantisUniformSuit
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - ClothingUniformJumpsuitMantis
+
+- type: loadout
+  id: LoadoutPsionicMantisUniformSkirt
+  category: JobsEpistemicsPsionicMantis
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutPsionicMantisUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ForensicMantis
+  items:
+    - ClothingUniformSkirtMantis

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/uncategorized.yml
@@ -1,5 +1,46 @@
 # Uniforms
 # Backpacks
+- type: loadout
+  id: LoadoutBackpackScience
+  category: JobsEpistemicsAAUncategorized
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackScience
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEpistemicsBackpacks
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Epistemics
+
+- type: loadout
+  id: LoadoutBackpackSatchelScience
+  category: JobsEpistemicsAAUncategorized
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSatchelScience
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEpistemicsBackpacks
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Epistemics
+
+- type: loadout
+  id: LoadoutBackpackDuffelScience
+  category: JobsEpistemicsAAUncategorized
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDuffelScience
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEpistemicsBackpacks
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Epistemics
 
 # Belt
 

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/cargoTechnician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/cargoTechnician.yml
@@ -50,3 +50,30 @@
     - ClothingShoesBootsWinterCargo
 
 # Uniforms
+- type: loadout
+  id: LoadoutCargoTechnicianUniformSuit
+  category: JobsLogisticsCargoTechnician
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCargoTechnicianUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - CargoTechnician
+  items:
+    - ClothingUniformJumpsuitCargo
+
+- type: loadout
+  id: LoadoutCargoTechnicianUniformSkirt
+  category: JobsLogisticsCargoTechnician
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCargoTechnicianUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - CargoTechnician
+  items:
+    - ClothingUniformJumpskirtCargo

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
@@ -12,6 +12,19 @@
 # Gloves
 
 # Head
+- type: loadout
+  id: LoadoutCourierHeadMail
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierHead
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingHeadMailCarrier
 
 # Id
 
@@ -20,6 +33,19 @@
 # Mask
 
 # Outer
+- type: loadout
+  id: LoadoutCourierOuterMail
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierOuter
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingOuterWinterCoatMail
 
 # Shoes
 
@@ -51,3 +77,31 @@
         - Courier
   items:
     - ClothingUniformSkirtCourier
+
+- type: loadout
+  id: LoadoutCourierUniformMailSuit
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingUniformMailCarrier
+
+- type: loadout
+  id: LoadoutCourierUniformMailSkirt
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingUniformSkirtMailCarrier

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
@@ -24,3 +24,30 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutCourierUniformSuit
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingUniformCourier
+
+- type: loadout
+  id: LoadoutCourierUniformSkirt
+  category: JobsLogisticsCourier
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCourierUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Courier
+  items:
+    - ClothingUniformSkirtCourier

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/courier.yml
@@ -22,7 +22,7 @@
       group: LoadoutCourierHead
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingHeadMailCarrier
 
@@ -43,7 +43,7 @@
       group: LoadoutCourierOuter
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingOuterWinterCoatMail
 
@@ -60,7 +60,7 @@
       group: LoadoutCourierUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingUniformCourier
 
@@ -74,7 +74,7 @@
       group: LoadoutCourierUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingUniformSkirtCourier
 
@@ -88,7 +88,7 @@
       group: LoadoutCourierUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingUniformMailCarrier
 
@@ -102,6 +102,6 @@
       group: LoadoutCourierUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - Courier
+        - MailCarrier
   items:
     - ClothingUniformSkirtMailCarrier

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -240,6 +240,21 @@
   items:
     - Katana
 
+- type: loadout
+  id: LoadoutSalvageWeaponsWakizashi
+  category: JobsLogisticsSalvageSpecialist
+  cost: 1
+  canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Wakizashi
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -5,6 +5,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpackSalvage
   requirements:
@@ -19,6 +20,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpackSatchelSalvage
   requirements:
@@ -33,6 +35,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   exclusive: true
+  customColorTint: true
   items:
     - ClothingBackpackDuffelSalvage
   requirements:
@@ -105,6 +108,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -119,6 +123,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -133,6 +138,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -147,6 +153,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -161,6 +168,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 0
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -175,6 +183,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 1
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -191,6 +200,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 1
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -205,6 +215,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 2
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -219,6 +230,7 @@
   category: JobsLogisticsSalvageSpecialist
   cost: 2
   canBeHeirloom: true
+  customColorTint: true # Go read Neuromancer
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -107,3 +107,16 @@
 # Shoes
 
 # Uniforms
+- type: loadout
+  id: LoadoutSalvageTechnicianUniformSuit
+  category: JobsLogisticsSalvageTechnician
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageTechnicianUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageTechnician
+  items:
+    - ClothingUniformJumpsuitSalvageSpecialist

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -73,6 +73,7 @@
   id: LoadoutSalvageBeltMilitaryWebbing
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  customColorTint: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistBelt

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -60,6 +60,125 @@
   items:
     - WeaponCrusherDagger
 
+- type: loadout
+  id: LoadoutSalvageWeaponsCombatKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - CombatKnife
+
+- type: loadout
+  id: LoadoutSalvageWeaponsKitchenKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - KitchenKnife
+
+- type: loadout
+  id: LoadoutSalvageWeaponsSurvivalKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - SurvivalKnife
+
+- type: loadout
+  id: LoadoutSalvageWeaponsKukriKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - KukriKnife
+
+- type: loadout
+  id: LoadoutSalvageWeaponsCleaver
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ButchCleaver
+
+- type: loadout
+  id: LoadoutSalvageWeaponsThrowingKnife
+  category: JobsLogisticsSalvageSpecialist
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ThrowingKnife
+    - ThrowingKnife
+    - ThrowingKnife
+
+- type: loadout
+  id: LoadoutSalvageWeaponsMachete
+  category: JobsLogisticsSalvageSpecialist
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Machete
+
+- type: loadout
+  id: LoadoutSalvageWeaponsCutlass
+  category: JobsLogisticsSalvageSpecialist
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Cutlass
+
+- type: loadout
+  id: LoadoutSalvageWeaponsKatana
+  category: JobsLogisticsSalvageSpecialist
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistWeapons
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - Katana
+
 # Eyes
 
 # Gloves
@@ -108,15 +227,15 @@
 
 # Uniforms
 - type: loadout
-  id: LoadoutSalvageTechnicianUniformSuit
-  category: JobsLogisticsSalvageTechnician
+  id: LoadoutSalvageSpecialistUniformSuit
+  category: JobsLogisticsSalvageSpecialist
   cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageTechnicianUniforms
+      group: LoadoutSalvageSpecialistUniforms
     - !type:CharacterJobRequirement
       jobs:
-        - SalvageTechnician
+        - SalvageSpecialist
   items:
     - ClothingUniformJumpsuitSalvageSpecialist

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -10,9 +10,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Logistics
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
 
 - type: loadout
   id: LoadoutSalvageBackpackSatchel
@@ -24,9 +24,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Logistics
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
 
 - type: loadout
   id: LoadoutSalvageBackpackDuffel
@@ -38,11 +38,49 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Logistics
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
 
 # Belt
+- type: loadout
+  id: LoadoutSalvageBeltMercWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltMercWebbing
+
+- type: loadout
+  id: LoadoutSalvageBeltSalvageWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltSalvageWebbing
+
+- type: loadout
+  id: LoadoutSalvageBeltMilitaryWebbing
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingBeltMilitaryWebbing
 
 # Ears
 
@@ -51,6 +89,7 @@
   id: LoadoutCargoWeaponsCrusherDagger
   category: JobsLogisticsSalvageSpecialist
   cost: 2
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -64,6 +103,7 @@
   id: LoadoutSalvageWeaponsCombatKnife
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -77,6 +117,7 @@
   id: LoadoutSalvageWeaponsKitchenKnife
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -90,6 +131,7 @@
   id: LoadoutSalvageWeaponsSurvivalKnife
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -103,6 +145,7 @@
   id: LoadoutSalvageWeaponsKukriKnife
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -116,6 +159,7 @@
   id: LoadoutSalvageWeaponsCleaver
   category: JobsLogisticsSalvageSpecialist
   cost: 0
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -129,6 +173,7 @@
   id: LoadoutSalvageWeaponsThrowingKnife
   category: JobsLogisticsSalvageSpecialist
   cost: 1
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -144,6 +189,7 @@
   id: LoadoutSalvageWeaponsMachete
   category: JobsLogisticsSalvageSpecialist
   cost: 1
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -157,6 +203,7 @@
   id: LoadoutSalvageWeaponsCutlass
   category: JobsLogisticsSalvageSpecialist
   cost: 2
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -170,6 +217,7 @@
   id: LoadoutSalvageWeaponsKatana
   category: JobsLogisticsSalvageSpecialist
   cost: 2
+  canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutSalvageSpecialistWeapons
@@ -206,13 +254,28 @@
   items:
     - ClothingNeckCloakGoliathCloak
 
+- type: loadout
+  id: LoadoutSalvageNeckCloakMiner
+  category: JobsLogisticsSalvageSpecialist
+  cost: 0
+  exclusive: true
+  canBeHeirloom: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSalvageSpecialistNeck
+    - !type:CharacterJobRequirement
+      jobs:
+        - SalvageSpecialist
+  items:
+    - ClothingNeckCloakMiner
+
 # Mask
 
 # Outer
 - type: loadout
   id: LoadoutCargoOuterWinterMiner
   category: JobsLogisticsSalvageSpecialist
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/Service/mime.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/mime.yml
@@ -1,5 +1,46 @@
 # Mime
 # Backpacks
+- type: loadout
+  id: LoadoutBackpackMime
+  category: JobsServiceMime
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackMime
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMimeBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+
+- type: loadout
+  id: LoadoutBackpackSatchelMime
+  category: JobsServiceMime
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSatchelMime
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMimeBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+
+- type: loadout
+  id: LoadoutBackpackDuffelMime
+  category: JobsServiceMime
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDuffelMime
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMimeBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
 
 # Belt
 


### PR DESCRIPTION
# Description

This PR adds a bunch more equipment selections for Engineering loadouts, plus Suit/Skirt selections for the jobs that were missing it.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/031224b4-e348-4030-9ea4-7f2dbc64c87d)

</p>
</details>

# Changelog

:cl:
- add: All engineering roles have had their equipment loadouts significantly expanded upon. Engineers can now buy construction materials with their loadout points. 
- fix: All engineering jobs now have their Suit/Skirt selection via loadouts.
- add: Salvage techs can now select from a variety of knife options to start their spess adventures with.
- add: Epistemics staff now have *some* equipment selection options that they share. More to come when I finish making the Potentiometer.
