### PR TITLE
Increase Trait Limit From 10 To 14

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -422,7 +422,7 @@ namespace Content.Shared.CCVar
         ///     How many traits a character can have at most.
         /// </summary>
         public static readonly CVarDef<int> GameTraitsMax =
-            CVarDef.Create("game.traits_max", 10, CVar.REPLICATED);
+            CVarDef.Create("game.traits_max", 14, CVar.REPLICATED);
 
         /// <summary>
         ///     How many points a character should start with.


### PR DESCRIPTION
# Description

When https://github.com/Simple-Station/Einstein-Engines/pull/720 (PR to raise trait limit from 5 to 10) was merged, we only had **53** traits. Now, we have a total of **109** traits. I was conservative with the trait limit back then because we didn't have as much traits, but now that we have so many we should raise the default trait limit from **10** to **14**. I believe 14 should be as high as it gets from now on.

For reference, the quirk limit in /tg/ station is just a maximum of 6 positive quirks. So a typical build that reaches the 14 trait limit would be something like 6 positive traits, 6 negative traits to afford all of those positive traits, 1 language trait and 1 accent trait. 

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Skubman
- tweak: The maximum trait limit has increased from 10 traits to 14 traits.
