### PR TITLE
Fix Various Language Trait Issues

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,6 +83,7 @@
       jobs:
         - Borg
         - MedicalBorg
+        - Mime
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -46,7 +46,7 @@
 - type: trait
   id: ForeignerLight
   category: TraitsSpeechLanguages
-  points: -2
+  points: 2
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -63,7 +63,7 @@
 - type: trait
   id: Foreigner
   category: TraitsSpeechLanguages
-  points: -4
+  points: 4
   requirements: # TODO: Add a requirement to know at least 1 non-gc language
     - !type:CharacterTraitRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -46,12 +46,13 @@
 - type: trait
   id: ForeignerLight
   category: TraitsSpeechLanguages
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
         - Foreigner
+        - Muted
   functions:
     - !type:TraitAddComponent
       components:
@@ -62,12 +63,13 @@
 - type: trait
   id: Foreigner
   category: TraitsSpeechLanguages
-  points: 4
+  points: -4
   requirements: # TODO: Add a requirement to know at least 1 non-gc language
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
         - ForeignerLight
+        - Muted
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -53,6 +53,10 @@
       traits:
         - Foreigner
         - Muted
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Mime
   functions:
     - !type:TraitAddComponent
       components:
@@ -70,6 +74,10 @@
       traits:
         - ForeignerLight
         - Muted
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Mime
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: SignLanguage
   category: TraitsSpeechLanguages
-  points: 0
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -79,7 +79,7 @@
 - type: trait
   id: ValyrianStandard
   category: TraitsSpeechLanguages
-  points: 1
+  points: -1
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -93,7 +93,7 @@
 - type: trait
   id: Azaziba
   category: TraitsSpeechLanguages
-  points: 1
+  points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
       species:


### PR DESCRIPTION
# Description

Fixes some various issues with language related traits, such as Mimes being able to take the Mute trait for "Free points", Foreigner being able to be combined with Mute for "Free Points", etc. Foreigner being able to be taken by Mimes for "Free Points". Also stuff like the "Rare" languages giving you points instead of costing points, Sign Language being the "Best Language" because its mechanically better and free, so now it costs points, etc. 

# Changelog

:cl:
- tweak: Mimes can no longer take the Muted or Foreigner traits. 
- tweak: "Rare" languages like Sinta'Azaziba, Valyrian Standard, now cost points instead of giving points.
- tweak: Sign Language now costs points.
