### PR TITLE
Some MobState Refactoring

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -388,6 +388,9 @@ public sealed partial class TraitModifyMobThresholds : TraitFunction
 [UsedImplicitly]
 public sealed partial class TraitModifyMobState : TraitFunction
 {
+    // Three-State Booleans my beloved.
+    // :faridabirb.png:
+
     [DataField, AlwaysPushInheritance]
     public bool? AllowMovementWhileCrit;
 

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -386,6 +386,91 @@ public sealed partial class TraitModifyMobThresholds : TraitFunction
 }
 
 [UsedImplicitly]
+public sealed partial class TraitModifyMobState : TraitFunction
+{
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowMovementWhileCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowMovementWhileSoftCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowMovementWhileDead;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowTalkingWhileCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowTalkingWhileSoftCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowTalkingWhileDead;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? DownWhenCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? DownWhenSoftCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? DownWhenDead;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowHandInteractWhileCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowHandInteractWhileSoftCrit;
+
+    [DataField, AlwaysPushInheritance]
+    public bool? AllowHandInteractWhileDead;
+
+    public override void OnPlayerSpawn(EntityUid uid,
+        IComponentFactory factory,
+        IEntityManager entityManager,
+        ISerializationManager serializationManager)
+    {
+        if (!entityManager.TryGetComponent<MobStateComponent>(uid, out var mobStateComponent))
+            return;
+
+        if (AllowMovementWhileCrit is not null)
+            mobStateComponent.AllowMovementWhileCrit = AllowMovementWhileCrit.Value;
+
+        if (AllowMovementWhileSoftCrit is not null)
+            mobStateComponent.AllowHandInteractWhileSoftCrit = AllowMovementWhileSoftCrit.Value;
+
+        if (AllowMovementWhileDead is not null)
+            mobStateComponent.AllowMovementWhileDead = AllowMovementWhileDead.Value;
+
+        if (AllowTalkingWhileCrit is not null)
+            mobStateComponent.AllowTalkingWhileCrit = AllowTalkingWhileCrit.Value;
+
+        if (AllowTalkingWhileSoftCrit is not null)
+            mobStateComponent.AllowTalkingWhileSoftCrit = AllowTalkingWhileSoftCrit.Value;
+
+        if (AllowTalkingWhileDead is not null)
+            mobStateComponent.AllowTalkingWhileDead = AllowTalkingWhileDead.Value;
+
+        if (DownWhenCrit is not null)
+            mobStateComponent.DownWhenCrit = DownWhenCrit.Value;
+
+        if (DownWhenSoftCrit is not null)
+            mobStateComponent.DownWhenSoftCrit = DownWhenSoftCrit.Value;
+
+        if (DownWhenDead is not null)
+            mobStateComponent.DownWhenDead = DownWhenDead.Value;
+
+        if (AllowHandInteractWhileCrit is not null)
+            mobStateComponent.AllowHandInteractWhileCrit = AllowHandInteractWhileCrit.Value;
+
+        if (AllowHandInteractWhileSoftCrit is not null)
+            mobStateComponent.AllowHandInteractWhileSoftCrit = AllowHandInteractWhileSoftCrit.Value;
+
+        if (AllowHandInteractWhileDead is not null)
+            mobStateComponent.AllowHandInteractWhileDead = AllowHandInteractWhileDead.Value;
+    }
+}
+
+[UsedImplicitly]
 public sealed partial class TraitModifyStamina : TraitFunction
 {
     [DataField, AlwaysPushInheritance]

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -348,6 +348,9 @@ public sealed partial class TraitModifyMobThresholds : TraitFunction
     public int CritThresholdModifier;
 
     [DataField, AlwaysPushInheritance]
+    public int SoftCritThresholdModifier;
+
+    [DataField, AlwaysPushInheritance]
     public int DeadThresholdModifier;
 
     public override void OnPlayerSpawn(EntityUid uid,
@@ -364,6 +367,13 @@ public sealed partial class TraitModifyMobThresholds : TraitFunction
             var critThreshold = thresholdSystem.GetThresholdForState(uid, MobState.Critical, threshold);
             if (critThreshold != 0)
                 thresholdSystem.SetMobStateThreshold(uid, critThreshold + CritThresholdModifier, MobState.Critical);
+        }
+
+        if (SoftCritThresholdModifier != 0)
+        {
+            var softCritThreshold = thresholdSystem.GetThresholdForState(uid, MobState.SoftCritical, threshold);
+            if (softCritThreshold != 0)
+                thresholdSystem.SetMobStateThreshold(uid, softCritThreshold + SoftCritThresholdModifier, MobState.SoftCritical);
         }
 
         if (DeadThresholdModifier != 0)

--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -1,108 +1,105 @@
 using Content.Shared.Damage;
-using Content.Shared.Mobs.Systems;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Mobs.Components
+namespace Content.Shared.Mobs.Components;
+
+/// <summary>
+///     When attached to an <see cref="DamageableComponent"/>,
+///     this component will handle critical and death behaviors for mobs.
+///     Additionally, it handles sending effects to clients
+///     (such as blur effect for unconsciousness) and managing the health HUD.
+/// </summary>
+[RegisterComponent]
+[NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class MobStateComponent : Component
 {
     /// <summary>
-    ///     When attached to an <see cref="DamageableComponent"/>,
-    ///     this component will handle critical and death behaviors for mobs.
-    ///     Additionally, it handles sending effects to clients
-    ///     (such as blur effect for unconsciousness) and managing the health HUD.
+    ///     Whether this mob will be allowed to issue movement commands when in the Critical MobState.
     /// </summary>
-    [RegisterComponent]
-    [NetworkedComponent]
-    [AutoGenerateComponentState]
-    [Access(typeof(MobStateSystem), typeof(MobThresholdSystem))]
-    public sealed partial class MobStateComponent : Component
-    {
-        /// <summary>
-        ///     Whether this mob will be allowed to issue movement commands when in the Critical MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowMovementWhileCrit;
+    [DataField]
+    public bool AllowMovementWhileCrit;
 
-        /// <summary>
-        ///     Whether this mob will be allowed to issue movement commands when in the Soft-Crit MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowMovementWhileSoftCrit;
+    /// <summary>
+    ///     Whether this mob will be allowed to issue movement commands when in the Soft-Crit MobState.
+    /// </summary>
+    [DataField]
+    public bool AllowMovementWhileSoftCrit;
 
-        /// <summary>
-        ///     Whether this mob will be allowed to issue movement commands when in the Dead MobState.
-        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
-        /// </summary>
-        [DataField]
-        public bool AllowMovementWhileDead;
+    /// <summary>
+    ///     Whether this mob will be allowed to issue movement commands when in the Dead MobState.
+    ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+    /// </summary>
+    [DataField]
+    public bool AllowMovementWhileDead;
 
-        /// <summary>
-        ///     Whether this mob will be allowed to talk while in the Critical MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowTalkingWhileCrit = true;
+    /// <summary>
+    ///     Whether this mob will be allowed to talk while in the Critical MobState.
+    /// </summary>
+    [DataField]
+    public bool AllowTalkingWhileCrit = true;
 
-        /// <summary>
-        ///     Whether this mob will be allowed to talk while in the SoftCritical MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowTalkingWhileSoftCrit = true;
+    /// <summary>
+    ///     Whether this mob will be allowed to talk while in the SoftCritical MobState.
+    /// </summary>
+    [DataField]
+    public bool AllowTalkingWhileSoftCrit = true;
 
-        /// <summary>
-        ///     Whether this mob will be allowed to talk while in the Dead MobState.
-        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
-        /// </summary>
-        [DataField]
-        public bool AllowTalkingWhileDead;
+    /// <summary>
+    ///     Whether this mob will be allowed to talk while in the Dead MobState.
+    ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+    /// </summary>
+    [DataField]
+    public bool AllowTalkingWhileDead;
 
-        /// <summary>
-        ///     Whether this mob is forced to be downed when entering the Critical MobState.
-        /// </summary>
-        [DataField]
-        public bool DownWhenCrit = true;
+    /// <summary>
+    ///     Whether this mob is forced to be downed when entering the Critical MobState.
+    /// </summary>
+    [DataField]
+    public bool DownWhenCrit = true;
 
-        /// <summary>
-        ///     Whether this mob is forced to be downed when entering the SoftCritical MobState.
-        /// </summary>
-        [DataField]
-        public bool DownWhenSoftCrit = true;
+    /// <summary>
+    ///     Whether this mob is forced to be downed when entering the SoftCritical MobState.
+    /// </summary>
+    [DataField]
+    public bool DownWhenSoftCrit = true;
 
-        /// <summary>
-        ///     Whether this mob is forced to be downed when entering the Dead MobState.
-        /// </summary>
-        [DataField]
-        public bool DownWhenDead = true;
+    /// <summary>
+    ///     Whether this mob is forced to be downed when entering the Dead MobState.
+    /// </summary>
+    [DataField]
+    public bool DownWhenDead = true;
 
-        /// <summary>
-        ///     Whether this mob is allowed to perform hand interactions while in the Critical MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowHandInteractWhileCrit;
+    /// <summary>
+    ///     Whether this mob is allowed to perform hand interactions while in the Critical MobState.
+    /// </summary>
+    [DataField]
+    public bool AllowHandInteractWhileCrit;
 
-        /// <summary>
-        ///     Whether this mob is allowed to perform hand interactions while in the SoftCritical MobState.
-        /// </summary>
-        [DataField]
-        public bool AllowHandInteractWhileSoftCrit;
+    /// <summary>
+    ///     Whether this mob is allowed to perform hand interactions while in the SoftCritical MobState.
+    /// </summary>
+    [DataField]
+    public bool AllowHandInteractWhileSoftCrit;
 
-        /// <summary>
-        ///     Whether this mob is allowed to perform hand interactions while in the Dead MobState.
-        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
-        /// </summary>
-        [DataField]
-        public bool AllowHandInteractWhileDead;
+    /// <summary>
+    ///     Whether this mob is allowed to perform hand interactions while in the Dead MobState.
+    ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+    /// </summary>
+    [DataField]
+    public bool AllowHandInteractWhileDead;
 
-        //default mobstate is always the lowest state level
-        [AutoNetworkedField, ViewVariables]
-        public MobState CurrentState { get; set; } = MobState.Alive;
+    //default mobstate is always the lowest state level
+    [AutoNetworkedField, ViewVariables]
+    public MobState CurrentState { get; set; } = MobState.Alive;
 
-        [DataField]
-        [AutoNetworkedField]
-        public HashSet<MobState> AllowedStates = new()
-            {
-                MobState.Alive,
-                MobState.Critical,
-                MobState.SoftCritical,
-                MobState.Dead
-            };
-    }
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<MobState> AllowedStates = new()
+        {
+            MobState.Alive,
+            MobState.Critical,
+            MobState.SoftCritical,
+            MobState.Dead
+        };
 }

--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Mobs.Components
 {
@@ -17,6 +16,81 @@ namespace Content.Shared.Mobs.Components
     [Access(typeof(MobStateSystem), typeof(MobThresholdSystem))]
     public sealed partial class MobStateComponent : Component
     {
+        /// <summary>
+        ///     Whether this mob will be allowed to issue movement commands when in the Critical MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowMovementWhileCrit;
+
+        /// <summary>
+        ///     Whether this mob will be allowed to issue movement commands when in the Soft-Crit MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowMovementWhileSoftCrit;
+
+        /// <summary>
+        ///     Whether this mob will be allowed to issue movement commands when in the Dead MobState.
+        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+        /// </summary>
+        [DataField]
+        public bool AllowMovementWhileDead;
+
+        /// <summary>
+        ///     Whether this mob will be allowed to talk while in the Critical MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowTalkingWhileCrit = true;
+
+        /// <summary>
+        ///     Whether this mob will be allowed to talk while in the SoftCritical MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowTalkingWhileSoftCrit = true;
+
+        /// <summary>
+        ///     Whether this mob will be allowed to talk while in the Dead MobState.
+        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+        /// </summary>
+        [DataField]
+        public bool AllowTalkingWhileDead;
+
+        /// <summary>
+        ///     Whether this mob is forced to be downed when entering the Critical MobState.
+        /// </summary>
+        [DataField]
+        public bool DownWhenCrit = true;
+
+        /// <summary>
+        ///     Whether this mob is forced to be downed when entering the SoftCritical MobState.
+        /// </summary>
+        [DataField]
+        public bool DownWhenSoftCrit = true;
+
+        /// <summary>
+        ///     Whether this mob is forced to be downed when entering the Dead MobState.
+        /// </summary>
+        [DataField]
+        public bool DownWhenDead = true;
+
+        /// <summary>
+        ///     Whether this mob is allowed to perform hand interactions while in the Critical MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowHandInteractWhileCrit;
+
+        /// <summary>
+        ///     Whether this mob is allowed to perform hand interactions while in the SoftCritical MobState.
+        /// </summary>
+        [DataField]
+        public bool AllowHandInteractWhileSoftCrit;
+
+        /// <summary>
+        ///     Whether this mob is allowed to perform hand interactions while in the Dead MobState.
+        ///     This is provided for completeness sake, and *probably* shouldn't be used by default.
+        /// </summary>
+        [DataField]
+        public bool AllowHandInteractWhileDead;
+
         //default mobstate is always the lowest state level
         [AutoNetworkedField, ViewVariables]
         public MobState CurrentState { get; set; } = MobState.Alive;
@@ -27,6 +101,7 @@ namespace Content.Shared.Mobs.Components
             {
                 MobState.Alive,
                 MobState.Critical,
+                MobState.SoftCritical,
                 MobState.Dead
             };
     }

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -11,20 +11,20 @@ namespace Content.Shared.Mobs.Components;
 [Access(typeof(MobThresholdSystem))]
 public sealed partial class MobThresholdsComponent : Component
 {
-    [DataField("thresholds", required: true)]
+    [DataField(required: true)]
     public SortedDictionary<FixedPoint2, MobState> Thresholds = new();
 
-    [DataField("triggersAlerts")]
+    [DataField]
     public bool TriggersAlerts = true;
 
-    [DataField("currentThresholdState")]
+    [DataField]
     public MobState CurrentThresholdState;
 
     /// <summary>
     /// The health alert that should be displayed for player controlled entities.
     /// Used for alternate health alerts (silicons, for example)
     /// </summary>
-    [DataField("stateAlertDict")]
+    [DataField]
     public Dictionary<MobState, ProtoId<AlertPrototype>> StateAlertDict = new()
     {
         {MobState.Alive, "HumanHealth"},
@@ -39,13 +39,13 @@ public sealed partial class MobThresholdsComponent : Component
     /// <summary>
     /// Whether or not this entity should display damage overlays (robots don't feel pain, black out etc.)
     /// </summary>
-    [DataField("showOverlays")]
+    [DataField]
     public bool ShowOverlays = true;
 
     /// <summary>
     /// Whether or not this entity can be revived out of a dead state.
     /// </summary>
-    [DataField("allowRevives")]
+    [DataField]
     public bool AllowRevives;
 }
 

--- a/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
+++ b/Content.Shared/Mobs/Components/MobThresholdsComponent.cs
@@ -29,6 +29,7 @@ public sealed partial class MobThresholdsComponent : Component
     {
         {MobState.Alive, "HumanHealth"},
         {MobState.Critical, "HumanCrit"},
+        {MobState.SoftCritical, "HumanCrit"},
         {MobState.Dead, "HumanDead"},
     };
 

--- a/Content.Shared/Mobs/MobState.cs
+++ b/Content.Shared/Mobs/MobState.cs
@@ -18,7 +18,6 @@ public enum MobState : byte
     Critical = 2,
     SoftCritical = 3,
     Dead = 4,
-
 }
 
 /// <summary>

--- a/Content.Shared/Mobs/MobState.cs
+++ b/Content.Shared/Mobs/MobState.cs
@@ -16,7 +16,9 @@ public enum MobState : byte
     Invalid = 0,
     Alive = 1,
     Critical = 2,
-    Dead = 3
+    SoftCritical = 3,
+    Dead = 4,
+
 }
 
 /// <summary>

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -65,7 +65,16 @@ public partial class MobStateSystem : EntitySystem
     {
         if (!Resolve(target, ref component, false))
             return false;
+
         return component.CurrentState == MobState.Dead;
+    }
+
+    public bool IsSoftCritical(EntityUid target, MobStateComponent? component = null)
+    {
+        if (!Resolve(target, ref component, false))
+            return false;
+
+        return component.CurrentState == MobState.SoftCritical;
     }
 
     /// <summary>
@@ -78,7 +87,7 @@ public partial class MobStateSystem : EntitySystem
     {
         if (!Resolve(target, ref component, false))
             return false;
-        return component.CurrentState is MobState.Critical or MobState.Dead;
+        return component.CurrentState is MobState.Critical or MobState.Dead or MobState.SoftCritical;
     }
 
     /// <summary>

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -78,7 +78,7 @@ public partial class MobStateSystem : EntitySystem
     }
 
     /// <summary>
-    ///  Check if a Mob is Critical or Dead
+    ///  Check if a Mob is Critical or Dead or SoftCrit
     /// </summary>
     /// <param name="target">Target Entity</param>
     /// <param name="component">The MobState component owned by the target</param>


### PR DESCRIPTION
# Description

This PR does *some* refactoring of MobState in preparation for adding a more in-depth SoftCritical system, mostly adding code support for the new threshold existing in the first place. Additionally, the MobStateComponent now also includes several DataFields that allow more precise fine tuning of what all mobs are allowed to do in each state, as opposed to hardcoding a majority of these interactions.

The actual SoftCritical state isn't currently used by anything, and so is a largely vestigial feature. It would have to be added individually to mobs, such as the BaseMobSpeciesOrganic when the time comes to actually add this feature.

# Changelog

:cl:
- add: Lots of refactoring of the Mob State Systerm in preparation for implementing a much more detailed Soft Critical state.
