### PR TITLE
Fix Shiva Ghost Role Missing Localization

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -257,6 +257,8 @@ ghost-role-information-syndicate-kobold-reinforcement-name = Syndicate Kobold Ag
 ghost-role-information-syndicate-kobold-reinforcement-description = Someone needs reinforcements. You, a trained kobold, will help them.
 ghost-role-information-syndicate-kobold-reinforcement-rules = Normal syndicate antagonist rules apply. Work with whoever called you in, and don't harm them.
 
+ghost-role-information-Shiva-name = Shiva
+ghost-role-information-Shiva-description = The first defender of the station.
 ghost-role-information-artifact-name = Sentient Artifact
 ghost-role-information-artifact-description =
       Enact your eldritch whims.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -259,6 +259,7 @@ ghost-role-information-syndicate-kobold-reinforcement-rules = Normal syndicate a
 
 ghost-role-information-Shiva-name = Shiva
 ghost-role-information-Shiva-description = The first defender of the station.
+
 ghost-role-information-artifact-name = Sentient Artifact
 ghost-role-information-artifact-description =
       Enact your eldritch whims.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -257,8 +257,8 @@ ghost-role-information-syndicate-kobold-reinforcement-name = Syndicate Kobold Ag
 ghost-role-information-syndicate-kobold-reinforcement-description = Someone needs reinforcements. You, a trained kobold, will help them.
 ghost-role-information-syndicate-kobold-reinforcement-rules = Normal syndicate antagonist rules apply. Work with whoever called you in, and don't harm them.
 
-ghost-role-information-Shiva-name = Shiva
-ghost-role-information-Shiva-description = The first defender of the station.
+ghost-role-information-shiva-name = Shiva
+ghost-role-information-shiva-description = The first defender of the station.
 
 ghost-role-information-artifact-name = Sentient Artifact
 ghost-role-information-artifact-description =

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -648,9 +648,8 @@
     makeSentient: true
     allowSpeech: true
     allowMovement: true
-    name: ghost-role-information-Shiva-name
-    description: ghost-role-information-Shiva-description
-    rules: ghost-role-information-Shiva-rules
+    name: ghost-role-information-shiva-name
+    description: ghost-role-information-shiva-description
   - type: GhostTakeoverAvailable # DeltaV
   - type: InteractionPopup
     successChance: 0.5 # spider is mean


### PR DESCRIPTION
# Description

Title!!!

Solves https://github.com/SS14-Classic/deep-station-14/issues/91

---

# Changelog

:cl:
- fix: Fix Shiva's name and description displaying improperly in ghost roles

