### PR TITLE
Build Your Own TEG!

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -99,3 +99,13 @@
   cost: 400
   category: cargoproduct-category-name-engineering
   group: market
+
+- type: cargoProduct
+  id: EngineTEGKit
+  icon:
+    sprite: Structures/Power/Generation/teg.rsi
+    state: static
+  product: CrateEngineeringTEGKit
+  cost: 8000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -182,4 +182,5 @@
       - id: TegCirculatorPartFlatpack
       - id: TegCenterPartFlatpack
       - id: GasAnalyzer
-      - id: SheetSteel30
+      - id: SheetSteel
+        amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -169,3 +169,17 @@
   - type: StorageFill
     contents:
       - id: TeslaGroundingRodFlatpack
+
+- type: entity
+  id: CrateEngineeringTEGKit
+  parent: CrateEngineeringSecure
+  name: TEG construction kit crate
+  description: A 'build your own TEG' kit. Some assembly required.
+  components:
+  - type: StorageFill
+    contents:
+      - id: TegCirculatorPartFlatpack
+      - id: TegCirculatorPartFlatpack
+      - id: TegCenterPartFlatpack
+      - id: GasAnalyzer
+      - id: SheetSteel30

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -69,6 +69,42 @@
 
 - type: entity
   parent: BaseFlatpack
+  id: TegCenterPartFlatpack
+  name: TEG Center flatpack
+  description: A flatpack used for constructing the central core of a TEG.
+  components:
+  - type: Flatpack
+    entity: TegCenter
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#cec8ac"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: GuideHelp
+    guides: [ TEG, Power ]
+
+- type: entity
+  parent: BaseFlatpack
+  id: TegCirculatorPartFlatpack
+  name: TEG Circulator flatpack
+  description: A flatpack used for constructing the circulator of a TEG.
+  components:
+  - type: Flatpack
+    entity: TegCirculator
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#cec8ac"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: GuideHelp
+    guides: [ TEG, Power ]
+
+- type: entity
+  parent: BaseFlatpack
   id: SingularityGeneratorFlatpack
   name: singularity generator flatpack
   description: A flatpack used for constructing a singularity generator.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR adds the option of constructing a Thermoelectric Generator (TEG) from scratch, by adding flatpacks for the TEG Center and TEG Circulator, as well as a crate that can be ordered from logistics that contains the flatpacks. 

The aim is to give engineering crews the ability to add a TEG to stations that might lack one, as a "fun" engineering project that can be pursued on shift. This capability already exists for the Singularity Engine and Tesla Engines.

The cost of the TEG Construction Kit is set at 8000 spesos, but this can be changed for balance reasons.

Note: Kit may contain small parts not suitable for children under 3 years old. Some assembly required.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

n/a

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Snímka obrazovky 2024-12-05 202816](https://github.com/user-attachments/assets/6c6c9f0d-89b2-4558-aa13-ca1c5bbca58d)
![Snímka obrazovky 2024-12-05 203211](https://github.com/user-attachments/assets/69227645-1382-45f0-848b-96b45e6da92f)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: zelezniciar
- add: TEG components now be ordered from Logistics and assembled on station. 
