### PR TITLE
Prisoner Headset Box in Warden's Locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
@@ -18,6 +18,21 @@
       - state: handcuff
 
 - type: entity
+  name: prisoner headset box
+  parent: BoxCardboard
+  id: BoxPrisonerHeadset
+  description: A box of prisoner headsets.
+  components:
+  - type: StorageFill
+    contents:
+    - id: ClothingHeadsetPrison
+      amount: 4
+  - type: Sprite
+    layers:
+    - state: box_security
+    - state: headset
+
+- type: entity
   name: flashbang box
   parent: BoxCardboard
   id: BoxFlashbang

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -24,6 +24,7 @@
       - id: BoxPDAPrisoner # Delta-V
       - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
       - id: BoxEncryptionKeyPrisoner #Delta-V
+      - id: BoxPrisonerHeadset
       - id: LunchboxSecurityFilledRandom # Delta-v Lunchboxes!
         prob: 0.3
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -53,6 +53,7 @@
       - id: BoxPDAPrisoner # Delta-V
       - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
       - id: BoxEncryptionKeyPrisoner #Delta-V
+      - id: BoxPrisonerHeadset
       - id: LunchboxSecurityFilledRandom # Delta-v Lunchboxes!
         prob: 0.3
 


### PR DESCRIPTION
# Description

Adds a prisoner headset box for warden's locker

Reason: There's too much chaos in security and making radio headsets with pure encryption keys takes time and tools. More so cause by the time someone gets a perma punishment, its gonna be most likely late in the round and sec department will be dealing with a lot of things at the same time. 

---

<details><summary><h1>Media</h1></summary>
<p>

![Content Client_LlH3OUGtCU](https://github.com/user-attachments/assets/ea20a648-9606-4104-9787-0766966bd358)


![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added prisoner headset box to warden's locker.