### PR TITLE
Redshirt And Brittle Bone Traits

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -464,3 +464,16 @@ trait-description-PsychognomyPower =
     A special talent derived from Telepathy, Psychognomy is the ability to read the underlying imprint of telepathic messages.
     A Psychognomist can glean additional information from their telepathy, seeing vague outlines of what the source of a message
     might be. This information is not precise, and is largely only useful for narrowing down who the source of a message might be.
+
+trait-name-Redshirt = Redshirt
+trait-description-Redshirt =
+    They said this air would be breathable.
+    Get in, get out again, and no one gets hurt.
+    Something is pulling me up the hill.
+    I look down in my red shirt.
+    I look down in my red shirt.
+
+trait-name-BrittleBoneDisease = Osteogenesis Imperfecta
+trait-description-BrittleBoneDisease =
+    Also known as "brittle bone disease", people with this genetic disorder have bones that are easily broken,
+    often simply by moving. This trait reduces your threshold for critical injury by 50 points.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -669,3 +669,43 @@
           - Biological
           - Inorganic
           - Silicon
+
+- type: trait
+  id: Redshirt
+  category: Physical
+  points: -8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: DeadModifier
+          deadThresholdModifier: -100
+
+- type: trait
+  id: BrittleBoneDisease
+  category: Physical
+  points: -10
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: CritModifier
+          critThresholdModifier: -50


### PR DESCRIPTION
# Description

This PR adds two additional "High Value" physical negative traits, to help address a growing need for more high point value negatives, since there is also a very large number of high point positive traits. These two traits are fairly simple, the first is Redshirt, which decreases your Dead threshold by 100, and Brittle Bone Disease , which reduces your Crit threshold by 50. Taking both on an ordinary human would give +18 trait points to work with, but would in turn give a healthbar of only 50/100, compared with the standard healthbar of 100/200. 

# Changelog

:cl:
- add: Added Redshirt and Brittle Bone Disease traits. These give extremely large negative modifiers to your healthbar, but also grant a large amount of trait points to work with.
