### PR TITLE
Add White Cane to Loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -762,7 +762,7 @@
 - type: loadout
   id: LoadoutItemDrinkVacuumFlask
   category: Items
-  cost: 0
+  cost: 1
   customColorTint: true
   items:
     - DrinkVacuumFlask
@@ -770,6 +770,7 @@
 - type: loadout
   id: LoadoutItemCaneBlind
   category: Items
+  cost: 0 # It shouldnt cost points to be able to function.
   items:
     - WhiteCane
 

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -762,10 +762,16 @@
 - type: loadout
   id: LoadoutItemDrinkVacuumFlask
   category: Items
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - DrinkVacuumFlask
+
+- type: loadout
+  id: LoadoutItemCaneBlind
+  category: Items
+  items:
+    - WhiteCane
 
 # Pets
 - type: loadout


### PR DESCRIPTION
# Description

Adds the white cane to loadouts, not restricted to people with the blind trait

Solves #1367

---

<details><summary><h1>Media</h1></summary>
<p>

# nuh uh :3

</p>
</details>

---

# Changelog

:cl:
- add: White cane added to loadout options