### PR TITLE
Fix Lamia Footprints

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/lamia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/lamia.yml
@@ -216,6 +216,11 @@
       types:
         Bloodloss: -1
   - type: PortalExempt
+  - type: FootPrints
+    leftBarePrint: "dragging-1"
+    rightBarePrint: "dragging-1"
+    shoesPrint: "dragging-1"
+    suitPrint: "dragging-1"
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description

Lamia don't have feet, so they instead make huge drag marks when moving through puddles. :)

# Changelog

:cl:
- fix: Lamia now make drag marks when moving through puddles instead of regular footprints.