### PR TITLE
Fix the Width Slider Not Translating Smoothly

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1393,7 +1393,7 @@ namespace Content.Client.Lobby.UI
 
             if (updateType == SliderUpdate.Height || updateType == SliderUpdate.Both)
                 if (ratio < 1 / sizeRatio || ratio > sizeRatio)
-                    widthValue = heightValue * (ratio < 1 / sizeRatio ? (1 / sizeRatio) : sizeRatio);
+                    widthValue = heightValue / (ratio < 1 / sizeRatio ? (1 / sizeRatio) : sizeRatio);
 
             if (updateType == SliderUpdate.Width || updateType == SliderUpdate.Both)
                 if (ratio < 1 / sizeRatio || ratio > sizeRatio)


### PR DESCRIPTION
# Description

The slider would jump around to fix the constraints because a division symbol was mistakenly replaced with a multiplication symbol, this fixes that.

---

<details><summary><h1>Media</h1></summary>
<p>

![edf53e72db6e17d97df08940f04e72d7](https://github.com/user-attachments/assets/b4ebcca5-e56b-41ab-8200-a2235d9b6f7c)

</p>
</details>

---

# Changelog

:cl:
- fix: The width slider in the profile editor view now moves correctly regarding the height slider.
