### PR TITLE
Example Hub Ad List

### DIFF
--- a/Resources/ConfigPresets/EinsteinEngines/default.toml
+++ b/Resources/ConfigPresets/EinsteinEngines/default.toml
@@ -18,7 +18,7 @@ lobbyduration      = 240
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med"
-hub_urls = "https://hub.spacestation14.com/"
+hub_urls = "https://hub.spacestation14.com/, https://web.networkgamez.com/, https://hub.singularity14.co.uk/"
 
 [ic]
 flavor_text = true


### PR DESCRIPTION
# Description

this PR extends the list of default advertiser hubs to include every existing hub except for SSMV(Which is mutually exclusive with the others). If there are more hubs I have missed, please let me know. This will allow our servers to appear on as many hubs as possible.
