### PR TITLE
Basic Soft-Crit Implementation

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2813,5 +2813,25 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> UseDynamicHostname =
             CVarDef.Create("game.use_dynamic_hostname", false, CVar.SERVERONLY);
+
+        #region SoftCrit
+
+        /// <summary>
+        ///     Used for basic Soft-Crit implementation. Entities are allowed to crawl when in crit, as this CVar intercepts the mover controller check for incapacitation,
+        ///     and prevents it from stopping movement if this CVar is set to true and the user is Crit but Not Dead. This is only for movement,
+        ///     you still can't stand up while crit, and you're still more or less helpless.
+        /// </summary>
+        public static readonly CVarDef<bool> AllowMovementWhileCrit =
+            CVarDef.Create("mobstate.allow_movement_while_crit", true, CVar.REPLICATED);
+
+        /// <summary>
+        ///     Currently does nothing because I would have to figure out WHERE I would even put this check, and the mover controller is fairly complicated.
+        ///     The goal is to make it so that attempting to move while in 'soft crit' can potentially cause further injury, causing you to die faster. Ideally there would be special
+        ///     actions that can be performed in soft crit, such as applying pressure to your own injuries to slow down the bleedout, or other varieties of "Will To Live".
+        /// </summary>
+        public static readonly CVarDef<bool> DamageWhileCritMove =
+            CVarDef.Create("mobstate.damage_while_crit_move", false, CVar.REPLICATED);
+
+        #endregion
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2824,6 +2824,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AllowMovementWhileCrit =
             CVarDef.Create("mobstate.allow_movement_while_crit", true, CVar.REPLICATED);
 
+        public static readonly CVarDef<bool> AllowTalkingWhileCrit =
+            CVarDef.Create("mobstate.allow_talking_while_crit", true, CVar.REPLICATED);
+
         /// <summary>
         ///     Currently does nothing because I would have to figure out WHERE I would even put this check, and the mover controller is fairly complicated.
         ///     The goal is to make it so that attempting to move while in 'soft crit' can potentially cause further injury, causing you to die faster. Ideally there would be special

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -30,7 +30,7 @@ public partial class MobStateSystem
     private void SubscribeEvents()
     {
         SubscribeLocalEvent<MobStateComponent, BeforeGettingStrippedEvent>(OnGettingStripped);
-        SubscribeLocalEvent<MobStateComponent, ChangeDirectionAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, ChangeDirectionAttemptEvent>(OnDirectionAttempt);
         SubscribeLocalEvent<MobStateComponent, UseAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, AttackAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, ConsciousAttemptEvent>(CheckAct);
@@ -42,7 +42,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, DropAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, PickupAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StartPullAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, UpdateCanMoveEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, UpdateCanMoveEvent>(OnMoveAttempt);
         SubscribeLocalEvent<MobStateComponent, StandAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, PointAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
@@ -51,6 +51,23 @@ public partial class MobStateSystem
 
         SubscribeLocalEvent<MobStateComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
     }
+
+    private void OnDirectionAttempt(Entity<MobStateComponent> ent, ref ChangeDirectionAttemptEvent args)
+    {
+        if (ent.Comp.CurrentState is MobState.Critical && _configurationManager.GetCVar(CCVars.AllowMovementWhileCrit))
+            return;
+
+        CheckAct(ent.Owner, ent.Comp, args);
+    }
+
+    private void OnMoveAttempt(Entity<MobStateComponent> ent, ref UpdateCanMoveEvent args)
+    {
+        if (ent.Comp.CurrentState is MobState.Critical && _configurationManager.GetCVar(CCVars.AllowMovementWhileCrit))
+            return;
+
+        CheckAct(ent.Owner, ent.Comp, args);
+    }
+
 
     private void OnUnbuckleAttempt(Entity<MobStateComponent> ent, ref UnbuckleAttemptEvent args)
     {

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Emoting;
@@ -16,12 +17,15 @@ using Content.Shared.Speech;
 using Content.Shared.Standing;
 using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
+using Robust.Shared.Configuration;
 using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Mobs.Systems;
 
 public partial class MobStateSystem
 {
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
     //General purpose event subscriptions. If you can avoid it register these events inside their own systems
     private void SubscribeEvents()
     {
@@ -144,6 +148,9 @@ public partial class MobStateSystem
             RemCompDeferred<AllowNextCritSpeechComponent>(uid);
             return;
         }
+
+        if (component.CurrentState is MobState.Critical && _configurationManager.GetCVar(CCVars.AllowTalkingWhileCrit))
+            return;
 
         CheckAct(uid, component, args);
     }

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -305,8 +305,11 @@ namespace Content.Shared.Movement.Systems
                 if (MoverQuery.TryGetComponent(entity, out var mover))
                     SetMoveInput(mover, MoveButtons.None);
 
-                if (!_mobState.IsIncapacitated(entity))
-                    HandleDirChange(relayMover.RelayEntity, dir, subTick, state);
+                if (_mobState.IsDead(entity)
+                    || _mobState.IsCritical(entity) && !_configManager.GetCVar(CCVars.AllowMovementWhileCrit))
+                    return;
+
+                HandleDirChange(relayMover.RelayEntity, dir, subTick, state);
 
                 return;
             }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -125,9 +125,10 @@ namespace Content.Shared.Movement.Systems
             var canMove = mover.CanMove;
             if (RelayTargetQuery.TryGetComponent(uid, out var relayTarget))
             {
-                if (_mobState.IsIncapacitated(relayTarget.Source) ||
-                    TryComp<SleepingComponent>(relayTarget.Source, out _) ||
-                    !MoverQuery.TryGetComponent(relayTarget.Source, out var relayedMover))
+                if (_mobState.IsDead(relayTarget.Source)
+                    || TryComp<SleepingComponent>(relayTarget.Source, out _)
+                    || !MoverQuery.TryGetComponent(relayTarget.Source, out var relayedMover)
+                    || _mobState.IsCritical(relayTarget.Source) && !_configManager.GetCVar(CCVars.AllowMovementWhileCrit))
                 {
                     canMove = false;
                 }


### PR DESCRIPTION
# Description

This PR adds a simple server configuration option for enabling basic "Soft-Crit", and not much else because oh my god this system is horribly complicated. When enabled, characters can crawl around very slowly while in crit, and really not much else. This more or less mirrors how crit affects character movement in SS13, where you can at least crawl to relative safety while bleeding to death. 

# Changelog

:cl:
- add: Added server config options for basic "Soft-Crit". When enabled, characters who are critically injured can still slowly crawl, but are otherwise still helpless and dying.
