### PR TITLE
Hiding and Clearing Department Prototype Code (#28114)

### DIFF
--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -147,7 +147,7 @@ public sealed partial class BanPanel : DefaultWindow
         var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
         foreach (var proto in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
         {
-            CreateRoleGroup(proto.ID, proto.Roles, proto.Color);
+            CreateRoleGroup(proto.ID, proto.Roles.Select(p =>  p.Id), proto.Color);
         }
 
         CreateRoleGroup("Antagonist", prototypeManager.EnumeratePrototypes<AntagPrototype>().Select(p => p.ID), Color.Red);

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -707,8 +707,17 @@ namespace Content.Client.Lobby.UI
             _jobPriorities.Clear();
             var firstCategory = true;
 
-            var departments = _prototypeManager.EnumeratePrototypes<DepartmentPrototype>().ToArray();
-            Array.Sort(departments, DepartmentUIComparer.Instance);
+            // Get all displayed departments
+            var departments = new List<DepartmentPrototype>();
+            foreach (var department in _prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
+            {
+                if (department.EditorHidden)
+                    continue;
+
+                departments.Add(department);
+            }
+
+            departments.Sort(DepartmentUIComparer.Instance);
 
             var items = new[]
             {
@@ -886,7 +895,7 @@ namespace Content.Client.Lobby.UI
                     JobList.AddChild(category);
                 }
 
-                var jobs = department.Roles.Select(jobId => _prototypeManager.Index<JobPrototype>(jobId))
+                var jobs = department.Roles.Select(jobId => _prototypeManager.Index(jobId))
                     .Where(job => job.SetPreference)
                     .ToArray();
                 Array.Sort(jobs, JobUIComparer.Instance);

--- a/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
@@ -43,7 +43,7 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
         {
             foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
             {
-                if (department.Roles.Contains(job.Prototype) && Blacklist.Contains(department.ID))
+                if (department.Roles.Contains(job.Prototype.Value) && Blacklist.Contains(department.ID))
                     return false;
             }
         }
@@ -56,7 +56,7 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
             {
                 foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
                 {
-                    if (department.Roles.Contains(job.Prototype) && Whitelist.Contains(department.ID))
+                    if (department.Roles.Contains(job.Prototype.Value) && Whitelist.Contains(department.ID))
                     {
                         found = true;
                         break;

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -1,28 +1,27 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Roles;
 
 [Prototype("department")]
 public sealed partial class DepartmentPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField]
+    public string ID { get; } = string.Empty;
 
     /// <summary>
-    ///     A description string to display in the character menu as an explanation of the department's function.
+    /// A description string to display in the character menu as an explanation of the department's function.
     /// </summary>
-    [DataField("description", required: true)]
-    public string Description = default!;
+    [DataField(required: true)]
+    public string Description = string.Empty;
 
     /// <summary>
-    ///     A color representing this department to use for text.
+    /// A color representing this department to use for text.
     /// </summary>
-    [DataField("color", required: true)]
-    public Color Color = default!;
+    [DataField(required: true)]
+    public Color Color;
 
-    [ViewVariables(VVAccess.ReadWrite),
-     DataField("roles", customTypeSerializer: typeof(PrototypeIdListSerializer<JobPrototype>))]
-    public List<string> Roles = new();
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public List<ProtoId<JobPrototype>> Roles = new();
 
     /// <summary>
     /// Whether this is a primary department or not.
@@ -34,8 +33,14 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// <summary>
     /// Departments with a higher weight sorted before other departments in UI.
     /// </summary>
-    [DataField("weight")]
-    public int Weight { get; private set; } = 0;
+    [DataField]
+    public int Weight { get; private set; }
+
+    /// <summary>
+    /// Toggles the display of the department in the priority setting menu in the character editor.
+    /// </summary>
+    [DataField]
+    public bool EditorHidden;
 }
 
 /// <summary>
@@ -50,14 +55,14 @@ public sealed class DepartmentUIComparer : IComparer<DepartmentPrototype>
     {
         if (ReferenceEquals(x, y))
             return 0;
+
         if (ReferenceEquals(null, y))
             return 1;
+
         if (ReferenceEquals(null, x))
             return -1;
 
         var cmp = -x.Weight.CompareTo(y.Weight);
-        if (cmp != 0)
-            return cmp;
-        return string.Compare(x.ID, y.ID, StringComparison.Ordinal);
+        return cmp != 0 ? cmp : string.Compare(x.ID, y.ID, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
(cherry picked from commit 07dfefc4a29927aa74cfd5c7e75c6cb344d713f6)

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Allows hiding of departments by a bool. Tested on Nuclear14 as working. Pertinent code is around line 710 of humanoidprofileeditor.xaml.cs. This was the only file to conflict and the conflicts were overwritten with our code.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

