### PR TITLE
Fix Elite Suit Being ONE FUCKING TC

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1495,7 +1495,7 @@
   discountDownTo:
     Telecrystal: 7
   cost:
-    Telecrystal: 1
+    Telecrystal: 12
   categories:
   - UplinkWearables
 


### PR DESCRIPTION
# Description

merge asap to fix powergaming reel

---

# TODO

- [x] Contemplate abusing this as long as I can until this gets merged.

---

# Changelog

:cl:
- fix: Fixed Syndicate Elite hardsuit being one singular Telecrystal. Cybersun will never recover from this financial blunder.