### PR TITLE
Fixed Monkey Skin Color

### DIFF
--- a/Resources/Prototypes/_Shitmed/Species/monkey.yml
+++ b/Resources/Prototypes/_Shitmed/Species/monkey.yml
@@ -5,8 +5,7 @@
   prototype: MobMonkey
   sprites: MobMonkeySprites
   dollPrototype: MobMonkeyDummy
-  skinColoration: Hues
-  defaultSkinTone: "#ffffff"
+  skinColoration: HumanToned
   markingLimits: MobMonkeyMarkingLimits
 
 - type: speciesBaseSprites


### PR DESCRIPTION
# Description

Apparently this bug was introduced by Shitmed. Pun Pun (And monkeys) were appearing with completely black sprites. This led to numerous situations where characters would ask, "WHY IS PUN PUN WEARING BLACKFACE?"

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0ad92f9e-4102-43d2-8e42-f7c4320e6e03)

</p>
</details>

# Changelog

:cl:
- fix: Confiscated Pun Pun's blackface. 