### PR TITLE
Fix Kα Deficiency Not Having a Description

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -366,7 +366,7 @@ trait-description-HighPotential =
     Your connection to the noösphere is greater than average, making it easier to obtain new psionic powers.
 
 trait-name-LowAmplification = kα Deficiency
-trait-description-LowAmplifiction =
+trait-description-LowAmplification =
     Your psionic abilities are noticeably weaker than ones used by other psions.
 
 trait-name-HighAmplification = kα Abundance


### PR DESCRIPTION
# Description

A misspelled localization string caused this, someone should probably make an integration test to ensure all traits have names and descriptions

---

<details><summary><h1>Media</h1></summary>
<p>

# Nuh uh :3

</p>
</details>

---

# Changelog

:cl:
- fix: The 'kα Deficiency' trait has a description now

