### PR TITLE
Inverts the Check for Material Whitelist in CanChangeMaterialAmount

### DIFF
--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -123,7 +123,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         if (!CanTakeVolume(uid, volume, component))
             return false;
 
-        if (component.MaterialWhiteList == null ? false : component.MaterialWhiteList.Contains(materialId))
+        if (component.MaterialWhiteList == null ? false : !component.MaterialWhiteList.Contains(materialId))
             return false;
 
         var amount = component.Storage.GetValueOrDefault(materialId);


### PR DESCRIPTION
This change was actually suggested by April, I'm not the author.

It fixes Pacman generators and god knows what else.

Prior to the change you could insert steel in it, or just the wrong kind of fuel.

Since you could only load the wrong kind of fuel the generators were not working at all.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Ejecting steel from a pacman gen
![image](https://github.com/user-attachments/assets/28771e24-4c46-48f1-94dc-c3db03b059a6)

Them working after the fix.
![image](https://github.com/user-attachments/assets/cce907b2-097c-4d4a-837a-606e3c19b5b9)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->
