### PR TITLE
Fix Ripley Hydraulic Clamp

### DIFF
--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -83,10 +83,9 @@ public sealed class MechGrabberSystem : EntitySystem
         var xform = Transform(toRemove);
         _transform.AttachToGridOrMap(toRemove, xform);
         var (mechPos, mechRot) = _transform.GetWorldPositionRotation(mechxform);
-        var toRemoveWorldPos = _transform.GetWorldPosition(xform);
 
         var offset = mechPos + mechRot.RotateVec(component.DepositOffset);
-        _transform.SetWorldPositionRotation(toRemove, toRemoveWorldPos + offset, Angle.Zero);
+        _transform.SetWorldPositionRotation(toRemove, offset, Angle.Zero);
         _mech.UpdateUserInterface(mech);
     }
 
@@ -157,7 +156,7 @@ public sealed class MechGrabberSystem : EntitySystem
 
         args.Handled = true;
         var audio = _audio.PlayPvs(component.GrabSound, uid);
-        
+
         if (audio == null)
             return;
 


### PR DESCRIPTION
# Description

Fix a bug in `MechGrabberSystem` causing the hydraulic clamps in Ripley to drop items far away.

---

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/d2c8e951-e391-42d7-b45d-78a275dc8bf2

</p>
</details>

---

# Changelog

:cl:
- fix: Hydraulic clamps now drop entities correctly
