### PR TITLE
Arrivals Tweaks

### DIFF
--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -35,6 +35,7 @@ entities:
     components:
     - type: MetaData
       name: map 30
+    - type: ProtectedGrid
     - type: Transform
     - type: Map
       mapPaused: True
@@ -48,6 +49,7 @@ entities:
     components:
     - type: MetaData
       name: CentCom Downstairs
+    - type: ProtectedGrid
     - type: Transform
       parent: 1
     - type: MapGrid
@@ -4823,6 +4825,9 @@ entities:
     - type: Transform
       pos: -3.478174,15.587257
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: BodyBagFolded
   entities:
   - uid: 2019
@@ -16556,6 +16561,9 @@ entities:
     - type: Transform
       pos: 2.5162191,14.7318
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: CarbonDioxideCanister
   entities:
   - uid: 8607
@@ -19089,6 +19097,25 @@ entities:
     - type: Transform
       pos: 4.5232472,13.728849
       parent: 2
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]10%[/color].
+          priority: 0
+          component: Armor
+        title: null
+    missingComponents:
+    - Item
+    - Pullable
 - proto: ClothingBackpackSatchelBrigmedic
   entities:
   - uid: 1908
@@ -19402,6 +19429,9 @@ entities:
     - type: Transform
       pos: 4.4697094,15.602008
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: ClothingHeadsetMining
   entities:
   - uid: 1076
@@ -19461,6 +19491,9 @@ entities:
     - type: Transform
       pos: -5.5118904,15.498761
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: ClothingMaskGasExplorer
   entities:
   - uid: 8612
@@ -19506,6 +19539,9 @@ entities:
     - type: Transform
       pos: 4.4697094,14.717052
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: ClothingNeckHeadphones
   entities:
   - uid: 8036
@@ -20565,6 +20601,58 @@ entities:
     components:
     - type: Transform
       pos: 0.5,35.5
+      parent: 2
+- proto: DecorFloorPalletStack
+  entities:
+  - uid: 8093
+    components:
+    - type: Transform
+      pos: -17.5,-39.5
+      parent: 2
+  - uid: 8094
+    components:
+    - type: Transform
+      pos: -17.5,-38.5
+      parent: 2
+  - uid: 8095
+    components:
+    - type: Transform
+      pos: -17.5,-40.5
+      parent: 2
+  - uid: 8134
+    components:
+    - type: Transform
+      pos: 16.5,-38.5
+      parent: 2
+  - uid: 8135
+    components:
+    - type: Transform
+      pos: 16.5,-39.5
+      parent: 2
+  - uid: 8153
+    components:
+    - type: Transform
+      pos: 16.5,-40.5
+      parent: 2
+  - uid: 8674
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 8675
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 8676
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 2
+  - uid: 8680
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
       parent: 2
 - proto: DisposalBend
   entities:
@@ -24375,6 +24463,9 @@ entities:
     - type: Transform
       pos: 2.5111954,18.597483
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: FoodDonkpocketSpicy
   entities:
   - uid: 7843
@@ -24390,6 +24481,9 @@ entities:
     - type: Transform
       pos: -5.5118904,13.610855
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: FoodPizzaMeatSlice
   entities:
   - uid: 8650
@@ -38500,6 +38594,58 @@ entities:
     - type: Transform
       pos: 38.5,-3.5
       parent: 2
+- proto: MarkerBlocker
+  entities:
+  - uid: 8131
+    components:
+    - type: Transform
+      pos: 16.5,-38.5
+      parent: 2
+  - uid: 8132
+    components:
+    - type: Transform
+      pos: 16.5,-39.5
+      parent: 2
+  - uid: 8133
+    components:
+    - type: Transform
+      pos: 16.5,-40.5
+      parent: 2
+  - uid: 8677
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 2
+  - uid: 8678
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 8679
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 8681
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 8682
+    components:
+    - type: Transform
+      pos: -17.5,-38.5
+      parent: 2
+  - uid: 8683
+    components:
+    - type: Transform
+      pos: -17.5,-39.5
+      parent: 2
+  - uid: 8684
+    components:
+    - type: Transform
+      pos: -17.5,-40.5
+      parent: 2
 - proto: Matchbox
   entities:
   - uid: 7912
@@ -42818,51 +42964,6 @@ entities:
     - type: Transform
       pos: -8.5,-10.5
       parent: 2
-  - uid: 8093
-    components:
-    - type: Transform
-      pos: 24.5,-3.5
-      parent: 2
-  - uid: 8094
-    components:
-    - type: Transform
-      pos: 22.5,2.5
-      parent: 2
-  - uid: 8095
-    components:
-    - type: Transform
-      pos: 42.5,-10.5
-      parent: 2
-  - uid: 8131
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 2
-  - uid: 8132
-    components:
-    - type: Transform
-      pos: 5.5,-6.5
-      parent: 2
-  - uid: 8133
-    components:
-    - type: Transform
-      pos: 3.5,-6.5
-      parent: 2
-  - uid: 8134
-    components:
-    - type: Transform
-      pos: -7.5,4.5
-      parent: 2
-  - uid: 8135
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 2
-  - uid: 8153
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 2
   - uid: 8745
     components:
     - type: Transform
@@ -44306,6 +44407,9 @@ entities:
     - type: Transform
       pos: 2.5752501,15.498761
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: TelecomServerFilled
   entities:
   - uid: 3110
@@ -44320,6 +44424,9 @@ entities:
     - type: Transform
       pos: -3.5098875,18.597483
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: ToolboxEmergencyFilled
   entities:
   - uid: 8570
@@ -52935,6 +53042,9 @@ entities:
     - type: Transform
       pos: -3.537204,14.761298
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: WeaponTaser
   entities:
   - uid: 3057
@@ -52942,6 +53052,9 @@ entities:
     - type: Transform
       pos: 2.5111954,11.4883375
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: WeaponTetherGun
   entities:
   - uid: 3059
@@ -52949,6 +53062,9 @@ entities:
     - type: Transform
       pos: -5.5782247,14.510563
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: WeaponTurretHostile
   entities:
   - uid: 1237
@@ -52980,6 +53096,9 @@ entities:
     - type: Transform
       pos: -3.513493,11.505985
       parent: 2
+    missingComponents:
+    - Item
+    - Pullable
 - proto: WelderMini
   entities:
   - uid: 1178
@@ -53087,11 +53206,15 @@ entities:
     - type: Transform
       pos: 2.5,-14.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 189
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 190
     components:
     - type: Transform
@@ -53132,11 +53255,15 @@ entities:
     - type: Transform
       pos: -3.5,-14.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 321
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 335
     components:
     - type: Transform
@@ -53192,11 +53319,15 @@ entities:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 797
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 2
+    - type: Godmode
+      oldDamage: {}
   - uid: 936
     components:
     - type: Transform


### PR DESCRIPTION
# Description

Arrivals spawns have been limited to only the massive cryogenics bay, and impassable barriers have been added that block access to the deeper parts of Terminal. I've also modified the admeme items that were in displays so that they are now fake items that can't actually be used by players even if they SOMEHOW smash their way in and defeat the turrets. I have photo evidence of people doing this. 

Just in case, I also made arrivals a ProtectedGrid.

# Changelog

:cl:
- tweak: Tweaked arrivals to reduce the playable area, and some concessions have been made to prevent access to admeme items that were on display. These changes are pending a later update where we port Arrivals Job Spawns. 
