### PR TITLE
Increase Title/Content Text Limits For News Articles

### DIFF
--- a/Content.Client/MassMedia/Ui/NewsArticleCard.xaml.cs
+++ b/Content.Client/MassMedia/Ui/NewsArticleCard.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class NewsArticleCard : Control
     public string? Title
     {
         get => TitleLabel.Text;
-        set => TitleLabel.Text = value?.Length <= 30 ? value : $"{value?[..30]}...";
+        set => TitleLabel.Text = value?.Length <= 40 ? value : $"{value?[..40]}...";
     }
 
     public string? Author

--- a/Content.Client/MassMedia/Ui/NewsWriterMenu.xaml
+++ b/Content.Client/MassMedia/Ui/NewsWriterMenu.xaml
@@ -4,8 +4,8 @@
     xmlns:ui="clr-namespace:Content.Client.MassMedia.Ui"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'news-write-ui-default-title'}"
-    MinSize="348 443"
-    SetSize="348 443">
+    MinSize="404 443"
+    SetSize="404 443">
 
     <ui:ArticleEditorPanel Name="ArticleEditorPanel" HorizontalAlignment="Left" VerticalExpand="True"
                            MinWidth="410" MinHeight="370" Margin="0 0 0 30" Access="Public" Visible="False"/>

--- a/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
+++ b/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.MassMedia.Systems;
 
 public abstract class SharedNewsSystem : EntitySystem
 {
-    public const int MaxTitleLength = 25;
-    public const int MaxContentLength = 2048;
+    public const int MaxTitleLength = 50;
+    public const int MaxContentLength = 2560;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
# Description

Increases the text limit for news reports:
- Title character limit: 25 -> 50
- Content character limit: 2048 -> 2560

Mostly a personal change for me because I often run into the title character limits when I was playing Reporter. 

## Media

![image](https://github.com/user-attachments/assets/121b29d3-af42-474d-bb04-a438dbab74c3)
![image](https://github.com/user-attachments/assets/5fd71407-a641-4dcc-8913-d0515ca7598c)
![image](https://github.com/user-attachments/assets/079142f8-5f39-4d91-b914-c1327bf4f0bb)


## Changelog

:cl: Skubman
- tweak: The news article title character limit has been increased from 25 to 50 characters, and news content from 2048 to 2560 characters.