### PR TITLE
Porting over My Cruise Control Code From Frontier

### DIFF
--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -77,18 +77,18 @@
                                          MinWidth="82"
                                          MaxWidth="82"/>
                         <controls:Button Name="DampenerOn"
-                                         Text="{controls:Loc 'shuttle-console-inertia-dampener-dampen'}"
+                                         Text="{controls:Loc 'shuttle-console-inertia-dampener-dampened'}"
                                          TextAlign="Center"
                                          ToggleMode="True"
                                          MinWidth="82"
                                          MaxWidth="82"/>
                         <controls:Button Name="AnchorOn"
-                                         Text="{controls:Loc 'shuttle-console-inertia-dampener-anchor'}"
+                                         Text="{controls:Loc 'shuttle-console-inertia-dampener-anchored'}"
                                          TextAlign="Center"
                                          ToggleMode="True"
                                          MinWidth="82"
                                          MaxWidth="82"/>
                     </controls:BoxContainer>
-                    <!-- End Frontier - Inertia dampener controls-->
+                    <!--end Inertia dampener controls-->
                     </controls:BoxContainer>
                 </controls:BoxContainer>

--- a/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -1,5 +1,5 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
 using Content.Client.Shuttles.UI;
 using Content.Shared._NF.Shuttles.Events;

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -1,48 +1,42 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
 using Content.Shared._NF.Shuttles.Events;
 using Robust.Client.UserInterface.Controls;
 
-namespace Content.Client.Shuttles.UI;
-
-public sealed partial class NavScreen
+namespace Content.Client.Shuttles.UI
 {
-    private readonly ButtonGroup _buttonGroup = new();
-    public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
-
-    private void NfInitialize()
+    public sealed partial class NavScreen
     {
-        DampenerOff.OnPressed += _ => SetDampenerMode(InertiaDampeningMode.Off);
-        DampenerOn.OnPressed += _ => SetDampenerMode(InertiaDampeningMode.Dampen);
-        AnchorOn.OnPressed += _ => SetDampenerMode(InertiaDampeningMode.Anchor);
+        private readonly ButtonGroup _buttonGroup = new();
+        public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
 
-        DampenerOff.Group = _buttonGroup;
-        DampenerOn.Group = _buttonGroup;
-        AnchorOn.Group = _buttonGroup;
+        private void NfInitialize()
+        {
 
-        // Send off a request to get the current dampening mode.
-        _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
-        OnInertiaDampeningModeChanged?.Invoke(shuttle, InertiaDampeningMode.Query);
-    }
+            DampenerOff.OnPressed += _ => SwitchDampenerMode(InertiaDampeningMode.Off);
+            DampenerOn.OnPressed += _ => SwitchDampenerMode(InertiaDampeningMode.Dampened);
+            AnchorOn.OnPressed += _ => SwitchDampenerMode(InertiaDampeningMode.Anchored);
 
-    private void SetDampenerMode(InertiaDampeningMode mode)
-    {
-        NavRadar.DampeningMode = mode;
-        _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
-        OnInertiaDampeningModeChanged?.Invoke(shuttle, mode);
-    }
+            var group = new ButtonGroup();
+            DampenerOff.Group = group;
+            DampenerOn.Group = group;
+            AnchorOn.Group = group;
+        }
 
-    private void NfUpdateState()
-    {
-        if (NavRadar.DampeningMode == InertiaDampeningMode.Station)
-            DampenerModeButtons.Visible = false;
-        else
+        private void SwitchDampenerMode(InertiaDampeningMode mode)
+        {
+            NavRadar.DampeningMode = mode;
+            _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+            OnInertiaDampeningModeChanged?.Invoke(shuttle, mode);
+        }
+
+        private void NfUpdateState()
         {
             DampenerModeButtons.Visible = true;
             DampenerOff.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Off;
-            DampenerOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Dampen;
-            AnchorOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Anchor;
+            DampenerOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Dampened;
+            AnchorOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Anchored;
         }
     }
 }

--- a/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -1,5 +1,5 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
 using Content.Shared._NF.Shuttles.Events;
 

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -1,30 +1,27 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
 using Content.Shared._NF.Shuttles.Events;
 using Content.Shared.Shuttles.BUIStates;
 using Robust.Shared.Physics.Components;
-using System.Numerics;
-using Robust.Client.Graphics;
-using Robust.Shared.Collections;
 
-namespace Content.Client.Shuttles.UI;
-
-public sealed partial class ShuttleNavControl
+namespace Content.Client.Shuttles.UI
 {
-    public InertiaDampeningMode DampeningMode { get; set; }
-
-    private void NfUpdateState(NavInterfaceState state)
+    public sealed partial class ShuttleNavControl
     {
+        public InertiaDampeningMode DampeningMode { get; set; }
 
-        if (!EntManager.GetCoordinates(state.Coordinates).HasValue ||
-            !EntManager.TryGetComponent(
-                EntManager.GetCoordinates(state.Coordinates).GetValueOrDefault().EntityId,
-                out TransformComponent? transform) ||
-            !EntManager.TryGetComponent(transform.GridUid, out PhysicsComponent? _))
-            return;
+        private void NfUpdateState(NavInterfaceState state)
+        {
 
-        DampeningMode = state.DampeningMode;
+            if (!EntManager.GetCoordinates(state.Coordinates).HasValue ||
+                !EntManager.TryGetComponent(EntManager.GetCoordinates(state.Coordinates).GetValueOrDefault().EntityId, out TransformComponent? transform) ||
+                !EntManager.TryGetComponent(transform.GridUid, out PhysicsComponent? physicsComponent))
+            {
+                return;
+            }
+
+            DampeningMode = state.DampeningMode;
+        }
     }
 }
-

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -258,7 +258,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         }
         else
         {
-            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen); // Frontier: inertia dampening);
+            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampened); // Frontier: inertia dampening);
             mapState = new ShuttleMapInterfaceState(
                 FTLState.Invalid,
                 default,
@@ -373,7 +373,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     public NavInterfaceState GetNavState(Entity<RadarConsoleComponent?, TransformComponent?> entity, Dictionary<NetEntity, List<DockingPortState>> docks)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampen); // Frontier: add inertia dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampened); // Frontier: add inertia dampening
 
         return GetNavState(
             entity,
@@ -389,7 +389,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         Angle angle)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen); // Frontier: add inertial dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampened); // Frontier: add inertial dampening
 
         return new NavInterfaceState(
             entity.Comp1.MaxRange,

--- a/Content.Server/Station/Systems/StationDampeningSystem.cs
+++ b/Content.Server/Station/Systems/StationDampeningSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Shuttles.Components;
 using Content.Server.Station.Events;
 using Content.Shared.Physics;
 
@@ -17,12 +18,16 @@ public sealed class StationDampeningSystem : EntitySystem
             // If the station grid doesn't have defined dampening, give it a small dampening by default
             // This will ensure cargo tech pros won't fling the station 1000 megaparsec away from the galaxy
             if (!TryComp<PassiveDampeningComponent>(grid, out var dampening))
-            {
                 dampening = AddComp<PassiveDampeningComponent>(grid);
-                dampening.Enabled = true;
-                dampening.LinearDampening = 0.01f;
-                dampening.AngularDampening = 0.01f;
-            }
+
+            EntityManager.TryGetComponent(grid, out ShuttleComponent? shuttleComponent);
+
+            // PassiveDampeningComponent conflicts with shuttles cruise control a frontier QOL and is resetting dampeners causing issues.
+            // so if a station which shuttles have the station component too, then don't reset the physics to a near off state when it gets bumped
+            dampening.Enabled = true;
+            dampening.LinearDampening = shuttleComponent?.LinearDamping ?? 0.01f;
+            dampening.AngularDampening = shuttleComponent?.AngularDamping ?? 0.01f;
+
         }
     }
 }

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -1,57 +1,49 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
-using Content.Server._NF.Station.Components;
 using Content.Server.Shuttles.Components;
-using Content.Server.Station.Components;
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.CCVar;
 using Robust.Shared.Physics.Components;
 
 namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
-    private const float SpaceFrictionStrength = 0.0015f;
-    private const float AnchorDampeningStrength = 0.5f;
+    private float _spaceFrictionStrength;
+    private float _anchorDampeningStrength;
     private void NfInitialize()
     {
         SubscribeLocalEvent<ShuttleConsoleComponent, SetInertiaDampeningRequest>(OnSetInertiaDampening);
+        _spaceFrictionStrength = _cfg.GetCVar(CCVars.SpaceFrictionStrength);
+        _anchorDampeningStrength = _cfg.GetCVar(CCVars.AnchorDampeningStrength);
     }
 
     private void OnSetInertiaDampening(EntityUid uid, ShuttleConsoleComponent component, SetInertiaDampeningRequest args)
     {
-        // Ensure that the entity requested is a valid shuttle (stations should not be togglable)
-        if (!EntityManager.TryGetComponent(uid, out TransformComponent? transform) ||
+        if (!EntityManager.TryGetComponent(GetEntity(args.ShuttleEntityUid), out TransformComponent? transform) ||
             !transform.GridUid.HasValue ||
             !EntityManager.TryGetComponent(transform.GridUid, out PhysicsComponent? physicsComponent) ||
             !EntityManager.TryGetComponent(transform.GridUid, out ShuttleComponent? shuttleComponent))
-            return;
-
-        if (args.Mode == InertiaDampeningMode.Query)
         {
-            _console.RefreshShuttleConsoles(transform.GridUid.Value);
             return;
         }
-
-        if (!EntityManager.HasComponent<ShuttleComponent>(transform.GridUid) ||
-            EntityManager.TryGetComponent<StationDataComponent>(_station.GetOwningStation(transform.GridUid), out var stationData)
-            && stationData.StationConfig != null)
-            return;
+        _console.RefreshShuttleConsoles(transform.GridUid.Value);
 
         var linearDampeningStrength = args.Mode switch
         {
-            InertiaDampeningMode.Off => SpaceFrictionStrength,
-            InertiaDampeningMode.Dampen => shuttleComponent.LinearDamping,
-            InertiaDampeningMode.Anchor => AnchorDampeningStrength,
-            _ => shuttleComponent.LinearDamping, // other values: default to some sane behaviour (assume normal dampening)
+            InertiaDampeningMode.Off => _spaceFrictionStrength,
+            InertiaDampeningMode.Dampened => shuttleComponent.LinearDamping, // should i use Dampener Strength instead?
+            InertiaDampeningMode.Anchored => _anchorDampeningStrength,
+            _ => shuttleComponent.LinearDamping, // if some how we end up here... just keep calm and carry on with your bad self
         };
 
         var angularDampeningStrength = args.Mode switch
         {
-            InertiaDampeningMode.Off => SpaceFrictionStrength,
-            InertiaDampeningMode.Dampen => shuttleComponent.AngularDamping,
-            InertiaDampeningMode.Anchor => AnchorDampeningStrength,
-            _ => shuttleComponent.AngularDamping, // other values: default to some sane behaviour (assume normal dampening)
+            InertiaDampeningMode.Off => _spaceFrictionStrength,
+            InertiaDampeningMode.Dampened => shuttleComponent.AngularDamping,
+            InertiaDampeningMode.Anchored => _anchorDampeningStrength,
+            _ => shuttleComponent.AngularDamping, // if some how we end up here... just keep calm and carry on with your bad self
         };
 
         _physics.SetLinearDamping(transform.GridUid.Value, physicsComponent, linearDampeningStrength);
@@ -61,27 +53,16 @@ public sealed partial class ShuttleSystem
 
     public InertiaDampeningMode NfGetInertiaDampeningMode(EntityUid entity)
     {
-        if (!EntityManager.TryGetComponent<TransformComponent>(entity, out var xform))
-            return InertiaDampeningMode.Dampen;
+        if (!EntityManager.TryGetComponent<TransformComponent>(entity, out var xform) ||
+            !EntityManager.TryGetComponent(xform.GridUid, out PhysicsComponent? physicsComponent))
+            return InertiaDampeningMode.Dampened;
 
-        var owningStation = _station.GetOwningStation(xform.GridUid);
+        if (physicsComponent.LinearDamping == _anchorDampeningStrength)
+            return InertiaDampeningMode.Anchored;
 
-        // Not a shuttle, shouldn't be togglable
-        if (!EntityManager.HasComponent<ShuttleComponent>(xform.GridUid) ||
-            EntityManager.TryGetComponent<StationDataComponent>(owningStation, out var stationData)
-            && stationData.StationConfig != null)
-            return InertiaDampeningMode.Station;
-
-        if (!EntityManager.TryGetComponent(xform.GridUid, out PhysicsComponent? physicsComponent))
-            return InertiaDampeningMode.Dampen;
-
-        if (physicsComponent.LinearDamping >= AnchorDampeningStrength)
-            return InertiaDampeningMode.Anchor;
-
-        if (physicsComponent.LinearDamping <= SpaceFrictionStrength)
+        else if (physicsComponent.LinearDamping == _spaceFrictionStrength)
             return InertiaDampeningMode.Off;
-
-        return InertiaDampeningMode.Dampen;
+        else
+            return InertiaDampeningMode.Dampened;
     }
-
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -10,6 +10,7 @@ namespace Content.Shared.CCVar
     [CVarDefs]
     public sealed class CCVars : CVars
     {
+        #region Server
         /*
          * Server
          */
@@ -26,6 +27,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> RulesFile =
             CVarDef.Create("server.rules_file", "DefaultRuleset", CVar.REPLICATED | CVar.SERVER);
 
+        #endregion
+        #region Ambience
         /*
          * Ambience
          */
@@ -84,6 +87,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> InterfaceVolume =
             CVarDef.Create("audio.interface_volume", 0.50f, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+        #endregion
+        #region Status
         /*
          * Status
          */
@@ -94,6 +99,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> StatusMoMMIPassword =
             CVarDef.Create("status.mommipassword", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
 
+        #endregion
+        #region Events
         /*
          * Events
          */
@@ -118,6 +125,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float>
             EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
 
+        #endregion
+        #region Game
         /*
          * Game
          */
@@ -503,6 +512,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> RoundEndSoundCollection =
             CVarDef.Create("game.round_end_sound_collection", "RoundEnd", CVar.SERVERONLY);
 
+        #endregion
+        #region Announcers
 
         /*
          * Announcers
@@ -540,6 +551,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("announcer.disable_multiple_sounds", false, CVar.ARCHIVE | CVar.CLIENTONLY);
 
 
+        #endregion
+        #region Queue
         /*
          * Queue
          */
@@ -551,6 +564,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> QueueEnabled =
             CVarDef.Create("queue.enabled", false, CVar.SERVERONLY);
 
+        #endregion
+        #region Discord
 
         /*
          * Discord
@@ -622,6 +637,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> DiscordAuthApiKey =
             CVarDef.Create("discord.auth_api_key", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
 
+        #endregion
+        #region Tips
         /*
          * Tips
          */
@@ -660,6 +677,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> TipsTippyChance =
             CVarDef.Create("tips.tippy_chance", 0.01f);
 
+        #endregion
+        #region Console
         /*
          * Console
          */
@@ -674,6 +693,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("console.login_host_user", "", CVar.ARCHIVE | CVar.SERVERONLY);
 
 
+        #endregion
+        #region Database stuff
         /*
          * Database stuff
          */
@@ -748,6 +769,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> DatabaseSynchronous =
             CVarDef.Create("database.sync", false, CVar.SERVERONLY);
 
+        #endregion
+        #region Interface
         /*
          * Interface
          */
@@ -758,6 +781,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> UIHoverSound =
             CVarDef.Create("interface.hover_sound", "/Audio/UserInterface/hover.ogg", CVar.REPLICATED);
 
+        #endregion
+        #region Outline
         /*
          * Outline
          */
@@ -766,6 +791,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("outline.enabled", true, CVar.CLIENTONLY);
 
 
+        #endregion
+        #region Parallax
         /*
          * Parallax
          */
@@ -779,6 +806,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ParallaxLowQuality =
             CVarDef.Create("parallax.low_quality", false, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+        #endregion
+        #region Physics
         /*
          * Physics
          */
@@ -804,6 +833,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> MobPushing =
             CVarDef.Create("physics.mob_pushing", false, CVar.REPLICATED);
 
+        #endregion
+        #region Music
         /*
          * Music
          */
@@ -814,6 +845,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> EventMusicEnabled =
             CVarDef.Create("ambience.event_music_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+        #endregion
+        #region Specific Sounds
+
         /*
          * Specific Sounds
          */
@@ -822,6 +856,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("ambience.restart_sounds_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
 
+        #endregion
+        #region Admin Sounds
         /*
          * Admin sounds
          */
@@ -833,6 +869,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AdminChatSoundVolume =
             CVarDef.Create("audio.admin_chat_sound_volume", -5f, CVar.ARCHIVE | CVar.CLIENT | CVar.REPLICATED);
 
+        #endregion
+        #region HUD
         /*
          * HUD
          */
@@ -857,6 +895,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> HudFpsCounterVisible =
             CVarDef.Create("hud.fps_counter_visible", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        #endregion
+        #region NPCs
         /*
          * NPCs
          */
@@ -871,6 +911,8 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> NPCPathfinding = CVarDef.Create("npc.pathfinding", true);
 
+        #endregion
+        #region Net
         /*
          * Net
          */
@@ -884,6 +926,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> GasOverlayThresholds =
             CVarDef.Create("net.gasoverlaythresholds", 20);
 
+        #endregion
+        #region Admin
         /*
          * Admin
          */
@@ -1052,6 +1096,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AdminsCountForMaxPlayers =
             CVarDef.Create("admin.admins_count_for_max_players", false, CVar.SERVERONLY);
 
+        #endregion
+        #region AHELP
         /*
          * AHELP
          */
@@ -1129,6 +1175,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> UseAdminOOCColorInBwoinks =
             CVarDef.Create("admin.bwoink_use_admin_ooc_color", false, CVar.SERVERONLY);
 
+        #endregion
+        #region Explosions
         /*
          * Explosions
          */
@@ -1235,6 +1283,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ExplosionCanCreateVacuum =
             CVarDef.Create("explosion.can_create_vacuum", true, CVar.SERVERONLY);
 
+        #endregion
+        #region Radiation
         /*
          * Radiation
          */
@@ -1265,6 +1315,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> RadiationGridcastMaxDistance =
             CVarDef.Create("radiation.gridcast.max_distance", 50f, CVar.SERVERONLY);
 
+        #endregion
+        #region Admin logs
         /*
          * Admin logs
          */
@@ -1297,6 +1349,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> AdminLogsServerName =
             CVarDef.Create("adminlogs.server_name", "unknown", CVar.SERVERONLY);
 
+        #endregion
+        #region Atmos
         /*
          * Atmos
          */
@@ -1487,6 +1541,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AtmosHumanoidThrowMultiplier =
             CVarDef.Create("atmos.humanoid_throw_multiplier", 2f, CVar.SERVERONLY);
 
+        #endregion
+        #region MIDI instruments
         /*
          * MIDI instruments
          */
@@ -1503,18 +1559,24 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> MaxMidiLaggedBatches =
             CVarDef.Create("midi.max_lagged_batches", 8, CVar.SERVERONLY);
 
+        #endregion
+        #region Holidays
         /*
          * Holidays
          */
 
         public static readonly CVarDef<bool> HolidaysEnabled = CVarDef.Create("holidays.enabled", true, CVar.SERVERONLY);
 
+        #endregion
+        #region Branding stuff
         /*
          * Branding stuff
          */
 
         public static readonly CVarDef<bool> BrandingSteam = CVarDef.Create("branding.steam", false, CVar.CLIENTONLY);
 
+        #endregion
+        #region OOC
         /*
          * OOC
          */
@@ -1538,6 +1600,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ShowOocPatronColor =
             CVarDef.Create("ooc.show_ooc_patron_color", true, CVar.ARCHIVE | CVar.REPLICATED | CVar.CLIENT);
 
+        #endregion
+        #region LOOC
         /*
          * LOOC
          */
@@ -1559,11 +1623,15 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> CritLoocEnabled = CVarDef.Create("looc.enabled_crit", false, CVar.NOTIFY | CVar.REPLICATED);
 
+        #endregion
+        #region Entity Menu Grouping Types
         /*
          * Entity Menu Grouping Types
          */
         public static readonly CVarDef<int> EntityMenuGroupingType = CVarDef.Create("entity_menu", 0, CVar.CLIENTONLY);
 
+        #endregion
+        #region Whitelist
         /*
          * Whitelist
          */
@@ -1581,6 +1649,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> WhitelistPrototypeList =
             CVarDef.Create("whitelist.prototype_list", "basicWhitelist", CVar.SERVERONLY);
 
+        #endregion
+        #region VOTE
         /*
          * VOTE
          */
@@ -1665,6 +1735,8 @@ namespace Content.Shared.CCVar
             VoteTimerAlone = CVarDef.Create("vote.timeralone", 10, CVar.SERVERONLY);
 
 
+        #endregion
+        #region BAN
         /*
          * BAN
          */
@@ -1672,6 +1744,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> BanHardwareIds =
             CVarDef.Create("ban.hardware_ids", true, CVar.SERVERONLY);
 
+        #endregion
+        #region Procgen
         /*
          * Procgen
          */
@@ -1682,6 +1756,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ProcgenPreload =
             CVarDef.Create("procgen.preload", true, CVar.SERVERONLY);
 
+        #endregion
+        #region Shuttles
         /*
          * Shuttles
          */
@@ -1787,6 +1863,19 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> HyperspaceKnockdownTime =
             CVarDef.Create("shuttle.hyperspace_knockdown_time", 5f, CVar.SERVERONLY);
 
+        ///<summary>
+        /// the Entropic decay of energy combined with the minimal but existent particles that would slow the vessel down
+        ///</summary>
+        public static readonly CVarDef<float> SpaceFrictionStrength =
+            CVarDef.Create("shuttle.space_friction_strength", 0.0015f, CVar.REPLICATED);
+
+        ///<summary>
+        /// the strength of drag when the inertia dampeners are set to anchor to slow the vessel down and hold it in place
+        ///</summary>
+        public static readonly CVarDef<float> AnchorDampeningStrength =
+            CVarDef.Create("shuttle.ancho_dampening_strength", 0.5f, CVar.REPLICATED);
+        #endregion
+        #region Emergency
         /*
          * Emergency
          */
@@ -1848,6 +1937,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
             CVarDef.Create("shuttle.auto_call_extension_time", 30, CVar.SERVERONLY);
 
+        #endregion
+        #region Crew Manifests
         /*
          * Crew Manifests
          */
@@ -1870,8 +1961,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> CrewManifestUnsecure =
             CVarDef.Create("crewmanifest.unsecure", true, CVar.REPLICATED);
 
+        #endregion
         #region Cloning
 
+        /*
+         * Cloning
+         */
         /// <summary>
         ///     How much should the cost to clone an entity be multiplied by.
         /// </summary>
@@ -1927,7 +2022,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("cloning.preserve_flavor_text", true, CVar.SERVERONLY);
 
         #endregion
-
+        #region Anomaly
         /*
          * Anomaly
          */
@@ -1938,6 +2033,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AnomalyGenerationGridBoundsScale =
             CVarDef.Create("anomaly.generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
 
+        #endregion
+        #region VIEWPORT
         /*
          * VIEWPORT
          */
@@ -1970,6 +2067,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ViewportVerticalFit =
             CVarDef.Create("viewport.vertical_fit", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        #endregion
+        #region FOV
         /*
          * FOV
          */
@@ -1987,6 +2086,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> ZoomLevels =
             CVarDef.Create("fov.zoom_levels", 7, CVar.SERVER | CVar.REPLICATED);
 
+        #endregion
+        #region UI
         /*
          * UI
          */
@@ -2000,6 +2101,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> SeparatedScreenChatSize =
             CVarDef.Create("ui.separated_chat_size", "0.6,0", CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        #endregion
+        #region Accessibility
 
         /*
         * Accessibility
@@ -2043,6 +2146,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> NoVisionFilters =
             CVarDef.Create("accessibility.no_vision_filters", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        #endregion
+        #region CHAT
         /*
          * CHAT
          */
@@ -2103,6 +2208,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> MOTD =
             CVarDef.Create("chat.motd", "", CVar.SERVER | CVar.SERVERONLY | CVar.ARCHIVE, "A message broadcast to each player that joins the lobby.");
 
+        #endregion
+        #region AFK
         /*
          * AFK
          */
@@ -2113,6 +2220,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AfkTime =
             CVarDef.Create("afk.time", 60f, CVar.SERVERONLY);
 
+        #endregion
+        #region IC
         /*
          * IC
          */
@@ -2165,6 +2274,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> EtherealPassThrough =
             CVarDef.Create("ic.EtherealPassThrough", false, CVar.SERVER);
 
+        #endregion
+        #region Salvage
         /*
          * Salvage
          */
@@ -2181,6 +2292,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float>
             SalvageExpeditionCooldown = CVarDef.Create("salvage.expedition_cooldown", 780f, CVar.REPLICATED);
 
+        #endregion
+        #region Flavor
         /*
          * Flavor
          */
@@ -2192,6 +2305,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int>
             FlavorLimit = CVarDef.Create("flavor.limit", 10, CVar.SERVERONLY);
 
+        #endregion
+        #region Mapping
         /*
          * Mapping
          */
@@ -2215,6 +2330,8 @@ namespace Content.Shared.CCVar
             AutosaveDirectory = CVarDef.Create("mapping.autosave_dir", "Autosaves", CVar.SERVERONLY);
 
 
+        #endregion
+        #region Rules
         /*
          * Rules
          */
@@ -2232,6 +2349,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("rules.exempt_local", false, CVar.SERVERONLY);
 
 
+        #endregion
+        #region Autogeneration
         /*
          * Autogeneration
          */
@@ -2239,6 +2358,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> DestinationFile =
             CVarDef.Create("autogen.destination_file", "", CVar.SERVER | CVar.SERVERONLY);
 
+        #endregion
+        #region Network Resource Manager
         /*
          * Network Resource Manager
          */
@@ -2257,6 +2378,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> ResourceUploadingStoreDeletionDays =
             CVarDef.Create("netres.store_deletion_days", 30, CVar.SERVER | CVar.SERVERONLY);
 
+        #endregion
+        #region Controls
         /*
          * Controls
          */
@@ -2278,7 +2401,8 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> DefaultWalk =
             CVarDef.Create("control.default_walk", true, CVar.CLIENT | CVar.REPLICATED | CVar.ARCHIVE);
-
+        #endregion
+        #region Interactions
         /*
          * Interactions
          */
@@ -2307,6 +2431,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> InteractionRateLimitAnnounceAdminsDelay =
             CVarDef.Create("interaction.rate_limit_announce_admins_delay", 120, CVar.SERVERONLY);
 
+        #endregion
+        #region STORAGE
         /*
          * STORAGE
          */
@@ -2323,6 +2449,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> OpaqueStorageWindow =
             CVarDef.Create("control.opaque_storage_background", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        #endregion
+        #region UPDATE
         /*
          * UPDATE
          */
@@ -2333,6 +2461,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> UpdateRestartDelay =
             CVarDef.Create("update.restart_delay", 20f, CVar.SERVERONLY);
 
+        #endregion
+        #region Ghost
         /*
          * Ghost
          */
@@ -2343,6 +2473,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> GhostRoleTime =
             CVarDef.Create("ghost.role_time", 8f, CVar.REPLICATED | CVar.SERVER);
 
+        #endregion
+        #region Fire alarm
         /*
          * Fire alarm
          */
@@ -2355,6 +2487,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> FireAlarmAllAccess =
             CVarDef.Create("firealarm.allaccess", true, CVar.SERVERONLY);
 
+        #endregion
+        #region PLAYTIME
         /*
          * PLAYTIME
          */
@@ -2365,6 +2499,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float>
             PlayTimeSaveInterval = CVarDef.Create("playtime.save_interval", 900f, CVar.SERVERONLY);
 
+        #endregion
+        #region INFOLINKS
         /*
          * INFOLINKS
          */
@@ -2417,6 +2553,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> InfoLinksAppeal =
             CVarDef.Create("infolinks.appeal", "", CVar.SERVER | CVar.REPLICATED);
 
+        #endregion
+        #region CONFIG
         /*
          * CONFIG
          */
@@ -2450,6 +2588,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ConfigPresetDebug =
             CVarDef.Create("config.preset_debug", true, CVar.SERVERONLY);
 
+        #endregion
+        #region World Generation
         /*
          * World Generation
          */
@@ -2471,6 +2611,8 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> GCMaximumTimeMs =
             CVarDef.Create("entgc.maximum_time_ms", 5, CVar.SERVERONLY);
 
+        #endregion
+        #region Replays
         /*
          * Replays
          */
@@ -2518,6 +2660,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("silicon.npcupdatetime", 1.5f, CVar.SERVERONLY);
 
 
+        #endregion
+        #region Miscellaneous
         /*
          * Miscellaneous
          */
@@ -2529,6 +2673,22 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> TippyEntity =
             CVarDef.Create("tippy.entity", "Tippy", CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        /// Set to true to disable parallel processing in the pow3r solver.
+        /// </summary>
+        public static readonly CVarDef<bool> DebugPow3rDisableParallel =
+            CVarDef.Create("debug.pow3r_disable_parallel", true, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Set to true to enable the dynamic hostname system.
+        /// Automatically updates the hostname to include current map and preset.
+        /// Configure what that looks like for you in Resources/Prototypes/Locale/en-US/dynamichostname/hostname.ftl
+        /// </summary>
+        public static readonly CVarDef<bool> UseDynamicHostname =
+            CVarDef.Create("game.use_dynamic_hostname", false, CVar.SERVERONLY);
+
+        #endregion
+        #region DEBUG
         /*
          * DEBUG
          */
@@ -2540,6 +2700,8 @@ namespace Content.Shared.CCVar
             CVarDef.Create("debug.option_visualizer_test", false, CVar.CLIENTONLY);
 
         /// DELTA-V CCVARS
+        #endregion
+        #region Glimmer
         /*
          * Glimmer
          */
@@ -2597,8 +2759,11 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> StationGoalsChance =
             CVarDef.Create("game.station_goals_chance", 0.1f, CVar.SERVERONLY);
 
-
+        #endregion
         #region CPR System
+        /*
+         * CPR System
+         */
         /// <summary>
         ///     Controls whether the entire CPR system runs. When false, nobody can perform CPR. You should probably remove the trait too
         ///     if you are wishing to permanently disable the system on your server.
@@ -2645,8 +2810,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("cpr.airloss_reduction_multiplier", 1f, CVar.REPLICATED | CVar.SERVER);
 
         #endregion
-
         #region Contests System
+        /*
+         * Contests System
+         */
 
         /// <summary>
         ///     The MASTER TOGGLE for the entire Contests System.
@@ -2700,8 +2867,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("contests.max_percentage", 0.25f, CVar.REPLICATED | CVar.SERVER);
 
         #endregion
-
         #region Supermatter System
+        /*
+         * Supermatter System
+         */
 
         /// <summary>
         ///     With completely default supermatter values, Singuloose delamination will occur if engineers inject at least 900 moles of coolant per tile
@@ -2749,15 +2918,17 @@ namespace Content.Shared.CCVar
             CVarDef.Create("supermatter.rads_modifier", 1f, CVar.SERVER);
 
         #endregion
-
         #region Mood System
+        /*
+         * Mood System
+         */
 
         public static readonly CVarDef<bool> MoodEnabled =
-        #if RELEASE
+#if RELEASE
             CVarDef.Create("mood.enabled", true, CVar.SERVER);
-        #else
+#else
             CVarDef.Create("mood.enabled", false, CVar.SERVER);
-        #endif
+#endif
 
         public static readonly CVarDef<bool> MoodIncreasesSpeed =
             CVarDef.Create("mood.increases_speed", true, CVar.SERVER);
@@ -2769,7 +2940,6 @@ namespace Content.Shared.CCVar
             CVarDef.Create("mood.modify_thresholds", false, CVar.SERVER);
 
         #endregion
-
         #region Lying Down System
 
         public static readonly CVarDef<bool> AutoGetUp =
@@ -2785,8 +2955,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("rest.crawlundertables", true, CVar.SERVER | CVar.ARCHIVE);
 
         #endregion
-
         #region Material Reclaimer
+        /*
+         * Material System
+         */
 
         /// <summary>
         ///     Whether or not a Material Reclaimer is allowed to eat people when emagged.
@@ -2795,8 +2967,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("reclaimer.allow_gibbing", true, CVar.SERVER);
 
         #endregion
-
         #region Jetpack System
+        /*
+         * Jetpack System
+         */
 
         /// <summary>
         ///     When true, Jetpacks can be enabled anywhere, even in gravity.
@@ -2811,8 +2985,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("jetpack.enable_in_no_gravity", true, CVar.REPLICATED);
 
         #endregion
-
         #region GhostRespawn
+        /*
+         * GhostRespawn
+         */
 
         public static readonly CVarDef<double> GhostRespawnTime =
             CVarDef.Create("ghost.respawn_time", 15d, CVar.SERVERONLY);
@@ -2824,19 +3000,16 @@ namespace Content.Shared.CCVar
             CVarDef.Create("ghost.allow_same_character", false, CVar.SERVERONLY);
 
         #endregion
-
         #region Surgery
+        /*
+         * Surgery
+         */
 
         public static readonly CVarDef<bool> CanOperateOnSelf =
             CVarDef.Create("surgery.can_operate_on_self", false, CVar.SERVERONLY);
 
         #endregion
-        /// <summary>
-        /// Set to true to disable parallel processing in the pow3r solver.
-        /// </summary>
-        public static readonly CVarDef<bool> DebugPow3rDisableParallel =
-            CVarDef.Create("debug.pow3r_disable_parallel", true, CVar.SERVERONLY);
-
+        #region AUTOVOTE SYSTEM
         /*
         * AUTOVOTE SYSTEM
         */
@@ -2855,7 +3028,11 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> PresetAutoVoteEnabled =
             CVarDef.Create("vote.preset_autovote_enabled", true, CVar.SERVERONLY);
 
+        #endregion
         #region Psionics
+        /*
+         * Psionics
+         */
 
         /// <summary>
         ///     When mindbroken, permanently eject the player from their own body, and turn their character into an NPC.
@@ -2865,16 +3042,10 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ScarierMindbreaking =
             CVarDef.Create("psionics.scarier_mindbreaking", false, CVar.SERVERONLY);
         #endregion
-
-        /// <summary>
-        /// Set to true to enable the dynamic hostname system.
-        /// Automatically updates the hostname to include current map and preset.
-        /// Configure what that looks like for you in Resources/Prototypes/Locale/en-US/dynamichostname/hostname.ftl
-        /// </summary>
-        public static readonly CVarDef<bool> UseDynamicHostname =
-            CVarDef.Create("game.use_dynamic_hostname", false, CVar.SERVERONLY);
-
         #region SoftCrit
+        /*
+         * SoftCrit
+         */
 
         /// <summary>
         ///     Used for basic Soft-Crit implementation. Entities are allowed to crawl when in crit, as this CVar intercepts the mover controller check for incapacitation,

--- a/Content.Shared/Physics/FrictionRemoverSystem.cs
+++ b/Content.Shared/Physics/FrictionRemoverSystem.cs
@@ -24,8 +24,11 @@ public sealed class FrictionRemoverSystem : EntitySystem
         var angular = 0f;
         if (TryComp<PassiveDampeningComponent>(uid, out var dampening) && dampening.Enabled)
         {
-            linear = dampening.LinearDampening;
-            angular = dampening.AngularDampening;
+            // use passive, that said, if its already set, it may have been updated by shuttle console.
+            // don't overwrite shuttle console just because you start moving or stop
+            // because for some reason when you go from stopped to moving, or moving to stopped this method is called
+            linear = component.LinearDamping != 0 ? component.LinearDamping : dampening.LinearDampening;
+            angular = component.AngularDamping != 0 ? component.AngularDamping: dampening.AngularDampening;
         }
 
         _physics.SetAngularDamping(uid, component, angular, false);

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -1,6 +1,6 @@
+using Content.Shared._NF.Shuttles.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
-using Content.Shared._NF.Shuttles.Events; // Frontier - InertiaDampeningMode access
 
 namespace Content.Shared.Shuttles.BUIStates;
 

--- a/Content.Shared/_NF/Shuttles/Events/SetInertiaDampeningRequest.cs
+++ b/Content.Shared/_NF/Shuttles/Events/SetInertiaDampeningRequest.cs
@@ -1,12 +1,12 @@
-// New Frontiers - This file is licensed under AGPLv3
-// Copyright (c) 2024 New Frontiers Contributors
+// NeuPanda - This file is licensed under AGPLv3
+// Copyright (c) 2025 NeuPanda
 // See AGPLv3.txt for details.
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._NF.Shuttles.Events
 {
     /// <summary>
-    /// Raised on the client when it wishes to change the inertial dampening of a ship.
+    /// Raised on the client when it wishes to not have 2 docking ports docked.
     /// </summary>
     [Serializable, NetSerializable]
     public sealed class SetInertiaDampeningRequest : BoundUserInterfaceMessage
@@ -16,12 +16,10 @@ namespace Content.Shared._NF.Shuttles.Events
     }
 
     [Serializable, NetSerializable]
-    public enum InertiaDampeningMode : byte
+    public enum InertiaDampeningMode
     {
         Off = 0,
-        Dampen = 1,
-        Anchor = 2,
-        Station = 3, // Reserved for station status, should not be used in requests.
-        Query = 255 // Reserved for requests - does not set the mode, only returns its state.
+        Dampened = 1,
+        Anchored = 2
     }
 }

--- a/Resources/Locale/en-US/_NF/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_NF/shuttles/console.ftl
@@ -1,3 +1,3 @@
-shuttle-console-inertia-dampener-off = Cruise
-shuttle-console-inertia-dampener-dampen = Drive
-shuttle-console-inertia-dampener-anchor = Park
+shuttle-console-inertia-dampener-off = Off
+shuttle-console-inertia-dampener-dampened = Dampened
+shuttle-console-inertia-dampener-anchored = Anchored

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -61,8 +61,8 @@ entities:
       fixedRotation: False
       bodyType: Dynamic
     - type: PassiveDampening # To prevent cargotechs from flingling it away.
-      linearDampening: 0.01
-      angularDampening: 0.01
+      linearDampening: 0.05
+      angularDampening: 0.05
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree


### PR DESCRIPTION
porting over my cruise control code from frontier with some minor bug fixes.  also had to fuck with the passive dampening system because the notsorobust toolbox has hurt its self in confusion

Description.

redid the port from frontier removing unnecessary complicated and confusing content.
replaced hard coded values with cvars
patched issues with the passive dampener system causing dampener states to reset
added regions to cvar file to make it easier to look threw
reverted text so that its more ship based, your not driving a car
this is my original work so re-licensed my work under my name rather than frontier blanket who is licensed to use edit agpl3


:cl:
- tweak: tweaked friction remover system
- fix: fixed inertia dampening system resetting or effecting the wrong grid
- remove: Removed overcomplicated alterations
