### PR TITLE
Replace Direct Uses of GameTicker Dictionary with `TryGetValue` (#33222)

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -174,7 +174,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return;
 
         var players = _playerManager.Sessions
-            .Where(x => GameTicker.PlayerGameStatuses[x.UserId] == PlayerGameStatus.JoinedGame)
+            .Where(x => GameTicker.PlayerGameStatuses.TryGetValue(x.UserId, out var status) && status == PlayerGameStatus.JoinedGame)
             .ToList();
 
         ChooseAntags((uid, component), players);


### PR DESCRIPTION
Cherry picks "Fix station events schedulers, antag selection and possibly other systems acting weird in a rare scenario."
# Description

This is being PRed mostly as a fix to an issue which caused the round to fail to start due to an error in antag selection, which did happen in Thief antags and may also happen with Bloodcult gamemode.

Double posting from discord:
> It fixed issues caused with antag selection at roundstart which affected roundstart Thief selection.
> 
> Since cultists are also selected exactly at roundstart - unlike traitors for instance, I think this might help with cultists too.
> 
> I tried to force start bloodcult gamemode in the past and it failed to start but I since I had tracebacks disabled trying to improve performance I'm not sure this was the cause.
> 

Credits to April for pointing this out for me after I commented on the issue.

----

This cherry picks 79ff990ddf7c7af40f70bcc7ba2d3220730852ab removing changes which change methods which do not exist yet on our side.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->
