### PR TITLE
Make Prisoner Not Shitter Role

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -22,6 +22,10 @@
         - !type:CharacterTraitRequirement
           traits:
             - ShadowkinBlackeye
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: Pacified
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
# Description

Prisoner is consistently the most problematic role in this entire game, being seen as "The Self Antagging Role", which produces endless amounts of administrative burden. This is especially a problem with lowpop servers, or servers that are understaffed with admins. Players just join as Prisoner, *immediately* break out of the permabrig, and then go on a self antagging spree. The solution to this was staring us in the face the whole time. Just give them the same Pacified component that the Thief antag has. Now it's impossible for them to smash the permabrig windows, someone has to intentionally let them out, and even if they do, they will be hard pressed to selfantag when they can't turn on harm intent.

# Changelog

:cl:
- add: Prisoners now spawn with a Pacifier Implant.
