### PR TITLE
Remove Europa From Map Pool

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -16,4 +16,4 @@
   - TheHive
   - Gax
   - Rad
-  - Europa
+#  - Europa


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

There are a _lot_ of issues surrounding Europa, which include, but the big two are:
- How many complaints I'm receiving about it in general.
- Engineering issues, including a lack of an alternative beyond an SM (supposedly)
- Lacking a cryosleep area.
- Distro air and waste are connected together.
- More here https://github.com/Simple-Station/Einstein-Engines/issues/1379#issuecomment-2564303908

Is there a way we can add people to review maps specifically? I'm not a mapper, but the last few maps that have gotten through have been _bad_ at the start.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: *Temporarily* removed Europa from map pool, pending some refurbishing.
