### PR TITLE
More Psionic Admin Commands

### DIFF
--- a/Content.Server/Psionics/PsionicsCommands.cs
+++ b/Content.Server/Psionics/PsionicsCommands.cs
@@ -105,18 +105,27 @@ public sealed class RemovePsionicPowerCommand : IConsoleCommand
 
         if (!EntityUid.TryParse(args[0], out var uid))
         {
-            shell.WriteError(Loc.GetString("addpsionicpower-args-one-error"));
+            shell.WriteError(Loc.GetString("removepsionicpower-args-one-error"));
             return;
         }
 
         if (!protoMan.TryIndex<PsionicPowerPrototype>(args[1], out var powerProto))
         {
-            shell.WriteError(Loc.GetString("addpsionicpower-args-two-error"));
+            shell.WriteError(Loc.GetString("removepsionicpower-args-two-error"));
             return;
         }
 
         if (!entMan.TryGetComponent<PsionicComponent>(uid, out var psionicComponent))
+        {
+            shell.WriteError(Loc.GetString("removepsionicpower-not-psionic-error"));
             return;
+        }
+
+        if (!psionicComponent.ActivePowers.Contains(powerProto))
+        {
+            shell.WriteError(Loc.GetString("removepsionicpower-not-contains-error"));
+            return;
+        }
 
         psionicPowers.RemovePsionicPower(uid, psionicComponent, powerProto, true);
     }
@@ -135,7 +144,13 @@ public sealed class RemoveAllPsionicPowersCommand : IConsoleCommand
 
         if (!EntityUid.TryParse(args[0], out var uid))
         {
-            shell.WriteError(Loc.GetString("addpsionicpower-args-one-error"));
+            shell.WriteError(Loc.GetString("removeallpsionicpowers-args-one-error"));
+            return;
+        }
+
+        if (!entMan.HasComponent<PsionicComponent>(uid))
+        {
+            shell.WriteError(Loc.GetString("removeallpsionicpowers-not-psionic-error"));
             return;
         }
 

--- a/Content.Server/Psionics/PsionicsCommands.cs
+++ b/Content.Server/Psionics/PsionicsCommands.cs
@@ -63,3 +63,82 @@ public sealed class AddPsionicPowerCommand : IConsoleCommand
         psionicPowers.InitializePsionicPower(uid, powerProto, psionic);
     }
 }
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class AddRandomPsionicPowerCommand : IConsoleCommand
+{
+    public string Command => "addrandompsionicpower";
+    public string Description => Loc.GetString("command-addrandompsionicpower-description");
+    public string Help => Loc.GetString("command-addrandompsionicpower-help");
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var psionicPowers = entMan.System<PsionicAbilitiesSystem>();
+
+        if (!EntityUid.TryParse(args[0], out var uid))
+        {
+            shell.WriteError(Loc.GetString("addrandompsionicpower-args-one-error"));
+            return;
+        }
+
+        psionicPowers.AddRandomPsionicPower(uid, true);
+    }
+}
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class RemovePsionicPowerCommand : IConsoleCommand
+{
+    public string Command => "removepsionicpower";
+    public string Description => Loc.GetString("command-removepsionicpower-description");
+    public string Help => Loc.GetString("command-addpsionicpower-help");
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var psionicPowers = entMan.System<PsionicAbilitiesSystem>();
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString("shell-need-exactly-one-argument"));
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[0], out var uid))
+        {
+            shell.WriteError(Loc.GetString("addpsionicpower-args-one-error"));
+            return;
+        }
+
+        if (!protoMan.TryIndex<PsionicPowerPrototype>(args[1], out var powerProto))
+        {
+            shell.WriteError(Loc.GetString("addpsionicpower-args-two-error"));
+            return;
+        }
+
+        if (!entMan.TryGetComponent<PsionicComponent>(uid, out var psionicComponent))
+            return;
+
+        psionicPowers.RemovePsionicPower(uid, psionicComponent, powerProto, true);
+    }
+}
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class RemoveAllPsionicPowersCommand : IConsoleCommand
+{
+    public string Command => "removeallpsionicpowers";
+    public string Description => Loc.GetString("command-removeallpsionicpowers-description");
+    public string Help => Loc.GetString("command-removeallpsionicpowers-help");
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var psionicPowers = entMan.System<PsionicAbilitiesSystem>();
+
+        if (!EntityUid.TryParse(args[0], out var uid))
+        {
+            shell.WriteError(Loc.GetString("addpsionicpower-args-one-error"));
+            return;
+        }
+
+        psionicPowers.RemoveAllPsionicPowers(uid);
+    }
+}

--- a/Resources/Locale/en-US/psionics/psionic-commands.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-commands.ftl
@@ -11,3 +11,15 @@ command-addpsionicpower-description = Initialize an entity as Psionic with a giv
 command-addpsionicpower-help = Argument 1 must be an EntityUid, and argument 2 must be a string matching the PrototypeId of a PsionicPower.
 addpsionicpower-args-one-error = Argument 1 must be an EntityUid
 addpsionicpower-args-two-error = Argument 2 must match the PrototypeId of a PsionicPower
+
+command-addrandompsionicpower-description = Initialize an entity as Psionic with a a random PowerPrototype that is available for that entity to roll.
+command-addrandompsionicpower-help = Argument 1 must be an EntityUid.
+addrandompsionicpower-args-one-error = Argument 1 must be an EntityUid
+
+command-removepsionicpower-description = Remove a Psionic power from an entity.
+command-removepsionicpower-help = Argument 1 must be an EntityUid, and argument 2 must be a string matching the PrototypeId of a PsionicPower.
+removepsionicpower-args-one-error = Argument 1 must be an EntityUid
+removepsionicpower-args-two-error = Argument 2 must match the PrototypeId of a PsionicPower.
+
+command-removeallpsionicpowers-description = Remove all Psionic powers from an entity.
+command-removeallpsionicpowers-help = Argument 1 must be an EntityUid.

--- a/Resources/Locale/en-US/psionics/psionic-commands.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-commands.ftl
@@ -20,6 +20,10 @@ command-removepsionicpower-description = Remove a Psionic power from an entity.
 command-removepsionicpower-help = Argument 1 must be an EntityUid, and argument 2 must be a string matching the PrototypeId of a PsionicPower.
 removepsionicpower-args-one-error = Argument 1 must be an EntityUid
 removepsionicpower-args-two-error = Argument 2 must match the PrototypeId of a PsionicPower.
+removepsionicpower-not-psionic-error = The target entity is not Psionic.
+removepsionicpower-not-contains-error = The target entity does not have this PsionicPower.
 
 command-removeallpsionicpowers-description = Remove all Psionic powers from an entity.
 command-removeallpsionicpowers-help = Argument 1 must be an EntityUid.
+removeallpsionicpowers-args-one-error = Argument 1 must be an EntityUid.
+removeallpsionicpowers-not-psionic-error = The target entity is not Psionic.

--- a/Resources/Locale/en-US/psionics/psionic-commands.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-commands.ftl
@@ -12,7 +12,7 @@ command-addpsionicpower-help = Argument 1 must be an EntityUid, and argument 2 m
 addpsionicpower-args-one-error = Argument 1 must be an EntityUid
 addpsionicpower-args-two-error = Argument 2 must match the PrototypeId of a PsionicPower
 
-command-addrandompsionicpower-description = Initialize an entity as Psionic with a a random PowerPrototype that is available for that entity to roll.
+command-addrandompsionicpower-description = Initialize an entity as Psionic with a random PowerPrototype that is available for that entity to roll.
 command-addrandompsionicpower-help = Argument 1 must be an EntityUid.
 addrandompsionicpower-args-one-error = Argument 1 must be an EntityUid
 


### PR DESCRIPTION
# Description

This PR adds three new admin commands that make use of the new functionality available to Psionics V3. These commands are:

- addrandompsionicpower
This takes a Uid and throws it at the random psi power generation code. Which gives it a random psi power that is available in its list of rollable powers.

- removepsionicpower
This takes a Uid and a PsionicPower prototype ID, and attempts to remove that power from said entity. It does nothing if the entity doesn't have that power.

- removeallpsionicpowers
As above, but instead of needing to declare a power prototype, it just removes ALL powers that the entity has, if any.


# Changelog

:cl:
- add: Added new admin commands AddRandomPsionicPower, RemovePsionicPower, and RemoveAllPsionicPowers.
