### PR TITLE
No Cocooning Yourself!

### DIFF
--- a/Content.Server/Cocoon/CocoonerSystem.cs
+++ b/Content.Server/Cocoon/CocoonerSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Cocoon
 
         private void AddCocoonVerb(EntityUid uid, CocoonerComponent component, GetVerbsEvent<InnateVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || !HasComp<MobStateComponent>(args.Target))
+            if (!args.CanAccess || !args.CanInteract || !HasComp<MobStateComponent>(args.Target) || args.Target == args.User)
                 return;
 
             InnateVerb verb = new()


### PR DESCRIPTION
# Description

I watched someone cocoon themselves while trying to cocoon a mouse on Goob MRP. It was pretty funny but you have to wait for someone to realize why you are making muffled sounds on the radio, then for them to come find you, and if you're not in your department it can take a while, its nearly round removal on low pop as well.

---

# Changelog

:cl:
- tweak: You can no longer cocoon yourself as a spider.