### PR TITLE
Back Out "Flash Now Flashes Black Instead of White. (#14642)"

### DIFF
--- a/Resources/Textures/Shaders/flashed_effect.swsl
+++ b/Resources/Textures/Shaders/flashed_effect.swsl
@@ -12,7 +12,7 @@ void fragment() {
     highp vec4 textureMix = mix(tex1, tex2, 0.5);
 
     // Gradually mixes between the texture mix and a full-white texture, causing the "blinding" effect
-    highp vec4 mixed = mix(vec4(0.0, 0.0, 0.0, 1.0), textureMix, percentComplete);
+    highp vec4 mixed = mix(vec4(1.0, 1.0, 1.0, 1.0), textureMix, percentComplete);
 
     COLOR = vec4(mixed.rgb, remaining);
 }


### PR DESCRIPTION
Original commit changeset: c3dcc7a12464

# Description

Dark flash is cowardly. Billions must be flashbanged irl

# Changelog

:cl:
- tweak: Flashes are bright again!
