### PR TITLE
Fix Mindbreaker and Soulbreaker Rounds Not Injecting Their Solutions.

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/special.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/special.yml
@@ -89,6 +89,6 @@
     solution: ammo
   - type: SolutionInjectOnProjectileHit
     transferAmount: 9
-    blockSlots: NONE #shouldn't be blocked by a mask
+    solution: ammo
   - type: InjectableSolution
     solution: ammo

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
@@ -21,6 +21,6 @@
     solution: ammo
   - type: SolutionInjectOnProjectileHit
     transferAmount: 15
-    blockSlots: NONE #tranquillizer darts shouldn't be blocked by a mask
+    solution: ammo
   - type: InjectableSolution
     solution: ammo


### PR DESCRIPTION
# Description

Fixes #1374

I'm not sure exactly when this changed, but you now have to specify which solution you want to inject.

Also inject on hit defaults to ignoring clothing, so I removed the redundant set.
---

# Changelog


:cl:
- fix: Fixed mindbreaker and soulbreaker cartridges not injecting their solutions.