### PR TITLE
Pointy Ears For Harpies And Arachne

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/pointy_ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/pointy_ears.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_standard
@@ -13,7 +13,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_wide
@@ -23,7 +23,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_small
@@ -33,7 +33,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_upwards
@@ -43,7 +43,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_tall
@@ -53,7 +53,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_slanted
@@ -63,7 +63,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_thin
@@ -73,7 +73,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_large
@@ -83,7 +83,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni, Harpy]
+  speciesRestriction: [Oni, Harpy, Arachne]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_none

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/pointy_ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/pointy_ears.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_standard
@@ -13,7 +13,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_wide
@@ -23,7 +23,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_small
@@ -33,7 +33,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_upwards
@@ -43,7 +43,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_tall
@@ -53,7 +53,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_slanted
@@ -63,7 +63,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_thin
@@ -73,7 +73,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_large
@@ -83,7 +83,7 @@
   bodyPart: HeadSide
   markingCategory: HeadSide
   forcedColoring: true
-  speciesRestriction: [Oni]
+  speciesRestriction: [Oni, Harpy]
   sprites:
   - sprite: Mobs/Customization/pointy_ears.rsi
     state: pointy_ears_none

--- a/Resources/Prototypes/Species/arachne.yml
+++ b/Resources/Prototypes/Species/arachne.yml
@@ -22,7 +22,7 @@
       points: 1
       required: false
     HeadSide:
-      points: 2
+      points: 3
       required: false
     Tail:
       points: 1

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -54,7 +54,7 @@
       required: true
       defaultMarkings: [ HarpyEarsDefault ]
     HeadSide:
-      points: 2
+      points: 3
       required: false
     Chest:
       points: 1


### PR DESCRIPTION
# Description

Like half the art references I have for Harpies have them with elf-like pointed ears, another half have them with their feather tufts. We have pointy ears markings, so this PR makes it so that Harpies can have them. Actually it also gives them to Arachne, for similar reasons(It's an oddly common thing on Arachne/Lamia art depictions). 

# Changelog

:cl:
- add: Added a variety of Pointy Ears markings for Harpy and Arachne characters. 
