### PR TITLE
Some Surgery Fixs

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedBodySystem : EntitySystem
     /// <summary>
     /// Gets the container Id for the specified slotId.
     /// </summary>
-    public string GetOrganContainerId(string slotId)
+    public static string GetOrganContainerId(string slotId)
     {
         return OrganSlotContainerIdPrefix + slotId;
     }

--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedBodySystem : EntitySystem
     /// <summary>
     /// Gets the container Id for the specified slotId.
     /// </summary>
-    public static string GetOrganContainerId(string slotId)
+    public string GetOrganContainerId(string slotId)
     {
         return OrganSlotContainerIdPrefix + slotId;
     }

--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganConditionComponent.cs
@@ -15,4 +15,7 @@ public sealed partial class SurgeryOrganConditionComponent : Component
 
     [DataField]
     public bool Reattaching;
+
+    [DataField(required: true)]
+    public string SlotId = string.Empty;
 }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Popups;
 using Content.Shared.Prototypes;
 using Content.Shared.Standing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
@@ -47,6 +48,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly RotateToFaceSystem _rotateToFace = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
 
     /// <summary>
     /// Cache of all surgery prototypes' singleton entities.
@@ -265,7 +267,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
                     && !organs.Any(organ => HasComp<OrganReattachedComponent>(organ.Id))))
                     args.Cancelled = true;
             }
-            else if (!ent.Comp.Inverse)
+            else if (!ent.Comp.Inverse || !_container.TryGetContainer(args.Part, _body.GetOrganContainerId(ent.Comp.SlotId), out _))
                 args.Cancelled = true;
         }
     }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -267,7 +267,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
                     && !organs.Any(organ => HasComp<OrganReattachedComponent>(organ.Id))))
                     args.Cancelled = true;
             }
-            else if (!ent.Comp.Inverse || !_container.TryGetContainer(args.Part, _body.GetOrganContainerId(ent.Comp.SlotId), out _))
+            else if (!ent.Comp.Inverse || !_container.TryGetContainer(args.Part, SharedBodySystem.GetOrganContainerId(ent.Comp.SlotId), out _))
                 args.Cancelled = true;
         }
     }

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -184,6 +184,11 @@
   - type: IsDeadIC
   - type: Body
     prototype: AnimalNymphBrain
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   id: OrganDionaNymphStomach
@@ -196,6 +201,11 @@
   - type: IsDeadIC
   - type: Body
     prototype: AnimalNymphStomach
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
 
 - type: entity
   id: OrganDionaNymphLungs
@@ -208,3 +218,8 @@
   - type: IsDeadIC
   - type: Body
     prototype: AnimalNymphLungs
+  - type: SurgeryTarget
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -104,6 +104,7 @@
   - type: FireVisuals
     alternateState: Standing
   - type: FootPrints
+  - type: LayingDown
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -377,6 +377,16 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Brain
+    slotId: brain
+
+- type: entity
+  parent: SurgeryRemoveBrain
+  id: SurgeryRemoveBrainTorso
+  name: Remove Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryPartCondition
+    part: Torso
 
 - type: entity
   parent: SurgeryBase
@@ -397,6 +407,16 @@
     - type: Brain
     inverse: true
     reattaching: true
+    slotId: brain
+
+- type: entity
+  parent: SurgeryInsertBrain
+  id: SurgeryInsertBrainTorso
+  name: Insert Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryPartCondition
+    part: Torso
 
 - type: entity
   parent: SurgeryBase
@@ -415,6 +435,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Heart
+    slotId: heart
 
 - type: entity
   parent: SurgeryBase
@@ -435,6 +456,7 @@
     - type: Heart
     inverse: true
     reattaching: true
+    slotId: heart
 
 - type: entity
   parent: SurgeryBase
@@ -453,6 +475,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Liver
+    slotId: liver
 
 - type: entity
   parent: SurgeryBase
@@ -473,6 +496,7 @@
     - type: Liver
     inverse: true
     reattaching: true
+    slotId: liver
 
 - type: entity
   parent: SurgeryBase
@@ -491,6 +515,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Lung
+    slotId: lungs
 
 - type: entity
   parent: SurgeryBase
@@ -511,6 +536,7 @@
     - type: Lung
     inverse: true
     reattaching: true
+    slotId: lungs
 
 - type: entity
   parent: SurgeryBase
@@ -529,6 +555,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Stomach
+    slotId: stomach
 
 - type: entity
   parent: SurgeryBase
@@ -549,6 +576,7 @@
     - type: Stomach
     inverse: true
     reattaching: true
+    slotId: stomach
 
 - type: entity
   parent: SurgeryBase
@@ -567,6 +595,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Eyes
+    slotId: eyes
 
 - type: entity
   parent: SurgeryBase
@@ -587,6 +616,7 @@
     - type: Eyes
     inverse: true
     reattaching: true
+    slotId: eyes
 
 - type: entity
   parent: SurgeryBase
@@ -602,6 +632,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Brain
+    slotId: brain
   - type: SurgeryOrganOnAddCondition
     components:
       brain:
@@ -629,6 +660,7 @@
   - type: SurgeryOrganCondition
     organ:
     - type: Brain
+    slotId: brain
   - type: SurgeryOrganOnAddCondition
     components:
       brain:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

When attempting to insert an organ, a check is now performed to ensure a container exists for it. Skeletons can now lie down, and nymphs can now be subject to surgery.
---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Spatison
- tweak: Nymphs are now operable.
- fix: Skeletons can now lie down.
- fix: It is no longer possible to insert an organ into a body if the required space is unavailable.
