### PR TITLE
Add Missing Localization for Supermatter Guide Entry

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -11,6 +11,7 @@ guide-entry-access-configurator = Access Configurator
 guide-entry-power = Power
 guide-entry-portable-generator = Portable Generators
 guide-entry-ame = Antimatter Engine (AME)
+guide-entry-sm = Supermatter Engine (SM)
 guide-entry-singularity = Singularity / Tesla
 guide-entry-teg = Thermo-electric Generator (TEG)
 guide-entry-rtg = RTG


### PR DESCRIPTION
# Description

Does what it says on the tin

Solves #664 

---

<details><summary><h1>Media</h1></summary>
<p>

# Nuh uh :3

</p>
</details>

---

# Changelog

:cl:
- fix: Supermatter's guide has a name now
