### PR TITLE
Unlimited Face Markings

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -37,9 +37,6 @@
 - type: markingPoints
   id: MobVulpkaninMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/makeup.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/makeup.yml
@@ -73,7 +73,7 @@
 - type: marking
   id: MakeupMothBlush
   bodyPart: Face
-  markingCategory: Overlay
+  markingCategory: Face
   speciesRestriction: [Moth]
   coloring:
     default:

--- a/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
@@ -21,9 +21,6 @@
 - type: markingPoints
   id: MobOniMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -17,9 +17,6 @@
 - type: markingPoints
   id: MobFelinidMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/arachne.yml
+++ b/Resources/Prototypes/Species/arachne.yml
@@ -15,9 +15,6 @@
 - type: markingPoints
   id: MobArachneMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -40,9 +40,6 @@
 - type: markingPoints
   id: MobHarpyMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -39,9 +39,6 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -16,6 +16,7 @@
   id: MobMothSprites
   sprites:
     Head: MobMothHead
+    Face: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
     Chest: MobMothTorso
     HeadTop: MobHumanoidAnyMarking

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -42,9 +42,6 @@
   id: MobReptilianMarkingLimits
   onlyWhitelisted: true
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 0
       required: false

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -60,7 +60,7 @@
       points: 2
       required: false
     HeadSide:
-      points: 2
+      points: 3
       required: false
     Chest:
       points: 1

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -31,9 +31,6 @@
 - type: markingPoints
   id: MobSlimeMarkingLimits
   points:
-    Face:
-      points: 1
-      required: false
     Hair:
       points: 1
       required: false


### PR DESCRIPTION
# Description

Removes the marking limits for the Face category (was limited to 1 marking) for all non-IPC species, now having unlimited markings as designed.

Moth makeup (Moth Blush / Moth Lipstick) is now usable again in the Face category.

## Media

**Markings without limits**

![image](https://github.com/user-attachments/assets/768c4d8b-d982-4836-a57c-1be17e48a33f)

**Lizard with frills and earrings**

![image](https://github.com/user-attachments/assets/1cd4902d-e187-496b-950f-2113655d02c3)

**Moth Makeup**

![image](https://github.com/user-attachments/assets/29236624-c417-4ee6-bf91-e9f80acf8216)

# Changelog

:cl: Skubman
- fix: The Face marking category now has unlimited markings for all species apart from IPCs.
- fix: Moth People can now apply Moth makeup markings again in the Face category.
- tweak: Unathi now have 3 'Head (Side)' marking points available, so they can use frills and both left and right-side earrings.  
