### PR TITLE
Fixes Make Cultist Admin Verb to Act on Target Not Self

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -146,7 +146,7 @@ public sealed partial class AdminVerbSystem
             Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Weapons/Melee/cult_dagger.rsi"), "icon"),
             Act = () =>
             {
-                _antag.ForceMakeAntag<BloodCultRuleComponent>(player, DefaultBloodCultRule);
+                _antag.ForceMakeAntag<BloodCultRuleComponent>(targetPlayer, DefaultBloodCultRule);
             },
             Impact = LogImpact.High,
             Message = Loc.GetString("admin-verb-make-blood-cultist"),


### PR DESCRIPTION
There's a small error on the admin verb for blood cultists which made the verb only work on self. This fixes it.