### PR TITLE
Trait Purchasable Mentalic Powers

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -3,7 +3,7 @@ trait-description-Blindness = You are legally blind, and can't see clearly past 
 trait-examined-Blindness = [color=lightblue]{CAPITALIZE(POSS-ADJ($target))} eyes are glassy and unfocused. It doesn't seem like {SUBJECT($target)} can see you well, if at all.[/color]
 
 trait-name-Narcolepsy = Narcolepsy
-trait-description-Narcolepsy = 
+trait-description-Narcolepsy =
     Due to a neurological disorder, controlling your sleep-wake cycles is difficult for you.
     As a result, you may repeatedly fall asleep for short periods of time throughout the day.
 
@@ -91,7 +91,7 @@ trait-name-Nearsighted = Nearsighted
 trait-description-Nearsighted = Your eyes are not what they once were, you have difficulty seeing things far away without corrective glasses.
 
 trait-name-NormalVisionHarpy = Trichromat Modification
-trait-description-NormalVisionHarpy = 
+trait-description-NormalVisionHarpy =
     Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
     You do not have the usual vision anomaly that your species may possess.
 
@@ -438,3 +438,29 @@ trait-description-CyberEyesOmni =
 
 trait-name-ShadowkinBlackeye = Blackeye
 trait-description-ShadowkinBlackeye = You lose your special Shadowkin powers, in return for some points.
+
+trait-name-DispelPower = Normality Projection
+trait-description-DispelPower =
+    Your Mentalic abilities include the power to enforce normality upon Noospheric phenomena.
+    This power, commonly known as "Dispel", allows the user to destroy otherworldly entities with their mind,
+    or to immediately end psychic effects.
+
+trait-name-MetapsionicPower = Metapsion
+trait-description-MetapsionicPower =
+    You are able to intuitively sense the activation of psionic abilities, as well as send out a 'scanning' pulse
+    to detect whether or not psions are nearby. This ability has a wide area of effect, and cannot precisely
+    scan individual entities. Still, it is better than being blind.
+
+trait-name-XenoglossyPower = Xenoglossy
+trait-description-XenoglossyPower =
+    An advanced form of Telepathy, Xenoglossy is the ability to speak using emotional and metaphysical concepts,
+    rather than words, to impart meaning directly into the minds of a listener. When speaking using Xenoglossy, a psion can be
+    universally understood by any entity, who will hear the words as if spoken in one's own native tongue. Additionally,
+    Xenoglossy grants the ability to divine the underlying emotional meaning from the minds of other speakers,
+    allowing its user to understand any spoken language as if it was the user's own native tongue.
+
+trait-name-PsychognomyPower = Psychognomist
+trait-description-PsychognomyPower =
+    A special talent derived from Telepathy, Psychognomy is the ability to read the underlying imprint of telepathic messages.
+    A Psychognomist can glean additional information from their telepathy, seeing vague outlines of what the source of a message
+    might be. This information is not precise, and is largely only useful for narrowing down who the source of a message might be.

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Blindness
   category: Visual
-  points: 6
+  points: 10
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -280,3 +280,134 @@
     - !type:TraitAddPsionics
       psionicPowers:
         - HighDampening
+
+- type: trait
+  id: DispelPower
+  category: Mental
+  points: -6
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - Librarian
+            - ForensicMantis
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - AnomalousPositronics
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - ResearchDirector
+  functions:
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - DispelPower
+
+- type: trait
+  id: MetapsionicPower
+  category: Mental
+  points: -4
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - Librarian
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - AnomalousPositronics
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - ResearchDirector
+        - ForensicMantis
+  functions:
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - MetapsionicPower
+
+- type: trait
+  id: XenoglossyPower
+  category: Mental
+  points: -10
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+            - NaturalTelepath
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - ResearchDirector
+            - ForensicMantis
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - AnomalousPositronics
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Librarian
+  functions:
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - XenoglossyPower
+
+- type: trait
+  id: PsychognomyPower
+  category: Mental
+  points: -3
+  requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterTraitRequirement
+          traits:
+            - LatentPsychic
+            - NaturalTelepath
+        - !type:CharacterJobRequirement
+          jobs:
+            - Chaplain
+            - ResearchDirector
+            - ForensicMantis
+            - Librarian
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - AnomalousPositronics
+  functions:
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - PsychognomyPower


### PR DESCRIPTION
# Description

This PR adds a few of the "Mentalic" category of psionic abilities to the Traits System, allowing them to be purchased by any character that is also a Latent Psychic. These powers are:
- Dispel
- Metapsionic Pulse
- Xenoglossy (Also requires Natural Telepath)
- Psychognomy (Also requires Natural Telepath)

These are all quite expensive, so to help address the "Expensive trait proliferation", I've increased the points granted by the Blindness trait to 10. Have fun being a blind wizard. From this point on, we're going to need to start adding more "High point value" negative traits.

# Changelog

:cl:
- add: Dispel, Metapsionic Pulse, Xenoglossy, and Psychognomy can all be purchased during character creation using trait points.
- tweak: Blindness now grants 10 trait points instead of 6.
