### PR TITLE
Add Chatstack

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -1,4 +1,4 @@
-﻿<tabs:MiscTab xmlns="https://spacestation14.io"
+<tabs:MiscTab xmlns="https://spacestation14.io"
                   xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                   xmlns:tabs="clr-namespace:Content.Client.Options.UI.Tabs"
                   xmlns:xNamespace="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,6 +26,11 @@
                 <CheckBox Name="EnableColorNameCheckBox" Text="{Loc 'ui-options-enable-color-name'}" />
                 <CheckBox Name="ColorblindFriendlyCheckBox" Text="{Loc 'ui-options-colorblind-friendly'}" />
                 <CheckBox Name="DisableFiltersCheckBox" Text="{Loc 'ui-options-no-filters'}" />
+                <BoxContainer Orientation="Horizontal">
+                    <Label Text="{Loc 'ui-options-chatstack'}" />
+                    <Control MinSize="4 0" />
+                    <OptionButton Name="ChatStackOption" />
+                </BoxContainer>
                 <BoxContainer Orientation="Horizontal">
                     <Label Text="{Loc 'ui-options-chat-window-opacity'}" Margin="8 0" />
                     <Slider Name="ChatWindowOpacitySlider"

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Client.UserInterface.Screens;
 using Content.Shared.CCVar;
 using Content.Shared.HUD;
@@ -56,6 +56,18 @@ namespace Content.Client.Options.UI.Tabs
             HudLayoutOption.OnItemSelected += args =>
             {
                 HudLayoutOption.SelectId(args.Id);
+                UpdateApplyButton();
+            };
+
+            ChatStackOption.AddItem(Loc.GetString("ui-options-chatstack-off"), 0);
+            ChatStackOption.AddItem(Loc.GetString("ui-options-chatstack-single"), 1);
+            ChatStackOption.AddItem(Loc.GetString("ui-options-chatstack-double"), 2);
+            ChatStackOption.AddItem(Loc.GetString("ui-options-chatstack-triple"), 3);
+            ChatStackOption.TrySelectId(_cfg.GetCVar(CCVars.ChatStackLastLines));
+
+            ChatStackOption.OnItemSelected += args =>
+            {
+                ChatStackOption.SelectId(args.Id);
                 UpdateApplyButton();
             };
 
@@ -157,6 +169,7 @@ namespace Content.Client.Options.UI.Tabs
             // _cfg.SetCVar(CCVars.ToggleWalk, ToggleWalk.Pressed);
             _cfg.SetCVar(CCVars.StaticStorageUI, StaticStorageUI.Pressed);
             _cfg.SetCVar(CCVars.NoVisionFilters, DisableFiltersCheckBox.Pressed);
+            _cfg.SetCVar(CCVars.ChatStackLastLines, ChatStackOption.SelectedId);
 
             if (HudLayoutOption.SelectedMetadata is string opt)
             {
@@ -188,6 +201,7 @@ namespace Content.Client.Options.UI.Tabs
             // var isToggleWalkSame = ToggleWalk.Pressed == _cfg.GetCVar(CCVars.ToggleWalk);
             var isStaticStorageUISame = StaticStorageUI.Pressed == _cfg.GetCVar(CCVars.StaticStorageUI);
             var isNoVisionFiltersSame = DisableFiltersCheckBox.Pressed == _cfg.GetCVar(CCVars.NoVisionFilters);
+            var isChatStackTheSame = ChatStackOption.SelectedId == _cfg.GetCVar(CCVars.ChatStackLastLines);
 
             ApplyButton.Disabled = isHudThemeSame &&
                                    isLayoutSame &&
@@ -207,7 +221,8 @@ namespace Content.Client.Options.UI.Tabs
                                    isScreenShakeIntensitySame &&
                                    // isToggleWalkSame &&
                                    isStaticStorageUISame &&
-                                   isNoVisionFiltersSame;
+                                   isNoVisionFiltersSame &&
+                                   isChatStackTheSame;
         }
 
     }

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -66,7 +66,7 @@ public partial class ChatBox : UIWidget
    
     private void UpdateChatStack(int value)
     {
-        _chatStackAmount = 42;
+        _chatStackAmount = value >= 0 ? value : 0;
         Repopulate();
     }
 
@@ -98,7 +98,7 @@ public partial class ChatBox : UIWidget
             return;
         }
 
-        int index = _chatStackList.FindIndex(data => data.WrappedMessage == msg.WrappedMessage && !msg.IgnoreChatStack);
+        int index = _chatStackList.FindIndex(data => data.WrappedMessage == msg.WrappedMessage && !data.IgnoresChatStack);
 
         if (index == -1) // this also handles chatstack being disabled, since FindIndex won't find anything in an empty array
         {

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -128,9 +128,6 @@ public partial class ChatBox : UIWidget
         {
             var data = _chatStackList[i];
             AddLine(data.WrappedMessage, data.ColorOverride, data.RepeatCount);
-        }
-        for (int i = index; i >= 0; i--) 
-        {
             Contents.RemoveEntry(Index.FromEnd(index + 2));
         }
     }

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -98,7 +98,7 @@ public partial class ChatBox : UIWidget
             return;
         }
 
-        int index = _chatStackList.FindIndex(data => data.WrappedMessage == msg.WrappedMessage && !data.IgnoresChatStack);
+        int index = _chatStackList.FindIndex(data => data.WrappedMessage == msg.WrappedMessage && !data.IgnoresChatstack);
 
         if (index == -1) // this also handles chatstack being disabled, since FindIndex won't find anything in an empty array
         {
@@ -287,7 +287,7 @@ public partial class ChatBox : UIWidget
         {
             WrappedMessage = wrappedMessage;
             ColorOverride = colorOverride;
-            IgnoresChatstack = IgnoresChatstack;    
+            IgnoresChatstack = ignoresChatstack;
         }
     }
 }

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,4 +1,5 @@
 using Content.Client.UserInterface.Systems.Chat.Controls;
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Input;
 using Robust.Client.Audio;
@@ -7,7 +8,9 @@ using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
+using Robust.Shared;
 using Robust.Shared.Audio;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
@@ -22,14 +25,22 @@ public partial class ChatBox : UIWidget
 {
     private readonly ChatUIController _controller;
     private readonly IEntityManager _entManager;
+    private readonly IConfigurationManager _cfg;
+    private readonly ILocalizationManager _loc;
 
     public bool Main { get; set; }
 
     public ChatSelectChannel SelectedChannel => ChatInput.ChannelSelector.SelectedChannel;
+   
+    private int _chatStackAmount = 0;
+    private bool _chatStackEnabled => _chatStackAmount > 0;
+    private List<ChatStackData> _chatStackList;
+   
 
     public ChatBox()
     {
         RobustXamlLoader.Load(this);
+        _loc = IoCManager.Resolve<ILocalizationManager>();
         _entManager = IoCManager.Resolve<IEntityManager>();
 
         ChatInput.Input.OnTextEntered += OnTextEntered;
@@ -41,6 +52,22 @@ public partial class ChatBox : UIWidget
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
         _controller.RegisterChat(this);
+
+       
+        _cfg = IoCManager.Resolve<IConfigurationManager>();
+        //_chatStackAmount = _cfg.GetCVar(CCVars.ChatStackLastLines);
+        //if (_chatStackAmount < 0) // anti-idiot protection
+        //    _chatStackAmount = 0;
+        _chatStackList = new(_chatStackAmount);
+        _cfg.OnValueChanged(CCVars.ChatStackLastLines, UpdateChatStack, true);
+       
+    }
+
+   
+    private void UpdateChatStack(int value)
+    {
+        _chatStackAmount = 42;
+        Repopulate();
     }
 
     private void OnTextEntered(LineEditEventArgs args)
@@ -63,7 +90,60 @@ public partial class ChatBox : UIWidget
 
         var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
 
-        AddLine(msg.WrappedMessage, color);
+       
+        if (msg.IgnoreChatStack)
+        {
+            TrackNewMessage(msg.WrappedMessage, color, true);
+            AddLine(msg.WrappedMessage, color);
+            return;
+        }
+
+        int index = _chatStackList.FindIndex(data => data.WrappedMessage == msg.WrappedMessage && !msg.IgnoreChatStack);
+
+        if (index == -1) // this also handles chatstack being disabled, since FindIndex won't find anything in an empty array
+        {
+            TrackNewMessage(msg.WrappedMessage, color);
+            AddLine(msg.WrappedMessage, color);
+            return;
+        }
+
+        UpdateRepeatingLine(index);
+    }
+
+    /// <summary>
+    /// Removing and then adding insantly nudges the chat window up before slowly dragging it back down, which makes the whole chat log shake.
+    /// With rapid enough updates, the whole chat becomes unreadable.
+    /// Adding first and then removing does not produce any visual effects.
+    /// The other option is to dublicate OutputPanel functionality and everything internal to the engine it relies on.
+    /// But OutputPanel relies on directly setting Control.Position for control embedding. (which is not exposed to Content.)
+    /// Thanks robustengine, very cool.
+    /// </summary>
+    /// <remarks>
+    /// zero index is the very last line in chat, 1 is the line before the last one, 2 is the line before that, etc.
+    /// </remarks>
+    private void UpdateRepeatingLine(int index)
+    {
+        _chatStackList[index].RepeatCount++;
+        for (int i = index; i >= 0; i--)
+        {
+            var data = _chatStackList[i];
+            AddLine(data.WrappedMessage, data.ColorOverride, data.RepeatCount);
+        }
+        for (int i = index; i >= 0; i--) 
+        {
+            Contents.RemoveEntry(Index.FromEnd(index + 2));
+        }
+    }
+
+    private void TrackNewMessage(string wrappedMessage, Color colorOverride, bool ignoresChatstack = false)
+    {
+        if (!_chatStackEnabled)
+            return;
+
+        if(_chatStackList.Count == _chatStackList.Capacity)
+            _chatStackList.RemoveAt(_chatStackList.Capacity - 1);
+
+        _chatStackList.Insert(0, new ChatStackData(wrappedMessage, colorOverride, ignoresChatstack)); 
     }
 
     private void OnChannelSelect(ChatSelectChannel channel)
@@ -74,7 +154,7 @@ public partial class ChatBox : UIWidget
     public void Repopulate()
     {
         Contents.Clear();
-
+        _chatStackList = new List<ChatStackData>(_chatStackAmount);
         foreach (var message in _controller.History)
         {
             OnMessageAdded(message.Item2);
@@ -96,12 +176,21 @@ public partial class ChatBox : UIWidget
         }
     }
 
-    public void AddLine(string message, Color color)
+    public void AddLine(string message, Color color, int repeat = 0)
     {
-        var formatted = new FormattedMessage(3);
+        var formatted = new FormattedMessage(4); 
         formatted.PushColor(color);
         formatted.AddMarkup(message);
         formatted.Pop();
+        if (repeat != 0)
+        {
+            int displayRepeat = repeat + 1;
+            int sizeIncrease = Math.Min(displayRepeat / 6, 5);
+            formatted.AddMarkup(_loc.GetString("chat-system-repeated-message-counter",
+                                ("count", displayRepeat),
+                                ("size", 8 + sizeIncrease)
+                                ));
+        }
         Contents.AddMessage(formatted);
     }
 
@@ -185,5 +274,20 @@ public partial class ChatBox : UIWidget
         ChatInput.Input.OnKeyBindDown -= OnInputKeyBindDown;
         ChatInput.Input.OnTextChanged -= OnTextChanged;
         ChatInput.ChannelSelector.OnChannelSelect -= OnChannelSelect;
+        _cfg.UnsubValueChanged(CCVars.ChatStackLastLines, UpdateChatStack);
+    }
+
+    private class ChatStackData
+    {
+        public string WrappedMessage;
+        public Color ColorOverride;
+        public int RepeatCount = 0;
+        public bool IgnoresChatstack;
+        public ChatStackData(string wrappedMessage, Color colorOverride, bool ignoresChatstack = false)
+        {
+            WrappedMessage = wrappedMessage;
+            ColorOverride = colorOverride;
+            IgnoresChatstack = IgnoresChatstack;    
+        }
     }
 }

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -296,13 +296,13 @@ namespace Content.Server.Chat.Managers
 
         #region Utility
 
-        public void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null)
+        public void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false)
         {
             var user = author == null ? null : EnsurePlayer(author);
             var netSource = _entityManager.GetNetEntity(source);
             user?.AddEntity(netSource);
 
-            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
+            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, ignoreChatStack);
             _netManager.ServerSendMessage(new MsgChatMessage() { Message = msg }, client);
 
             if (!recordReplay)
@@ -315,16 +315,16 @@ namespace Content.Server.Chat.Managers
             }
         }
 
-        public void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, IEnumerable<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null)
-            => ChatMessageToMany(channel, message, wrappedMessage, source, hideChat, recordReplay, clients.ToList(), colorOverride, audioPath, audioVolume, author);
+        public void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, IEnumerable<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false)
+            => ChatMessageToMany(channel, message, wrappedMessage, source, hideChat, recordReplay, clients.ToList(), colorOverride, audioPath, audioVolume, author, ignoreChatStack);
 
-        public void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, List<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null)
+        public void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, List<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false)
         {
             var user = author == null ? null : EnsurePlayer(author);
             var netSource = _entityManager.GetNetEntity(source);
             user?.AddEntity(netSource);
 
-            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
+            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, ignoreChatStack);
             _netManager.ServerSendToMany(new MsgChatMessage() { Message = msg }, clients);
 
             if (!recordReplay)
@@ -338,7 +338,7 @@ namespace Content.Server.Chat.Managers
         }
 
         public void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string wrappedMessage, EntityUid source,
-            bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0)
+            bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, bool ignoreChatStack = false)
         {
             if (!recordReplay && !filter.Recipients.Any())
                 return;
@@ -349,16 +349,16 @@ namespace Content.Server.Chat.Managers
                 clients.Add(recipient.Channel);
             }
 
-            ChatMessageToMany(channel, message, wrappedMessage, source, hideChat, recordReplay, clients, colorOverride, audioPath, audioVolume);
+            ChatMessageToMany(channel, message, wrappedMessage, source, hideChat, recordReplay, clients, colorOverride, audioPath, audioVolume, null, ignoreChatStack);
         }
 
-        public void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null)
+        public void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false)
         {
             var user = author == null ? null : EnsurePlayer(author);
             var netSource = _entityManager.GetNetEntity(source);
             user?.AddEntity(netSource);
 
-            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
+            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, ignoreChatStack);
             _netManager.ServerSendToAll(new MsgChatMessage() { Message = msg });
 
             if (!recordReplay)

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -25,14 +25,14 @@ namespace Content.Server.Chat.Managers
         void SendAdminAnnouncementMessage(ICommonSession player, string message, bool suppressLog = true);
 
         void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat,
-            INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null);
+            INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false);
 
         void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay,
-            IEnumerable<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null);
+            IEnumerable<INetChannel> clients, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false);
 
-        void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride, string? audioPath = null, float audioVolume = 0);
+        void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride, string? audioPath = null, float audioVolume = 0, bool ignoreChatStack = false);
 
-        void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null);
+        void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, bool recordReplay, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool ignoreChatStack = false);
 
         bool MessageCharacterLimit(ICommonSession player, string message);
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2091,6 +2091,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ChatFancyNameBackground =
             CVarDef.Create("chat.fancy_name_background", false, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles displaying a background under the speaking character's name.");
 
+        public static readonly CVarDef<int> ChatStackLastLines =
+            CVarDef.Create("chat.chatstack_last_lines", 1, CVar.CLIENTONLY | CVar.ARCHIVE, "How far into the chat history to look when looking for similiar messages to coalesce them.");
+
         /// <summary>
         /// A message broadcast to each player that joins the lobby.
         /// May be changed by admins ingame through use of the "set-motd" command.

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -26,11 +26,11 @@ namespace Content.Shared.Chat
         public Color? MessageColorOverride;
         public string? AudioPath;
         public float AudioVolume;
-
+        public bool IgnoreChatStack;
         [NonSerialized]
         public bool Read;
 
-        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0)
+        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, bool ignoreChatStack = false)
         {
             Channel = channel;
             Message = message;
@@ -41,6 +41,7 @@ namespace Content.Shared.Chat
             MessageColorOverride = colorOverride;
             AudioPath = audioPath;
             AudioVolume = audioVolume;
+            IgnoreChatStack = IgnoreChatStack;
         }
     }
 

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -41,7 +41,7 @@ namespace Content.Shared.Chat
             MessageColorOverride = colorOverride;
             AudioPath = audioPath;
             AudioVolume = audioVolume;
-            IgnoreChatStack = IgnoreChatStack;
+            IgnoreChatStack = ignoreChatStack;
         }
     }
 

--- a/Resources/Locale/en-US/chat/chatstack.ftl
+++ b/Resources/Locale/en-US/chat/chatstack.ftl
@@ -1,0 +1,1 @@
+chat-system-repeated-message-counter = {" "}[font size={$size}][color=#DD3333][bold]x{$count}![/bold][/color][/font]

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -20,6 +20,11 @@ ui-options-general-cursor = Cursor
 ui-options-general-speech = Speech
 ui-options-general-storage = Storage
 ui-options-general-accessibility = Accessibility
+ui-options-chatstack = Automatically merge identical chat messages
+ui-options-chatstack-off = Off
+ui-options-chatstack-single = Only last message
+ui-options-chatstack-double = Last two messages
+ui-options-chatstack-triple = Last three messages
 
 ## Audio menu
 


### PR DESCRIPTION
# Description

Chatstack.

Can be changed/disabled in settings, and the chat automatically updates to reflect the change.
Does not interfere with filters, etc.
Also updated ChatMessage class and serverside IChatManager with a new IgnoreChatStack bool option, default false.

Currently is limited to looking up to 3 messages behind, only because I feel off adding a textbox to the options.

---

# TODO


- [x] Make sure it works
- [x] Add it to settings
---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/e020bb35-3bac-4620-80d1-3dbd9dee2d1c)

[ee.webm](https://github.com/user-attachments/assets/bf1c92f0-b52a-47a0-b142-70b1ee5003cc)


</p>
</details>

---

# Changelog

:cl:
- add: Chatstack. Look for it in Options under "General - Accessibility".