### PR TITLE
Senior Physician CPR

### DIFF
--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -16,6 +16,7 @@
         - Paramedic
         - ChiefMedicalOfficer
         - Brigmedic
+        - SeniorPhysician
 
 - type: trait
   id: SelfAware


### PR DESCRIPTION
# Description

Senior Physician wasn't included in the list of jobs that can't take CPR Training, but they already have CPR training, thus allowing players who don't know this to waste 4 points on a trait they get for free.
