### PR TITLE
Radstation AI

### DIFF
--- a/Resources/Maps/radstation.yml
+++ b/Resources/Maps/radstation.yml
@@ -304,15 +304,15 @@ entities:
           version: 6
         -1,4:
           ind: -1,4
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAADcQAAAAAADwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAABGwAAAAABGwAAAAACAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAAAGwAAAAADGwAAAAADcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAACDwAAAAAAcQAAAAAADwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAGwAAAAAAGwAAAAABGwAAAAABDwAAAAAAcQAAAAAASAAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAADGwAAAAABGwAAAAAADwAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAADwAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAADGwAAAAADcQAAAAAADwAAAAAAcQAAAAAASAAAAAAASAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAACDwAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAACGwAAAAAADwAAAAAAcQAAAAAAcAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAADcQAAAAAADwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAABGwAAAAABGwAAAAACAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAAAGwAAAAADGwAAAAADcQAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAACDwAAAAAAcQAAAAAADwAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAGwAAAAAAGwAAAAABGwAAAAABDwAAAAAAcQAAAAAASAAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAADGwAAAAABGwAAAAAADwAAAAAAcQAAAAAADwAAAAAADwAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAADwAAAAAAcQAAAAAADwAAAAAADwAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAADGwAAAAADcQAAAAAADwAAAAAAcQAAAAAASAAAAAAASAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAACDwAAAAAAcQAAAAAADwAAAAAADwAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAACGwAAAAAADwAAAAAAcQAAAAAADwAAAAAADwAAAAAA
           version: 6
         0,4:
           ind: 0,4
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAADcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAABDwAAAAAAGwAAAAADGwAAAAADGwAAAAABGwAAAAACGwAAAAAAGwAAAAABGwAAAAADcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAADDwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAGwAAAAAAGwAAAAABGwAAAAABGwAAAAABGwAAAAABcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAGwAAAAADGwAAAAABGwAAAAAAGwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAASAAAAAAASAAAAAAASAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAASAAAAAAASAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAADcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAABDwAAAAAAGwAAAAADGwAAAAADGwAAAAABGwAAAAACGwAAAAAAGwAAAAABGwAAAAADcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGwAAAAADDwAAAAAAGwAAAAAAGwAAAAAAcQAAAAAAGwAAAAAAGwAAAAABGwAAAAABGwAAAAABGwAAAAABcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAGwAAAAADGwAAAAABGwAAAAAAGwAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAADwAAAAAASAAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAASAAAAAAASAAAAAAASAAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAASAAAAAAASAAAAAAASAAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAADwAAAAAASAAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
           version: 6
         0,5:
           ind: 0,5
-          tiles: cAAAAAAASAAAAAAAcAAAAAAAcQAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAASAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAAAGwAAAAACGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAADGwAAAAAAGwAAAAABGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: DwAAAAAASAAAAAAADwAAAAAAcQAAAAAASAAAAAAAcQAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcQAAAAAASAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAAAGwAAAAACGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAGwAAAAADGwAAAAAAGwAAAAABGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,5:
           ind: -1,5
@@ -422,81 +422,81 @@ entities:
             color: '#EFB34196'
             id: 1
           decals:
-            4101: -9,24
+            4092: -9,24
         - node:
             color: '#EFB341FF'
             id: 1
           decals:
-            1353: -46,-27
-            5399: 44,-34
+            1352: -46,-27
+            5390: 44,-34
         - node:
             color: '#EFB34196'
             id: 2
           decals:
-            4102: -9,23
+            4093: -9,23
         - node:
             color: '#EFB341FF'
             id: 2
           decals:
-            1388: -39,-33
-            5400: 45,-34
+            1379: -39,-33
+            5391: 45,-34
         - node:
             color: '#EFB34196'
             id: 3
           decals:
-            4103: -9,22
-            7217: -21,-46
+            4094: -9,22
+            7208: -21,-46
         - node:
             color: '#EFB341FF'
             id: 3
           decals:
-            5401: 46,-34
+            5392: 46,-34
         - node:
             color: '#EFB341FF'
             id: 4
           decals:
-            5402: 47,-34
+            5393: 47,-34
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7534: -5,-69
-            7535: -6,-69
-            7546: 2,-63
-            7547: 3,-63
+            7525: -5,-69
+            7526: -6,-69
+            7537: 2,-63
+            7538: 3,-63
         - node:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7537: -5,-72
-            7538: -5,-73
-            7545: 1,-63
+            7528: -5,-72
+            7529: -5,-73
+            7536: 1,-63
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7536: -6,-71
-            7544: 8,-75
+            7527: -6,-71
+            7535: 8,-75
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            5036: 1,52
-            5037: 0,52
-            7539: 5,-73
-            7540: 5,-72
-            7541: 5,-71
-            7542: 5,-70
-            7543: 5,-69
+            5027: 1,52
+            5028: 0,52
+            7530: 5,-73
+            7531: 5,-72
+            7532: 5,-71
+            7533: 5,-70
+            7534: 5,-69
         - node:
             color: '#FFFFFFFF'
             id: Basalt1
           decals:
             347: -5,-2
-            6062: 3,47
+            6053: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Basalt2
@@ -504,9 +504,9 @@ entities:
             346: -7,-3
             360: 6,-2
             362: 6,-4
-            3696: 35,-8
-            3697: 40,-8
-            3702: 32,-4
+            3687: 35,-8
+            3688: 40,-8
+            3693: 32,-4
         - node:
             color: '#FFFFFFFF'
             id: Basalt3
@@ -516,15 +516,15 @@ entities:
             374: -6,3
             375: -5,6
             376: -3,7
-            3701: 32,-4
-            6052: 14,-27
+            3692: 32,-4
+            6043: 14,-27
         - node:
             color: '#FFFFFFFF'
             id: Basalt4
           decals:
             359: 5,-6
-            3695: 37,-8
-            6060: 3,48
+            3686: 37,-8
+            6051: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Basalt5
@@ -537,10 +537,10 @@ entities:
             381: 6,4
             382: 4,7
             383: 4,8
-            3693: 41,-9
-            3694: 34,-10
-            6053: 14,-26
-            6061: 3,49
+            3684: 41,-9
+            3685: 34,-10
+            6044: 14,-26
+            6052: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Basalt6
@@ -564,15 +564,15 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            3148: 32,14
-            3149: 32,13
-            3150: 37,13
-            3151: 38,13
-            3152: 38,19
-            3153: 36,19
-            3154: 35,19
-            3155: 34,19
-            3156: 34,20
+            3139: 32,14
+            3140: 32,13
+            3141: 37,13
+            3142: 38,13
+            3143: 38,19
+            3144: 36,19
+            3145: 35,19
+            3146: 34,19
+            3147: 34,20
         - node:
             color: '#FFFFFFFF'
             id: Bot
@@ -647,556 +647,556 @@ entities:
             1292: -37,-16
             1293: -37,-17
             1294: -37,-18
-            1418: -29,-21
-            1433: -37,-29
-            1434: -37,-27
-            1539: -31,-36
-            1540: -28,-36
-            1541: -28,-35
-            1542: -36,-39
-            1543: -36,-40
-            1554: -31,-40
-            1555: -31,-39
-            1556: -31,-38
-            1566: -31,-42
-            1567: -30,-42
-            1568: -29,-42
-            1569: -28,-42
-            1649: -26,-34
-            1673: -24,-22
-            1674: -24,-24
-            1675: -22,-24
-            1676: -22,-22
-            1677: -25,-25
-            1678: -21,-19
-            1806: -21,-31
-            1807: -21,-32
-            1808: -21,-34
-            1809: -23,-34
-            1810: -23,-33
-            1876: -9,-33
-            1877: -9,-32
-            1878: -9,-31
-            1879: -3,-34
-            1880: -4,-34
-            1881: -3,-31
-            1882: -4,-31
-            1883: -5,-31
-            1980: -14,-50
-            1981: -14,-47
-            1982: -14,-44
-            1983: -14,-41
-            1984: -14,-38
-            1985: -13,-35
-            1986: -12,-50
-            2090: -9,-22
-            2091: -37,-42
-            2122: -42,-39
-            2260: -35,-46
-            2261: -33,-46
-            2262: -32,-46
-            2263: -40,-53
-            2264: -40,-52
-            2670: -36,6
-            2671: -33,8
-            2767: 28,-5
-            2768: 27,-5
-            2769: 27,-5
-            2770: 28,-3
-            2771: 30,-3
-            3025: 21,12
-            3026: 32,11
-            3027: 15,16
-            3028: 19,17
-            3029: 19,18
-            3030: 21,19
-            3031: 23,19
-            3032: 24,19
-            3033: 24,17
-            3034: 21,21
-            3035: 24,23
-            3036: 25,23
-            3037: 26,23
-            3038: 26,21
-            3039: 25,21
-            3040: 22,23
-            3188: 40,17
-            3189: 41,17
-            3190: 42,17
-            3191: 43,17
-            3215: 43,9
-            3230: 37,24
-            3231: 36,24
-            3232: 36,22
-            3233: 36,21
-            3661: 27,29
-            3662: 27,33
-            3663: 30,39
-            3664: 31,30
-            3665: 32,30
-            3666: 33,30
-            3667: 35,30
-            3668: 36,30
-            3669: 37,30
-            3670: 39,30
-            3671: 31,26
-            3672: 32,26
-            3673: 33,26
-            3674: 35,26
-            3675: 36,26
-            3676: 37,26
-            3677: 42,39
-            3678: 42,43
-            3679: 42,44
-            3680: 42,45
-            3844: 32,-13
-            3845: 33,-13
-            3846: 34,-13
-            3847: 35,-13
-            3848: 39,-13
-            3849: 40,-13
-            3850: 41,-13
-            3851: 42,-13
-            3852: 43,-13
-            3853: 44,-12
-            3854: 41,-4
-            3855: 42,-4
-            3856: 43,-4
-            3857: 44,-5
-            3908: 46,-17
-            3909: 45,-17
-            3910: 45,-19
-            3911: 46,-19
-            4072: -3,18
-            4096: -13,24
-            4097: -10,24
-            4098: -10,23
-            4099: -10,22
-            4100: -4,24
-            4254: -12,34
-            4255: -11,34
-            4256: -11,35
-            4257: -12,35
-            4258: -12,36
-            4259: -9,34
-            4260: -8,34
-            4261: -8,32
-            4262: -10,31
-            4263: -11,31
-            4264: -12,31
-            4290: -17,31
-            4291: -18,31
-            4292: -18,33
-            4293: -18,34
-            4294: -18,35
-            4295: -18,36
-            4296: -15,36
-            4297: -15,33
-            4300: -17,40
-            4301: -16,40
-            4302: -15,40
-            4303: -14,40
-            4304: -13,40
-            4305: -14,38
-            4306: -15,38
-            4307: -16,38
-            4327: -21,31
-            4328: -21,33
-            4329: -21,34
-            4330: -21,35
-            4331: -21,36
-            4350: -21,40
-            4351: -21,39
-            4352: -21,38
-            4353: -27,40
-            4354: -27,39
-            4355: -27,38
-            4371: -27,36
-            4372: -28,36
-            4373: -29,38
-            4405: -43,28
-            4406: -42,28
-            4407: -41,28
-            4408: -40,28
-            4409: -41,30
-            4410: -42,30
-            4411: -43,30
-            4412: -37,39
-            4463: -36,19
-            4464: -36,20
-            4465: -36,21
-            4466: -36,22
-            4558: -27,30
-            4590: -3,40
-            4594: -3,28
-            4595: -6,30
-            4596: -7,30
-            4647: 7,30
-            4648: 8,31
-            4649: 7,32
-            4650: 6,31
-            4791: 13,50
-            4792: 13,49
-            4793: 8,56
-            4794: 7,56
-            4795: 4,56
-            4796: 4,55
-            4835: 4,46
-            4836: 4,48
-            4837: 4,49
-            4838: 4,50
-            5007: -3,58
-            5008: -6,58
-            5009: -6,59
-            5010: -6,60
-            5011: 7,58
-            5012: 7,59
-            5013: 7,60
-            5014: 3,61
-            5015: 3,60
-            5016: -2,61
-            5017: -2,60
-            5018: -3,61
-            5019: 4,61
-            5020: 1,62
-            5021: -1,62
-            5022: 0,62
-            5023: 2,62
-            5135: 6,69
-            5136: -5,69
-            5137: -5,61
-            5138: 6,61
-            5187: 12,-15
-            5188: 12,-16
-            5189: 12,-17
-            5190: 15,-14
-            5191: 17,-14
-            5199: 20,-19
-            5200: 20,-20
-            5201: 20,-21
-            5202: 17,-21
-            5250: 26,-22
-            5251: 26,-21
-            5252: 22,-20
-            5253: 25,-18
-            5254: 26,-18
-            5337: 34,-22
-            5382: 38,-33
-            5383: 42,-33
-            5384: 42,-35
-            5385: 41,-31
-            5386: 41,-28
-            5391: 39,-27
-            5469: 28,-28
-            5470: 28,-29
-            5471: 28,-30
-            5472: 25,-31
-            5473: 25,-30
-            5474: 25,-28
-            5475: 30,-28
-            5476: 31,-28
-            5477: 32,-28
-            5478: 32,-32
-            5479: 30,-30
-            5500: 10,-33
-            5501: 8,-33
-            5502: 7,-33
-            5503: 9,-33
-            5504: 10,-30
-            5505: 9,-30
-            5506: 8,-30
-            5507: 4,-30
-            5508: 4,-31
-            5509: 4,-32
-            5593: 10,-28
-            5903: 11,-31
-            5907: 41,-21
-            5908: 40,-21
-            5909: 39,-21
-            5910: 15,-23
-            5911: 16,-23
-            5912: 20,-23
-            5913: 21,-23
-            5914: 22,-23
-            5915: 23,-23
-            6186: -2,-45
-            6187: 8,-46
-            6231: 2,-49
-            6232: 3,-49
-            6233: 4,-49
-            6315: 4,-57
-            6316: 4,-58
-            6317: 4,-59
-            6318: 4,-60
-            6319: 4,-61
-            6320: 2,-57
-            6321: 2,-56
-            6322: 2,-55
-            6449: -16,-62
-            6450: -19,-60
-            6524: 4,25
-            6532: 11,-66
-            6533: 12,-66
-            6534: 13,-66
-            6550: 10,-63
-            6581: -4,-67
-            6582: -3,-67
-            6583: 3,-67
-            6584: 4,-67
-            6585: 0,-70
-            6586: -5,-63
-            6587: -4,-65
-            6588: 5,-65
-            6589: 3,-75
-            6590: 3,-76
-            6591: -8,-71
-            6592: -8,-69
-            6593: -5,-71
-            6707: 7,-77
-            6708: -7,-77
-            6841: 16,-50
-            6842: 16,-51
-            6843: 16,-52
-            6844: 17,-52
-            6845: 17,-51
-            6846: 17,-50
-            6847: 18,-50
-            6848: 18,-51
-            6849: 18,-52
-            6850: 19,-52
-            6851: 19,-51
-            6852: 19,-50
-            6884: 28,-60
-            6885: 27,-60
-            6886: 27,-59
-            6887: 27,-58
-            6888: 28,-58
-            6889: 30,-58
-            6890: 30,-59
-            6891: 30,-60
-            7023: 22,-49
-            7024: 21,-49
-            7025: 20,-49
-            7045: 35,-52
-            7046: 36,-52
-            7047: 37,-52
-            7048: 38,-52
-            7049: 38,-51
-            7050: 38,-50
-            7051: 38,-49
-            7052: 36,-49
-            7053: 37,-49
-            7054: 35,-49
-            7055: 35,-50
-            7056: 35,-51
-            7057: 36,-51
-            7058: 37,-51
-            7059: 37,-50
-            7060: 36,-50
-            7061: 34,-42
-            7062: 35,-42
-            7063: 37,-43
-            7064: 38,-43
-            7065: 38,-45
-            7069: 34,-44
-            7092: 22,-40
-            7093: 26,-40
-            7094: 27,-40
-            7095: 28,-40
-            7129: 14,-44
-            7130: 14,-46
-            7170: 10,-49
-            7171: 11,-49
-            7172: 12,-49
-            7173: 13,-49
-            7174: 14,-49
-            7313: 15,23
-            7314: 15,22
-            7315: 24,-59
-            7342: 8,-55
-            7343: 41,-15
-            7470: -7,-59
-            7471: -7,-58
-            7472: -7,-57
-            7473: -6,-57
-            7474: -6,-58
-            7475: -6,-59
-            7476: -5,-59
-            7477: -5,-58
-            7478: -5,-57
-            7479: -4,-57
-            7480: -4,-58
-            7481: -4,-59
-            7482: -3,-59
-            7483: -3,-58
-            7484: -3,-57
-            7485: -2,-57
-            7486: -2,-58
-            7487: -2,-59
-            7488: -1,-59
-            7489: -1,-58
-            7490: -1,-57
-            7549: 6,56
+            1409: -29,-21
+            1424: -37,-29
+            1425: -37,-27
+            1530: -31,-36
+            1531: -28,-36
+            1532: -28,-35
+            1533: -36,-39
+            1534: -36,-40
+            1545: -31,-40
+            1546: -31,-39
+            1547: -31,-38
+            1557: -31,-42
+            1558: -30,-42
+            1559: -29,-42
+            1560: -28,-42
+            1640: -26,-34
+            1664: -24,-22
+            1665: -24,-24
+            1666: -22,-24
+            1667: -22,-22
+            1668: -25,-25
+            1669: -21,-19
+            1797: -21,-31
+            1798: -21,-32
+            1799: -21,-34
+            1800: -23,-34
+            1801: -23,-33
+            1867: -9,-33
+            1868: -9,-32
+            1869: -9,-31
+            1870: -3,-34
+            1871: -4,-34
+            1872: -3,-31
+            1873: -4,-31
+            1874: -5,-31
+            1971: -14,-50
+            1972: -14,-47
+            1973: -14,-44
+            1974: -14,-41
+            1975: -14,-38
+            1976: -13,-35
+            1977: -12,-50
+            2081: -9,-22
+            2082: -37,-42
+            2113: -42,-39
+            2251: -35,-46
+            2252: -33,-46
+            2253: -32,-46
+            2254: -40,-53
+            2255: -40,-52
+            2661: -36,6
+            2662: -33,8
+            2758: 28,-5
+            2759: 27,-5
+            2760: 27,-5
+            2761: 28,-3
+            2762: 30,-3
+            3016: 21,12
+            3017: 32,11
+            3018: 15,16
+            3019: 19,17
+            3020: 19,18
+            3021: 21,19
+            3022: 23,19
+            3023: 24,19
+            3024: 24,17
+            3025: 21,21
+            3026: 24,23
+            3027: 25,23
+            3028: 26,23
+            3029: 26,21
+            3030: 25,21
+            3031: 22,23
+            3179: 40,17
+            3180: 41,17
+            3181: 42,17
+            3182: 43,17
+            3206: 43,9
+            3221: 37,24
+            3222: 36,24
+            3223: 36,22
+            3224: 36,21
+            3652: 27,29
+            3653: 27,33
+            3654: 30,39
+            3655: 31,30
+            3656: 32,30
+            3657: 33,30
+            3658: 35,30
+            3659: 36,30
+            3660: 37,30
+            3661: 39,30
+            3662: 31,26
+            3663: 32,26
+            3664: 33,26
+            3665: 35,26
+            3666: 36,26
+            3667: 37,26
+            3668: 42,39
+            3669: 42,43
+            3670: 42,44
+            3671: 42,45
+            3835: 32,-13
+            3836: 33,-13
+            3837: 34,-13
+            3838: 35,-13
+            3839: 39,-13
+            3840: 40,-13
+            3841: 41,-13
+            3842: 42,-13
+            3843: 43,-13
+            3844: 44,-12
+            3845: 41,-4
+            3846: 42,-4
+            3847: 43,-4
+            3848: 44,-5
+            3899: 46,-17
+            3900: 45,-17
+            3901: 45,-19
+            3902: 46,-19
+            4063: -3,18
+            4087: -13,24
+            4088: -10,24
+            4089: -10,23
+            4090: -10,22
+            4091: -4,24
+            4245: -12,34
+            4246: -11,34
+            4247: -11,35
+            4248: -12,35
+            4249: -12,36
+            4250: -9,34
+            4251: -8,34
+            4252: -8,32
+            4253: -10,31
+            4254: -11,31
+            4255: -12,31
+            4281: -17,31
+            4282: -18,31
+            4283: -18,33
+            4284: -18,34
+            4285: -18,35
+            4286: -18,36
+            4287: -15,36
+            4288: -15,33
+            4291: -17,40
+            4292: -16,40
+            4293: -15,40
+            4294: -14,40
+            4295: -13,40
+            4296: -14,38
+            4297: -15,38
+            4298: -16,38
+            4318: -21,31
+            4319: -21,33
+            4320: -21,34
+            4321: -21,35
+            4322: -21,36
+            4341: -21,40
+            4342: -21,39
+            4343: -21,38
+            4344: -27,40
+            4345: -27,39
+            4346: -27,38
+            4362: -27,36
+            4363: -28,36
+            4364: -29,38
+            4396: -43,28
+            4397: -42,28
+            4398: -41,28
+            4399: -40,28
+            4400: -41,30
+            4401: -42,30
+            4402: -43,30
+            4403: -37,39
+            4454: -36,19
+            4455: -36,20
+            4456: -36,21
+            4457: -36,22
+            4549: -27,30
+            4581: -3,40
+            4585: -3,28
+            4586: -6,30
+            4587: -7,30
+            4638: 7,30
+            4639: 8,31
+            4640: 7,32
+            4641: 6,31
+            4782: 13,50
+            4783: 13,49
+            4784: 8,56
+            4785: 7,56
+            4786: 4,56
+            4787: 4,55
+            4826: 4,46
+            4827: 4,48
+            4828: 4,49
+            4829: 4,50
+            4998: -3,58
+            4999: -6,58
+            5000: -6,59
+            5001: -6,60
+            5002: 7,58
+            5003: 7,59
+            5004: 7,60
+            5005: 3,61
+            5006: 3,60
+            5007: -2,61
+            5008: -2,60
+            5009: -3,61
+            5010: 4,61
+            5011: 1,62
+            5012: -1,62
+            5013: 0,62
+            5014: 2,62
+            5126: 6,69
+            5127: -5,69
+            5128: -5,61
+            5129: 6,61
+            5178: 12,-15
+            5179: 12,-16
+            5180: 12,-17
+            5181: 15,-14
+            5182: 17,-14
+            5190: 20,-19
+            5191: 20,-20
+            5192: 20,-21
+            5193: 17,-21
+            5241: 26,-22
+            5242: 26,-21
+            5243: 22,-20
+            5244: 25,-18
+            5245: 26,-18
+            5328: 34,-22
+            5373: 38,-33
+            5374: 42,-33
+            5375: 42,-35
+            5376: 41,-31
+            5377: 41,-28
+            5382: 39,-27
+            5460: 28,-28
+            5461: 28,-29
+            5462: 28,-30
+            5463: 25,-31
+            5464: 25,-30
+            5465: 25,-28
+            5466: 30,-28
+            5467: 31,-28
+            5468: 32,-28
+            5469: 32,-32
+            5470: 30,-30
+            5491: 10,-33
+            5492: 8,-33
+            5493: 7,-33
+            5494: 9,-33
+            5495: 10,-30
+            5496: 9,-30
+            5497: 8,-30
+            5498: 4,-30
+            5499: 4,-31
+            5500: 4,-32
+            5584: 10,-28
+            5894: 11,-31
+            5898: 41,-21
+            5899: 40,-21
+            5900: 39,-21
+            5901: 15,-23
+            5902: 16,-23
+            5903: 20,-23
+            5904: 21,-23
+            5905: 22,-23
+            5906: 23,-23
+            6177: -2,-45
+            6178: 8,-46
+            6222: 2,-49
+            6223: 3,-49
+            6224: 4,-49
+            6306: 4,-57
+            6307: 4,-58
+            6308: 4,-59
+            6309: 4,-60
+            6310: 4,-61
+            6311: 2,-57
+            6312: 2,-56
+            6313: 2,-55
+            6440: -16,-62
+            6441: -19,-60
+            6515: 4,25
+            6523: 11,-66
+            6524: 12,-66
+            6525: 13,-66
+            6541: 10,-63
+            6572: -4,-67
+            6573: -3,-67
+            6574: 3,-67
+            6575: 4,-67
+            6576: 0,-70
+            6577: -5,-63
+            6578: -4,-65
+            6579: 5,-65
+            6580: 3,-75
+            6581: 3,-76
+            6582: -8,-71
+            6583: -8,-69
+            6584: -5,-71
+            6698: 7,-77
+            6699: -7,-77
+            6832: 16,-50
+            6833: 16,-51
+            6834: 16,-52
+            6835: 17,-52
+            6836: 17,-51
+            6837: 17,-50
+            6838: 18,-50
+            6839: 18,-51
+            6840: 18,-52
+            6841: 19,-52
+            6842: 19,-51
+            6843: 19,-50
+            6875: 28,-60
+            6876: 27,-60
+            6877: 27,-59
+            6878: 27,-58
+            6879: 28,-58
+            6880: 30,-58
+            6881: 30,-59
+            6882: 30,-60
+            7014: 22,-49
+            7015: 21,-49
+            7016: 20,-49
+            7036: 35,-52
+            7037: 36,-52
+            7038: 37,-52
+            7039: 38,-52
+            7040: 38,-51
+            7041: 38,-50
+            7042: 38,-49
+            7043: 36,-49
+            7044: 37,-49
+            7045: 35,-49
+            7046: 35,-50
+            7047: 35,-51
+            7048: 36,-51
+            7049: 37,-51
+            7050: 37,-50
+            7051: 36,-50
+            7052: 34,-42
+            7053: 35,-42
+            7054: 37,-43
+            7055: 38,-43
+            7056: 38,-45
+            7060: 34,-44
+            7083: 22,-40
+            7084: 26,-40
+            7085: 27,-40
+            7086: 28,-40
+            7120: 14,-44
+            7121: 14,-46
+            7161: 10,-49
+            7162: 11,-49
+            7163: 12,-49
+            7164: 13,-49
+            7165: 14,-49
+            7304: 15,23
+            7305: 15,22
+            7306: 24,-59
+            7333: 8,-55
+            7334: 41,-15
+            7461: -7,-59
+            7462: -7,-58
+            7463: -7,-57
+            7464: -6,-57
+            7465: -6,-58
+            7466: -6,-59
+            7467: -5,-59
+            7468: -5,-58
+            7469: -5,-57
+            7470: -4,-57
+            7471: -4,-58
+            7472: -4,-59
+            7473: -3,-59
+            7474: -3,-58
+            7475: -3,-57
+            7476: -2,-57
+            7477: -2,-58
+            7478: -2,-59
+            7479: -1,-59
+            7480: -1,-58
+            7481: -1,-57
+            7540: 6,56
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            2134: -48,-30
+            2125: -48,-30
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            5145: 14,-9
-            5146: 14,-10
-            5147: 14,-11
-            5148: 17,-9
-            5149: 17,-10
-            5150: 17,-11
-            5151: 19,-9
-            5152: 19,-10
-            5153: 19,-11
+            5136: 14,-9
+            5137: 14,-10
+            5138: 14,-11
+            5139: 17,-9
+            5140: 17,-10
+            5141: 17,-11
+            5142: 19,-9
+            5143: 19,-10
+            5144: 19,-11
         - node:
             color: '#D4D4D4D9'
             id: BotGreyscale
           decals:
-            4403: -41,31
-            4404: -42,31
+            4394: -41,31
+            4395: -42,31
         - node:
             color: '#FFFFFFFF'
             id: BotLeft
           decals:
-            4643: 8,32
-            4645: 6,30
+            4634: 8,32
+            4636: 6,30
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: BotLeft
           decals:
-            4644: 6,32
-            4646: 8,30
+            4635: 6,32
+            4637: 8,30
         - node:
             color: '#DE3A3AFF'
             id: Box
           decals:
-            2279: -25,-48
+            2270: -25,-48
         - node:
             color: '#EFB34196'
             id: Box
           decals:
-            7218: -21,-46
+            7209: -21,-46
         - node:
             color: '#EFB341FF'
             id: Box
           decals:
-            1352: -46,-27
-            1387: -39,-33
+            1351: -46,-27
+            1378: -39,-33
         - node:
             color: '#FFFFFFFF'
             id: Box
           decals:
             1180: -40,-1
-            1875: -4,-33
-            5255: 30,-23
-            5256: 32,-23
-            5387: 38,-28
-            5388: 38,-29
-            5389: 38,-30
-            5390: 38,-31
-            5594: 6,-28
-            5595: 8,-22
-            5897: 32,-23
-            5898: 30,-23
+            1866: -4,-33
+            5246: 30,-23
+            5247: 32,-23
+            5378: 38,-28
+            5379: 38,-29
+            5380: 38,-30
+            5381: 38,-31
+            5585: 6,-28
+            5586: 8,-22
+            5888: 32,-23
+            5889: 30,-23
         - node:
             color: '#DE3A3AFF'
             id: BoxGreyscale
           decals:
-            4332: -21,32
+            4323: -21,32
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            4482: -31,26
-            5192: 16,-15
+            4473: -31,26
+            5183: 16,-15
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
           decals:
-            3407: 23,30
-            3417: 19,34
+            3398: 23,30
+            3408: 19,34
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNw
           decals:
-            3402: 25,30
-            3410: 21,30
-            3415: 21,36
-            3423: 17,33
+            3393: 25,30
+            3401: 21,30
+            3406: 21,36
+            3414: 17,33
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSe
           decals:
-            3408: 23,32
-            3422: 19,29
-            4761: -5,56
+            3399: 23,32
+            3413: 19,29
+            4752: -5,56
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSw
           decals:
-            3401: 25,32
-            3409: 21,32
-            3424: 17,29
-            4760: -7,56
-            6512: 6,25
+            3392: 25,32
+            3400: 21,32
+            3415: 17,29
+            4751: -7,56
+            6503: 6,25
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkEndE
           decals:
-            3416: 19,36
+            3407: 19,36
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineE
           decals:
-            3405: 23,33
-            3406: 23,29
-            3418: 19,33
-            3419: 19,32
-            3420: 19,31
-            3421: 19,30
+            3396: 23,33
+            3397: 23,29
+            3409: 19,33
+            3410: 19,32
+            3411: 19,31
+            3412: 19,30
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineN
           decals:
-            2481: -35,-65
-            2482: -36,-65
-            2483: -37,-65
-            3429: 22,30
+            2472: -35,-65
+            2473: -36,-65
+            2474: -37,-65
+            3420: 22,30
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineS
           decals:
-            3425: 18,29
-            3430: 22,32
-            4762: -6,56
-            6507: 8,25
-            6509: 7,25
+            3416: 18,29
+            3421: 22,32
+            4753: -6,56
+            6498: 8,25
+            6500: 7,25
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineW
           decals:
-            3403: 25,29
-            3404: 25,33
-            3411: 21,29
-            3412: 21,33
-            3413: 21,34
-            3414: 21,35
-            3426: 17,30
-            3427: 17,31
-            3428: 17,32
-            4759: -7,57
-            6514: 6,26
-            6515: 6,27
+            3394: 25,29
+            3395: 25,33
+            3402: 21,29
+            3403: 21,33
+            3404: 21,34
+            3405: 21,35
+            3417: 17,30
+            3418: 17,31
+            3419: 17,32
+            4750: -7,57
+            6505: 6,26
+            6506: 6,27
         - node:
             color: '#FFFFFFFF'
             id: Bushf1
@@ -1230,13 +1230,13 @@ entities:
             400: 7,3
             401: 9,3
             402: 7,4
-            3681: 34,-10
-            3682: 35,-8
-            3683: 37,-9
-            3684: 40,-9
-            3685: 41,-8
-            6048: 14,-26
-            6054: 3,49
+            3672: 34,-10
+            3673: 35,-8
+            3674: 37,-9
+            3675: 40,-9
+            3676: 41,-8
+            6039: 14,-26
+            6045: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Bushf2
@@ -1247,9 +1247,9 @@ entities:
             414: -4,6
             415: -5,7
             422: 5,5
-            3699: 32,-3
-            6049: 14,-27
-            6056: 3,47
+            3690: 32,-3
+            6040: 14,-27
+            6047: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Bushf3
@@ -1262,11 +1262,11 @@ entities:
             419: 5,7
             420: 6,7
             421: 8,4
-            3686: 41,-10
-            3687: 40,-8
-            3688: 34,-8
-            3698: 32,-4
-            6055: 3,48
+            3677: 41,-10
+            3678: 40,-8
+            3679: 34,-8
+            3689: 32,-4
+            6046: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Bushl1
@@ -1276,140 +1276,140 @@ entities:
             color: '#FFFFFFFF'
             id: Bushl2
           decals:
-            3689: 34,-9
+            3680: 34,-9
         - node:
             color: '#FFFFFFFF'
             id: Bushl4
           decals:
             410: -2,6
-            3690: 41,-9
+            3681: 41,-9
         - node:
             angle: -3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            4155: -3,26
-            4156: -3,26
-            4157: -4,26
-            4158: -6,26
-            4159: -7,26
-            4160: -9,26
-            4161: -10,26
-            4162: -12,26
-            4163: -13,26
-            4164: -13,26
-            4165: -21,26
-            4166: -21,26
-            4167: -20,26
+            4146: -3,26
+            4147: -3,26
+            4148: -4,26
+            4149: -6,26
+            4150: -7,26
+            4151: -9,26
+            4152: -10,26
+            4153: -12,26
+            4154: -13,26
+            4155: -13,26
+            4156: -21,26
+            4157: -21,26
+            4158: -20,26
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            5392: 46,-32
-            5393: 46,-32
-            5394: 46,-32
-            5395: 46,-32
-            5396: 46,-32
-            5397: 46,-32
-            7076: 38,-47
+            5383: 46,-32
+            5384: 46,-32
+            5385: 46,-32
+            5386: 46,-32
+            5387: 46,-32
+            5388: 46,-32
+            7067: 38,-47
         - node:
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            5030: 2,53
-            5031: -1,53
-            6577: 4,-71
-            6578: -4,-71
+            5021: 2,53
+            5022: -1,53
+            6568: 4,-71
+            6569: -4,-71
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            2129: -43,-44
+            2120: -43,-44
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            5032: 2,58
-            5033: -1,58
-            6579: 4,-69
-            6580: -4,-69
+            5023: 2,58
+            5024: -1,58
+            6570: 4,-69
+            6571: -4,-69
         - node:
             color: '#52B4E996'
             id: CheckerNESW
           decals:
-            3236: 37,21
-            3237: 38,21
-            3238: 38,22
-            3239: 37,22
-            3240: 37,23
-            3241: 38,23
-            3242: 36,23
-            3243: 38,24
-            5228: 25,-22
-            5229: 26,-22
-            5230: 26,-21
-            5231: 25,-21
-            5232: 24,-21
-            5233: 23,-21
-            5234: 22,-21
-            5235: 22,-20
-            5236: 23,-20
-            5237: 24,-20
-            5238: 25,-20
-            5239: 26,-20
-            5240: 26,-19
-            5241: 25,-19
-            5242: 24,-19
-            5243: 23,-19
-            5244: 22,-19
-            5245: 22,-18
-            5246: 23,-18
-            5247: 24,-18
-            5248: 25,-18
-            5249: 26,-18
+            3227: 37,21
+            3228: 38,21
+            3229: 38,22
+            3230: 37,22
+            3231: 37,23
+            3232: 38,23
+            3233: 36,23
+            3234: 38,24
+            5219: 25,-22
+            5220: 26,-22
+            5221: 26,-21
+            5222: 25,-21
+            5223: 24,-21
+            5224: 23,-21
+            5225: 22,-21
+            5226: 22,-20
+            5227: 23,-20
+            5228: 24,-20
+            5229: 25,-20
+            5230: 26,-20
+            5231: 26,-19
+            5232: 25,-19
+            5233: 24,-19
+            5234: 23,-19
+            5235: 22,-19
+            5236: 22,-18
+            5237: 23,-18
+            5238: 24,-18
+            5239: 25,-18
+            5240: 26,-18
         - node:
             color: '#6C6C6C92'
             id: CheckerNESW
           decals:
-            2484: -26,-65
-            2485: -25,-65
-            2486: -25,-64
-            2487: -24,-64
-            2488: -23,-65
-            2489: -23,-63
-            2490: -26,-63
-            2491: -27,-63
-            2492: -27,-64
+            2475: -26,-65
+            2476: -25,-65
+            2477: -25,-64
+            2478: -24,-64
+            2479: -23,-65
+            2480: -23,-63
+            2481: -26,-63
+            2482: -27,-63
+            2483: -27,-64
         - node:
             color: '#DE3A3A96'
             id: CheckerNESW
           decals:
             904: -20,12
-            2888: 15,6
-            2889: 15,7
-            2890: 15,8
-            2891: 15,9
-            2892: 15,10
-            2893: 15,11
-            2894: 16,11
-            2895: 17,11
-            2896: 18,11
-            2897: 19,11
-            2898: 20,11
-            2899: 21,11
-            2900: 21,10
-            2901: 21,9
-            2902: 22,8
-            2903: 23,8
-            2904: 24,8
-            2905: 25,8
-            2906: 26,8
-            2907: 27,9
-            2908: 27,10
-            2909: 27,11
+            2879: 15,6
+            2880: 15,7
+            2881: 15,8
+            2882: 15,9
+            2883: 15,10
+            2884: 15,11
+            2885: 16,11
+            2886: 17,11
+            2887: 18,11
+            2888: 19,11
+            2889: 20,11
+            2890: 21,11
+            2891: 21,10
+            2892: 21,9
+            2893: 22,8
+            2894: 23,8
+            2895: 24,8
+            2896: 25,8
+            2897: 26,8
+            2898: 27,9
+            2899: 27,10
+            2900: 27,11
         - node:
             color: '#EFB34196'
             id: CheckerNESW
@@ -1419,99 +1419,99 @@ entities:
             color: '#52B4E996'
             id: CheckerNWSE
           decals:
-            2813: 26,-14
+            2804: 26,-14
         - node:
             color: '#6C6C6C93'
             id: CheckerNWSE
           decals:
-            2940: 23,10
-            2941: 24,10
-            2942: 25,10
-            2943: 25,11
-            2944: 24,11
-            2945: 23,11
-            2946: 23,12
-            2947: 24,12
-            2948: 25,12
-            2949: 22,13
-            2950: 22,14
-            2951: 23,14
-            2952: 23,13
-            2953: 24,13
-            2954: 24,14
-            2955: 25,13
-            2956: 26,13
-            2957: 26,14
-            2958: 25,14
-            2959: 27,14
-            2960: 26,15
-            2961: 25,15
-            2962: 24,15
-            2963: 23,15
-            2964: 21,15
-            2965: 20,15
+            2931: 23,10
+            2932: 24,10
+            2933: 25,10
+            2934: 25,11
+            2935: 24,11
+            2936: 23,11
+            2937: 23,12
+            2938: 24,12
+            2939: 25,12
+            2940: 22,13
+            2941: 22,14
+            2942: 23,14
+            2943: 23,13
+            2944: 24,13
+            2945: 24,14
+            2946: 25,13
+            2947: 26,13
+            2948: 26,14
+            2949: 25,14
+            2950: 27,14
+            2951: 26,15
+            2952: 25,15
+            2953: 24,15
+            2954: 23,15
+            2955: 21,15
+            2956: 20,15
         - node:
             color: '#79150096'
             id: CheckerNWSE
           decals:
-            2910: 16,12
-            2911: 17,12
-            2912: 18,12
-            2913: 19,12
-            2914: 20,12
-            2915: 21,12
-            2916: 21,13
-            2917: 20,13
-            2918: 19,13
-            2919: 18,13
-            2920: 17,13
-            2921: 16,13
-            2922: 15,13
-            2923: 15,14
-            2924: 16,14
-            2925: 17,14
-            2926: 18,14
-            2927: 19,14
-            2928: 20,14
-            2929: 21,14
-            2930: 16,15
-            2931: 16,16
-            2932: 15,16
-            2933: 15,17
-            2934: 16,17
-            2935: 17,17
-            2936: 17,16
-            2937: 17,18
-            2938: 16,18
-            2939: 15,18
+            2901: 16,12
+            2902: 17,12
+            2903: 18,12
+            2904: 19,12
+            2905: 20,12
+            2906: 21,12
+            2907: 21,13
+            2908: 20,13
+            2909: 19,13
+            2910: 18,13
+            2911: 17,13
+            2912: 16,13
+            2913: 15,13
+            2914: 15,14
+            2915: 16,14
+            2916: 17,14
+            2917: 18,14
+            2918: 19,14
+            2919: 20,14
+            2920: 21,14
+            2921: 16,15
+            2922: 16,16
+            2923: 15,16
+            2924: 15,17
+            2925: 16,17
+            2926: 17,17
+            2927: 17,16
+            2928: 17,18
+            2929: 16,18
+            2930: 15,18
         - node:
             color: '#EFB34196'
             id: CheckerNWSE
           decals:
-            2528: -12,-54
-            6261: -1,-54
+            2519: -12,-54
+            6252: -1,-54
         - node:
             color: '#F9801D87'
             id: CheckerNWSE
           decals:
-            7452: 5,-30
-            7453: 5,-31
-            7454: 5,-32
-            7455: 6,-32
-            7456: 6,-31
-            7457: 6,-30
-            7458: 6,-29
-            7459: 5,-29
-            7460: 7,-31
-            7461: 7,-32
-            7462: 8,-32
-            7463: 8,-31
-            7464: 9,-31
-            7465: 9,-32
-            7466: 10,-32
-            7467: 10,-31
-            7468: 11,-31
-            7469: 11,-32
+            7443: 5,-30
+            7444: 5,-31
+            7445: 5,-32
+            7446: 6,-32
+            7447: 6,-31
+            7448: 6,-30
+            7449: 6,-29
+            7450: 5,-29
+            7451: 7,-31
+            7452: 7,-32
+            7453: 8,-32
+            7454: 8,-31
+            7455: 9,-31
+            7456: 9,-32
+            7457: 10,-32
+            7458: 10,-31
+            7459: 11,-31
+            7460: 11,-32
         - node:
             color: '#DE3A3A96'
             id: Delivery
@@ -1522,17 +1522,17 @@ entities:
             color: '#FF0000FF'
             id: Delivery
           decals:
-            7492: -4,-60
-            7493: -4,-60
-            7494: -4,-60
-            7495: -4,-60
-            7496: -4,-60
+            7483: -4,-60
+            7484: -4,-60
+            7485: -4,-60
+            7486: -4,-60
+            7487: -4,-60
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            3157: 37,19
+            3148: 37,19
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -1557,253 +1557,253 @@ entities:
             1255: -36,15
             1256: -35,17
             1257: -33,17
-            1435: -36,-34
-            1510: -31,-28
-            1511: -31,-27
-            1544: -36,-38
-            1557: -30,-40
-            1558: -29,-40
-            1559: -28,-40
-            1560: -28,-39
-            1561: -29,-39
-            1562: -30,-39
-            1563: -30,-38
-            1564: -29,-38
-            1565: -28,-38
-            1648: -26,-35
-            1819: -20,-33
-            1978: -11,-40
-            1979: -11,-46
-            2088: -3,-29
-            2089: -4,-29
-            2275: -42,-52
-            2594: -3,-41
-            2595: -3,-40
-            2596: -5,-40
-            2597: -5,-41
-            2598: -5,-38
-            2599: -5,-37
-            2600: -5,-36
-            2601: -4,-36
-            2602: -3,-36
-            2603: -3,-38
-            2672: -33,3
-            2673: -35,3
-            2674: -36,8
-            2675: -36,9
-            2676: -36,10
-            2772: 29,-2
-            3192: 43,19
-            3234: 40,21
-            3235: 40,22
-            3858: 44,-4
-            3859: 44,-6
-            3860: 44,-7
-            3861: 44,-8
-            3862: 44,-9
-            3863: 44,-10
-            3864: 44,-11
-            3865: 44,-13
-            4093: -8,25
-            4094: -3,25
-            4095: -12,25
-            4299: -13,38
-            4337: -12,43
-            4338: -10,41
-            4339: -10,42
-            4340: -10,37
-            4341: -10,38
-            4374: -27,32
-            4460: -43,22
-            4461: -43,26
-            4462: -40,26
-            4559: -28,27
-            4591: -4,37
-            4592: -5,37
-            4593: -6,37
-            4651: 7,31
-            4788: 11,48
-            4789: 12,49
-            4790: 12,50
-            4834: 4,47
-            4875: 1,53
-            4876: 0,53
-            5119: -7,76
-            5596: 7,-28
-            5597: 7,-22
-            5617: 12,-33
-            5618: 19,-27
-            5619: 19,-26
-            5620: 17,-26
-            5621: 17,-27
-            5622: 15,-27
-            5623: 15,-26
-            6234: 5,-50
-            6235: 0,-44
-            6236: -1,-44
-            6446: -18,-62
-            6447: -20,-63
-            6448: -20,-58
-            6535: 14,-66
-            6536: 10,-66
-            6594: -7,-71
-            6595: -7,-69
-            6596: -5,-70
-            6597: -3,-74
-            6598: -1,-74
-            6599: 1,-74
-            6600: 3,-74
-            6601: -3,-76
-            6602: -2,-77
-            6603: -1,-77
-            6604: 1,-77
-            6605: 2,-77
-            6606: 4,-76
-            6607: 0,-65
-            6608: -4,-66
-            6609: -3,-66
-            6610: 3,-66
-            6611: 4,-66
-            6612: -1,-67
-            6613: 1,-67
-            6614: -5,-64
-            6615: -3,-65
-            6870: 23,-64
-            6871: 23,-63
-            6872: 23,-62
-            6873: 27,-61
-            6874: 31,-62
-            6875: 28,-59
-            6876: 30,-56
-            6877: 24,-53
-            6878: 24,-52
-            6879: 24,-51
-            6880: 26,-53
-            6881: 23,-58
-            6882: 20,-51
-            6883: 20,-52
-            7016: 22,-60
-            7017: 28,-65
-            7018: 32,-64
-            7019: 32,-62
-            7020: 32,-60
-            7021: 32,-58
-            7022: 32,-56
-            7041: 34,-49
-            7042: 34,-50
-            7043: 34,-51
-            7044: 34,-52
-            7066: 38,-46
-            7067: 36,-46
-            7068: 35,-47
-            7077: 16,-39
-            7131: 13,-43
-            7132: 13,-47
-            7316: 26,-57
-            7317: 28,-56
-            7318: 28,-62
-            7319: 29,-62
-            7320: 22,-57
-            7321: 26,-65
-            7325: 30,-55
-            7327: 28,-53
-            7328: 31,-54
-            7330: 30,-61
-            7331: 25,-61
-            7336: 31,-58
-            7337: 24,-64
-            7338: 32,-54
-            7491: -4,-60
-            7497: -6,-59
-            7498: -6,-58
-            7499: -6,-57
-            7500: -5,-57
-            7501: -5,-58
-            7502: -5,-59
-            7503: -4,-59
-            7504: -4,-58
-            7505: -4,-57
-            7506: -3,-57
-            7507: -3,-58
-            7508: -3,-59
-            7509: -2,-59
-            7510: -2,-58
-            7511: -2,-57
-            7525: 32,24
-            7526: 34,24
-            7527: 34,22
-            7528: 32,22
+            1426: -36,-34
+            1501: -31,-28
+            1502: -31,-27
+            1535: -36,-38
+            1548: -30,-40
+            1549: -29,-40
+            1550: -28,-40
+            1551: -28,-39
+            1552: -29,-39
+            1553: -30,-39
+            1554: -30,-38
+            1555: -29,-38
+            1556: -28,-38
+            1639: -26,-35
+            1810: -20,-33
+            1969: -11,-40
+            1970: -11,-46
+            2079: -3,-29
+            2080: -4,-29
+            2266: -42,-52
+            2585: -3,-41
+            2586: -3,-40
+            2587: -5,-40
+            2588: -5,-41
+            2589: -5,-38
+            2590: -5,-37
+            2591: -5,-36
+            2592: -4,-36
+            2593: -3,-36
+            2594: -3,-38
+            2663: -33,3
+            2664: -35,3
+            2665: -36,8
+            2666: -36,9
+            2667: -36,10
+            2763: 29,-2
+            3183: 43,19
+            3225: 40,21
+            3226: 40,22
+            3849: 44,-4
+            3850: 44,-6
+            3851: 44,-7
+            3852: 44,-8
+            3853: 44,-9
+            3854: 44,-10
+            3855: 44,-11
+            3856: 44,-13
+            4084: -8,25
+            4085: -3,25
+            4086: -12,25
+            4290: -13,38
+            4328: -12,43
+            4329: -10,41
+            4330: -10,42
+            4331: -10,37
+            4332: -10,38
+            4365: -27,32
+            4451: -43,22
+            4452: -43,26
+            4453: -40,26
+            4550: -28,27
+            4582: -4,37
+            4583: -5,37
+            4584: -6,37
+            4642: 7,31
+            4779: 11,48
+            4780: 12,49
+            4781: 12,50
+            4825: 4,47
+            4866: 1,53
+            4867: 0,53
+            5110: -7,76
+            5587: 7,-28
+            5588: 7,-22
+            5608: 12,-33
+            5609: 19,-27
+            5610: 19,-26
+            5611: 17,-26
+            5612: 17,-27
+            5613: 15,-27
+            5614: 15,-26
+            6225: 5,-50
+            6226: 0,-44
+            6227: -1,-44
+            6437: -18,-62
+            6438: -20,-63
+            6439: -20,-58
+            6526: 14,-66
+            6527: 10,-66
+            6585: -7,-71
+            6586: -7,-69
+            6587: -5,-70
+            6588: -3,-74
+            6589: -1,-74
+            6590: 1,-74
+            6591: 3,-74
+            6592: -3,-76
+            6593: -2,-77
+            6594: -1,-77
+            6595: 1,-77
+            6596: 2,-77
+            6597: 4,-76
+            6598: 0,-65
+            6599: -4,-66
+            6600: -3,-66
+            6601: 3,-66
+            6602: 4,-66
+            6603: -1,-67
+            6604: 1,-67
+            6605: -5,-64
+            6606: -3,-65
+            6861: 23,-64
+            6862: 23,-63
+            6863: 23,-62
+            6864: 27,-61
+            6865: 31,-62
+            6866: 28,-59
+            6867: 30,-56
+            6868: 24,-53
+            6869: 24,-52
+            6870: 24,-51
+            6871: 26,-53
+            6872: 23,-58
+            6873: 20,-51
+            6874: 20,-52
+            7007: 22,-60
+            7008: 28,-65
+            7009: 32,-64
+            7010: 32,-62
+            7011: 32,-60
+            7012: 32,-58
+            7013: 32,-56
+            7032: 34,-49
+            7033: 34,-50
+            7034: 34,-51
+            7035: 34,-52
+            7057: 38,-46
+            7058: 36,-46
+            7059: 35,-47
+            7068: 16,-39
+            7122: 13,-43
+            7123: 13,-47
+            7307: 26,-57
+            7308: 28,-56
+            7309: 28,-62
+            7310: 29,-62
+            7311: 22,-57
+            7312: 26,-65
+            7316: 30,-55
+            7318: 28,-53
+            7319: 31,-54
+            7321: 30,-61
+            7322: 25,-61
+            7327: 31,-58
+            7328: 24,-64
+            7329: 32,-54
+            7482: -4,-60
+            7488: -6,-59
+            7489: -6,-58
+            7490: -6,-57
+            7491: -5,-57
+            7492: -5,-58
+            7493: -5,-59
+            7494: -4,-59
+            7495: -4,-58
+            7496: -4,-57
+            7497: -3,-57
+            7498: -3,-58
+            7499: -3,-59
+            7500: -2,-59
+            7501: -2,-58
+            7502: -2,-57
+            7516: 32,24
+            7517: 34,24
+            7518: 34,22
+            7519: 32,22
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            2130: -45,-44
-            2132: -48,-35
+            2121: -45,-44
+            2123: -48,-35
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            4561: -33,26
+            4552: -33,26
         - node:
             color: '#EFB341FF'
             id: DeliveryGreyscale
           decals:
-            6303: 6,-61
-            6304: 7,-61
-            6305: 8,-61
+            6294: 6,-61
+            6295: 7,-61
+            6296: 8,-61
         - node:
             color: '#52B4E996'
             id: DiagonalOverlay
           decals:
-            6834: 12,-43
-            6835: 12,-44
-            6836: 13,-44
-            6837: 14,-43
-            7127: 14,-44
-            7128: 13,-43
+            6825: 12,-43
+            6826: 12,-44
+            6827: 13,-44
+            6828: 14,-43
+            7118: 14,-44
+            7119: 13,-43
         - node:
             color: '#DE3A3A96'
             id: DiagonalOverlay
           decals:
-            6838: 12,-47
-            6839: 12,-46
-            6840: 14,-47
-            7124: 13,-47
-            7125: 13,-46
-            7126: 14,-46
+            6829: 12,-47
+            6830: 12,-46
+            6831: 14,-47
+            7115: 13,-47
+            7116: 13,-46
+            7117: 14,-46
         - node:
             color: '#FFFFFFFF'
             id: Dirt
           decals:
-            7377: -42,-23
-            7378: -44,-24
-            7379: -48,-17
-            7380: -48,-20
-            7381: -45,-22
-            7382: -45,-19
-            7383: -46,-18
-            7384: -42,-16
-            7385: -41,-18
-            7386: -48,-22
-            7387: -49,-20
-            7388: -49,-17
-            7389: -47,-24
-            7438: -41,-21
-            7439: -42,-20
-            7440: -43,-18
-            7441: -44,-18
-            7442: -42,-17
-            7443: -47,-18
-            7444: -49,-16
-            7445: -49,-22
-            7446: -49,-23
-            7447: -47,-23
-            7448: -47,-23
-            7449: -45,-24
-            7450: -45,-23
-            7451: -41,-24
+            7368: -42,-23
+            7369: -44,-24
+            7370: -48,-17
+            7371: -48,-20
+            7372: -45,-22
+            7373: -45,-19
+            7374: -46,-18
+            7375: -42,-16
+            7376: -41,-18
+            7377: -48,-22
+            7378: -49,-20
+            7379: -49,-17
+            7380: -47,-24
+            7429: -41,-21
+            7430: -42,-20
+            7431: -43,-18
+            7432: -44,-18
+            7433: -42,-17
+            7434: -47,-18
+            7435: -49,-16
+            7436: -49,-22
+            7437: -49,-23
+            7438: -47,-23
+            7439: -47,-23
+            7440: -45,-24
+            7441: -45,-23
+            7442: -41,-24
         - node:
             color: '#A4610696'
             id: DirtHeavy
@@ -2190,1459 +2190,1459 @@ entities:
             1346: -41,-26
             1347: -42,-26
             1348: -42,-27
-            1355: -46,-28
-            1356: -46,-27
-            1357: -46,-27
-            1359: -46,-26
-            1360: -45,-26
-            1361: -45,-27
-            1362: -45,-27
-            1363: -46,-28
-            1366: -46,-27
-            1367: -46,-27
-            1368: -44,-27
-            1369: -44,-27
-            1370: -44,-27
-            1371: -44,-27
-            1377: -40,-29
-            1378: -39,-29
-            1379: -39,-29
-            1380: -39,-29
-            1381: -40,-29
-            1394: -39,-34
-            1395: -38,-34
-            1396: -38,-33
-            1397: -38,-33
-            1398: -38,-34
-            1399: -39,-34
-            1400: -39,-34
-            1401: -39,-34
-            1402: -40,-34
-            1403: -40,-33
-            1404: -40,-33
-            1405: -40,-33
-            1406: -40,-32
-            1407: -39,-32
-            1408: -39,-31
-            1409: -39,-31
-            1410: -40,-31
-            1411: -39,-30
-            1412: -39,-30
-            1413: -39,-29
-            1414: -40,-30
-            1415: -40,-31
-            1416: -40,-32
-            1417: -40,-32
-            1512: -36,-32
-            1513: -36,-31
-            1514: -36,-29
+            1353: -46,-28
+            1354: -46,-27
+            1355: -46,-27
+            1356: -46,-26
+            1357: -45,-26
+            1358: -45,-27
+            1359: -45,-27
+            1360: -46,-28
+            1361: -46,-27
+            1362: -46,-27
+            1363: -44,-27
+            1364: -44,-27
+            1365: -44,-27
+            1366: -44,-27
+            1368: -40,-29
+            1369: -39,-29
+            1370: -39,-29
+            1371: -39,-29
+            1372: -40,-29
+            1385: -39,-34
+            1386: -38,-34
+            1387: -38,-33
+            1388: -38,-33
+            1389: -38,-34
+            1390: -39,-34
+            1391: -39,-34
+            1392: -39,-34
+            1393: -40,-34
+            1394: -40,-33
+            1395: -40,-33
+            1396: -40,-33
+            1397: -40,-32
+            1398: -39,-32
+            1399: -39,-31
+            1400: -39,-31
+            1401: -40,-31
+            1402: -39,-30
+            1403: -39,-30
+            1404: -39,-29
+            1405: -40,-30
+            1406: -40,-31
+            1407: -40,-32
+            1408: -40,-32
+            1503: -36,-32
+            1504: -36,-31
+            1505: -36,-29
+            1506: -36,-27
+            1507: -34,-27
+            1508: -33,-27
+            1509: -33,-28
+            1510: -33,-29
+            1511: -35,-27
+            1512: -36,-28
+            1513: -37,-30
+            1514: -37,-28
             1515: -36,-27
-            1516: -34,-27
-            1517: -33,-27
-            1518: -33,-28
-            1519: -33,-29
-            1520: -35,-27
-            1521: -36,-28
-            1522: -37,-30
-            1523: -37,-28
-            1524: -36,-27
-            1525: -34,-31
-            1526: -34,-32
-            1527: -35,-32
-            1528: -33,-32
-            1529: -33,-30
-            1530: -35,-33
-            1531: -34,-35
-            1532: -35,-34
-            1533: -35,-34
-            1534: -35,-34
-            1535: -34,-31
-            1536: -36,-31
-            1537: -36,-29
-            1538: -36,-30
-            1608: -34,-37
-            1609: -34,-38
-            1610: -34,-40
-            1611: -33,-42
-            1612: -34,-44
-            1613: -35,-44
-            1614: -35,-41
-            1615: -31,-41
-            1616: -30,-42
-            1617: -29,-41
-            1618: -31,-39
-            1619: -30,-38
-            1620: -28,-39
-            1621: -29,-41
-            1622: -29,-39
-            1683: -27,-24
-            1684: -26,-23
-            1685: -25,-22
-            1686: -23,-24
-            1687: -22,-24
-            1688: -22,-22
-            1689: -23,-21
-            1690: -23,-20
-            1691: -23,-18
-            1692: -22,-19
-            1693: -24,-19
-            1694: -23,-18
-            1695: -19,-18
-            1696: -20,-18
-            1697: -21,-18
-            1698: -20,-18
-            1699: -21,-17
-            1700: -21,-17
-            1701: -25,-18
-            1702: -25,-22
-            1703: -27,-22
-            1704: -26,-24
-            1705: -27,-24
-            1706: -24,-25
-            1707: -21,-24
-            1708: -21,-20
-            1709: -23,-24
-            1710: -23,-21
-            1711: -25,-24
-            1712: -22,-22
-            1713: -22,-22
-            1714: -24,-24
-            1837: -13,-29
-            1838: -13,-29
-            1839: -12,-25
-            1840: -10,-22
-            1841: -10,-24
-            1842: -12,-23
-            1843: -11,-22
-            1844: -11,-23
-            1845: -11,-24
-            1987: -7,-38
-            1988: -8,-38
-            1989: -10,-38
-            1990: -11,-37
-            1991: -10,-37
-            1992: -9,-36
-            1993: -8,-36
-            1994: -10,-36
-            1995: -11,-36
-            1996: -12,-37
-            1997: -13,-38
-            1998: -13,-39
-            1999: -12,-40
-            2000: -12,-41
-            2001: -13,-42
-            2002: -13,-42
-            2003: -12,-40
-            2004: -12,-41
-            2005: -13,-42
-            2006: -12,-44
-            2007: -12,-45
-            2008: -12,-47
-            2009: -13,-48
-            2010: -12,-50
-            2011: -11,-50
-            2012: -12,-49
-            2013: -11,-48
-            2014: -12,-48
-            2015: -13,-49
-            2016: -13,-49
-            2017: -12,-48
-            2018: -12,-45
-            2019: -12,-44
-            2020: -13,-45
-            2021: -13,-43
-            2022: -13,-42
-            2023: -13,-40
-            2024: -12,-39
-            2025: -12,-39
-            2026: -11,-41
-            2027: -11,-43
-            2028: -11,-45
-            2029: -11,-45
-            2030: -11,-43
-            2031: -11,-42
-            2032: -14,-43
-            2033: -14,-46
-            2034: -14,-40
-            2035: -13,-37
-            2036: -13,-36
-            2037: -14,-37
-            2038: -12,-36
-            2039: -8,-38
-            2040: -7,-37
-            2041: -7,-36
-            2042: -8,-34
-            2043: -8,-32
-            2044: -8,-31
-            2045: -8,-31
-            2046: -7,-31
-            2047: -7,-32
-            2048: -6,-34
-            2049: -5,-32
-            2050: -5,-31
-            2051: -4,-32
-            2052: -4,-33
-            2053: -3,-34
-            2054: -3,-33
-            2055: -4,-31
-            2056: -5,-32
-            2057: -7,-34
-            2058: -14,-49
-            2059: -14,-49
-            2060: -13,-50
-            2061: -13,-51
-            2162: -40,-40
-            2163: -39,-40
-            2164: -38,-39
-            2165: -39,-39
-            2166: -40,-39
-            2167: -40,-38
-            2168: -39,-38
-            2169: -39,-37
-            2170: -40,-37
-            2171: -40,-37
-            2172: -41,-36
-            2173: -41,-37
-            2174: -39,-37
-            2175: -38,-38
+            1516: -34,-31
+            1517: -34,-32
+            1518: -35,-32
+            1519: -33,-32
+            1520: -33,-30
+            1521: -35,-33
+            1522: -34,-35
+            1523: -35,-34
+            1524: -35,-34
+            1525: -35,-34
+            1526: -34,-31
+            1527: -36,-31
+            1528: -36,-29
+            1529: -36,-30
+            1599: -34,-37
+            1600: -34,-38
+            1601: -34,-40
+            1602: -33,-42
+            1603: -34,-44
+            1604: -35,-44
+            1605: -35,-41
+            1606: -31,-41
+            1607: -30,-42
+            1608: -29,-41
+            1609: -31,-39
+            1610: -30,-38
+            1611: -28,-39
+            1612: -29,-41
+            1613: -29,-39
+            1674: -27,-24
+            1675: -26,-23
+            1676: -25,-22
+            1677: -23,-24
+            1678: -22,-24
+            1679: -22,-22
+            1680: -23,-21
+            1681: -23,-20
+            1682: -23,-18
+            1683: -22,-19
+            1684: -24,-19
+            1685: -23,-18
+            1686: -19,-18
+            1687: -20,-18
+            1688: -21,-18
+            1689: -20,-18
+            1690: -21,-17
+            1691: -21,-17
+            1692: -25,-18
+            1693: -25,-22
+            1694: -27,-22
+            1695: -26,-24
+            1696: -27,-24
+            1697: -24,-25
+            1698: -21,-24
+            1699: -21,-20
+            1700: -23,-24
+            1701: -23,-21
+            1702: -25,-24
+            1703: -22,-22
+            1704: -22,-22
+            1705: -24,-24
+            1828: -13,-29
+            1829: -13,-29
+            1830: -12,-25
+            1831: -10,-22
+            1832: -10,-24
+            1833: -12,-23
+            1834: -11,-22
+            1835: -11,-23
+            1836: -11,-24
+            1978: -7,-38
+            1979: -8,-38
+            1980: -10,-38
+            1981: -11,-37
+            1982: -10,-37
+            1983: -9,-36
+            1984: -8,-36
+            1985: -10,-36
+            1986: -11,-36
+            1987: -12,-37
+            1988: -13,-38
+            1989: -13,-39
+            1990: -12,-40
+            1991: -12,-41
+            1992: -13,-42
+            1993: -13,-42
+            1994: -12,-40
+            1995: -12,-41
+            1996: -13,-42
+            1997: -12,-44
+            1998: -12,-45
+            1999: -12,-47
+            2000: -13,-48
+            2001: -12,-50
+            2002: -11,-50
+            2003: -12,-49
+            2004: -11,-48
+            2005: -12,-48
+            2006: -13,-49
+            2007: -13,-49
+            2008: -12,-48
+            2009: -12,-45
+            2010: -12,-44
+            2011: -13,-45
+            2012: -13,-43
+            2013: -13,-42
+            2014: -13,-40
+            2015: -12,-39
+            2016: -12,-39
+            2017: -11,-41
+            2018: -11,-43
+            2019: -11,-45
+            2020: -11,-45
+            2021: -11,-43
+            2022: -11,-42
+            2023: -14,-43
+            2024: -14,-46
+            2025: -14,-40
+            2026: -13,-37
+            2027: -13,-36
+            2028: -14,-37
+            2029: -12,-36
+            2030: -8,-38
+            2031: -7,-37
+            2032: -7,-36
+            2033: -8,-34
+            2034: -8,-32
+            2035: -8,-31
+            2036: -8,-31
+            2037: -7,-31
+            2038: -7,-32
+            2039: -6,-34
+            2040: -5,-32
+            2041: -5,-31
+            2042: -4,-32
+            2043: -4,-33
+            2044: -3,-34
+            2045: -3,-33
+            2046: -4,-31
+            2047: -5,-32
+            2048: -7,-34
+            2049: -14,-49
+            2050: -14,-49
+            2051: -13,-50
+            2052: -13,-51
+            2153: -40,-40
+            2154: -39,-40
+            2155: -38,-39
+            2156: -39,-39
+            2157: -40,-39
+            2158: -40,-38
+            2159: -39,-38
+            2160: -39,-37
+            2161: -40,-37
+            2162: -40,-37
+            2163: -41,-36
+            2164: -41,-37
+            2165: -39,-37
+            2166: -38,-38
+            2167: -38,-38
+            2168: -39,-37
+            2169: -41,-36
+            2170: -40,-38
+            2171: -39,-39
+            2172: -38,-38
+            2173: -39,-37
+            2174: -40,-37
+            2175: -39,-38
             2176: -38,-38
-            2177: -39,-37
-            2178: -41,-36
-            2179: -40,-38
-            2180: -39,-39
-            2181: -38,-38
-            2182: -39,-37
-            2183: -40,-37
-            2184: -39,-38
-            2185: -38,-38
-            2186: -40,-37
-            2280: -29,-49
-            2281: -29,-48
-            2282: -28,-47
-            2283: -27,-48
-            2284: -25,-48
-            2285: -26,-47
-            2286: -27,-47
-            2287: -26,-48
-            2288: -24,-48
-            2289: -32,-46
-            2290: -36,-46
-            2291: -37,-46
-            2292: -38,-46
-            2293: -37,-48
-            2294: -34,-48
-            2295: -33,-49
-            2296: -35,-49
-            2297: -36,-47
-            2298: -37,-49
-            2299: -35,-50
-            2300: -33,-48
-            2301: -33,-48
-            2302: -33,-51
-            2303: -35,-52
-            2304: -38,-51
-            2305: -39,-51
-            2306: -39,-53
-            2307: -37,-52
-            2308: -35,-52
-            2309: -37,-52
-            2310: -39,-50
-            2311: -37,-49
-            2312: -36,-52
-            2313: -35,-51
-            2314: -34,-51
-            2315: -42,-50
-            2316: -43,-50
-            2317: -43,-51
-            2318: -41,-51
-            2319: -41,-51
-            2369: -20,-50
-            2370: -21,-50
-            2371: -22,-50
-            2372: -22,-50
-            2373: -22,-49
-            2374: -21,-49
-            2375: -20,-49
-            2376: -20,-49
-            2377: -21,-49
-            2378: -22,-48
-            2379: -22,-48
-            2380: -21,-48
-            2381: -20,-47
-            2382: -21,-47
-            2383: -22,-46
-            2384: -21,-46
-            2385: -20,-45
-            2386: -22,-44
-            2387: -23,-44
-            2388: -23,-44
-            2389: -25,-45
-            2390: -25,-45
-            2391: -26,-44
-            2392: -28,-44
-            2393: -28,-44
-            2394: -28,-45
-            2395: -29,-45
-            2396: -30,-45
-            2397: -30,-44
-            2398: -31,-44
-            2399: -31,-44
-            2400: -29,-44
-            2401: -26,-44
-            2402: -25,-44
-            2403: -20,-40
-            2404: -21,-40
-            2405: -21,-40
-            2406: -22,-40
-            2407: -22,-39
-            2408: -21,-38
-            2409: -20,-37
-            2410: -21,-37
-            2411: -22,-37
-            2412: -21,-36
-            2413: -21,-36
-            2414: -20,-36
-            2415: -21,-37
-            2416: -21,-38
-            2417: -21,-39
-            2418: -21,-39
-            2419: -21,-39
-            2420: -21,-37
-            2421: -21,-37
-            2425: -20,-54
-            2426: -21,-54
-            2427: -21,-53
-            2428: -21,-53
-            2429: -21,-53
-            2430: -23,-53
-            2431: -23,-52
-            2432: -23,-52
-            2433: -23,-51
-            2434: -22,-51
-            2435: -21,-51
-            2436: -20,-52
-            2437: -20,-51
-            2438: -20,-52
-            2439: -22,-53
-            2443: -26,-53
-            2444: -28,-53
-            2445: -29,-53
-            2446: -30,-52
-            2447: -30,-52
+            2177: -40,-37
+            2271: -29,-49
+            2272: -29,-48
+            2273: -28,-47
+            2274: -27,-48
+            2275: -25,-48
+            2276: -26,-47
+            2277: -27,-47
+            2278: -26,-48
+            2279: -24,-48
+            2280: -32,-46
+            2281: -36,-46
+            2282: -37,-46
+            2283: -38,-46
+            2284: -37,-48
+            2285: -34,-48
+            2286: -33,-49
+            2287: -35,-49
+            2288: -36,-47
+            2289: -37,-49
+            2290: -35,-50
+            2291: -33,-48
+            2292: -33,-48
+            2293: -33,-51
+            2294: -35,-52
+            2295: -38,-51
+            2296: -39,-51
+            2297: -39,-53
+            2298: -37,-52
+            2299: -35,-52
+            2300: -37,-52
+            2301: -39,-50
+            2302: -37,-49
+            2303: -36,-52
+            2304: -35,-51
+            2305: -34,-51
+            2306: -42,-50
+            2307: -43,-50
+            2308: -43,-51
+            2309: -41,-51
+            2310: -41,-51
+            2360: -20,-50
+            2361: -21,-50
+            2362: -22,-50
+            2363: -22,-50
+            2364: -22,-49
+            2365: -21,-49
+            2366: -20,-49
+            2367: -20,-49
+            2368: -21,-49
+            2369: -22,-48
+            2370: -22,-48
+            2371: -21,-48
+            2372: -20,-47
+            2373: -21,-47
+            2374: -22,-46
+            2375: -21,-46
+            2376: -20,-45
+            2377: -22,-44
+            2378: -23,-44
+            2379: -23,-44
+            2380: -25,-45
+            2381: -25,-45
+            2382: -26,-44
+            2383: -28,-44
+            2384: -28,-44
+            2385: -28,-45
+            2386: -29,-45
+            2387: -30,-45
+            2388: -30,-44
+            2389: -31,-44
+            2390: -31,-44
+            2391: -29,-44
+            2392: -26,-44
+            2393: -25,-44
+            2394: -20,-40
+            2395: -21,-40
+            2396: -21,-40
+            2397: -22,-40
+            2398: -22,-39
+            2399: -21,-38
+            2400: -20,-37
+            2401: -21,-37
+            2402: -22,-37
+            2403: -21,-36
+            2404: -21,-36
+            2405: -20,-36
+            2406: -21,-37
+            2407: -21,-38
+            2408: -21,-39
+            2409: -21,-39
+            2410: -21,-39
+            2411: -21,-37
+            2412: -21,-37
+            2416: -20,-54
+            2417: -21,-54
+            2418: -21,-53
+            2419: -21,-53
+            2420: -21,-53
+            2421: -23,-53
+            2422: -23,-52
+            2423: -23,-52
+            2424: -23,-51
+            2425: -22,-51
+            2426: -21,-51
+            2427: -20,-52
+            2428: -20,-51
+            2429: -20,-52
+            2430: -22,-53
+            2434: -26,-53
+            2435: -28,-53
+            2436: -29,-53
+            2437: -30,-52
+            2438: -30,-52
+            2439: -30,-51
+            2440: -28,-52
+            2441: -26,-51
+            2442: -26,-51
+            2443: -26,-52
+            2444: -25,-52
+            2445: -27,-53
+            2446: -25,-53
+            2447: -25,-53
             2448: -30,-51
-            2449: -28,-52
-            2450: -26,-51
-            2451: -26,-51
-            2452: -26,-52
-            2453: -25,-52
-            2454: -27,-53
-            2455: -25,-53
-            2456: -25,-53
-            2457: -30,-51
-            2458: -30,-53
-            2459: -28,-51
-            2466: -27,-57
-            2467: -27,-56
-            2468: -26,-55
-            2469: -26,-55
-            2470: -26,-57
-            2471: -24,-56
-            2472: -24,-55
-            2473: -24,-55
-            2474: -23,-56
-            2475: -23,-57
-            2476: -23,-55
-            2477: -27,-55
-            2478: -26,-57
-            2479: -27,-56
-            2480: -23,-55
-            2493: -29,-55
-            2494: -29,-56
-            2495: -31,-56
-            2496: -32,-56
-            2497: -31,-55
-            2498: -28,-61
-            2499: -28,-60
-            2500: -27,-60
-            2501: -26,-60
-            2502: -25,-60
-            2503: -25,-58
-            2504: -24,-59
-            2505: -24,-60
-            2506: -24,-60
-            2507: -23,-60
-            2508: -24,-59
-            2509: -25,-60
-            2510: -24,-61
-            2511: -26,-63
-            2512: -27,-63
-            2513: -27,-65
-            2514: -25,-65
-            2515: -24,-65
-            2516: -25,-63
-            2517: -25,-63
-            2518: -24,-64
-            2519: -26,-65
-            2520: -27,-61
-            2521: -27,-61
-            2522: -29,-59
-            2523: -29,-58
-            2524: -29,-57
-            2530: -18,-54
-            2531: -18,-54
-            2532: -18,-53
-            2533: -18,-53
-            2534: -17,-53
-            2535: -16,-54
-            2536: -16,-54
-            2537: -15,-53
-            2538: -14,-52
-            2539: -12,-53
-            2540: -11,-53
-            2541: -11,-52
-            2542: -11,-52
-            2543: -15,-52
-            2544: -10,-54
-            2545: -13,-54
-            2546: -15,-54
-            2547: -16,-54
-            2548: -14,-52
-            2549: -11,-52
-            2550: -10,-53
-            2551: -17,-53
-            2552: -16,-52
-            2553: -13,-54
-            2554: -15,-54
-            2555: -13,-53
-            2556: -11,-52
-            2561: -8,-54
-            2562: -7,-54
-            2563: -8,-53
-            2564: -8,-52
-            2565: -7,-52
-            2566: -7,-54
-            2567: -6,-54
-            2568: -6,-53
+            2449: -30,-53
+            2450: -28,-51
+            2457: -27,-57
+            2458: -27,-56
+            2459: -26,-55
+            2460: -26,-55
+            2461: -26,-57
+            2462: -24,-56
+            2463: -24,-55
+            2464: -24,-55
+            2465: -23,-56
+            2466: -23,-57
+            2467: -23,-55
+            2468: -27,-55
+            2469: -26,-57
+            2470: -27,-56
+            2471: -23,-55
+            2484: -29,-55
+            2485: -29,-56
+            2486: -31,-56
+            2487: -32,-56
+            2488: -31,-55
+            2489: -28,-61
+            2490: -28,-60
+            2491: -27,-60
+            2492: -26,-60
+            2493: -25,-60
+            2494: -25,-58
+            2495: -24,-59
+            2496: -24,-60
+            2497: -24,-60
+            2498: -23,-60
+            2499: -24,-59
+            2500: -25,-60
+            2501: -24,-61
+            2502: -26,-63
+            2503: -27,-63
+            2504: -27,-65
+            2505: -25,-65
+            2506: -24,-65
+            2507: -25,-63
+            2508: -25,-63
+            2509: -24,-64
+            2510: -26,-65
+            2511: -27,-61
+            2512: -27,-61
+            2513: -29,-59
+            2514: -29,-58
+            2515: -29,-57
+            2521: -18,-54
+            2522: -18,-54
+            2523: -18,-53
+            2524: -18,-53
+            2525: -17,-53
+            2526: -16,-54
+            2527: -16,-54
+            2528: -15,-53
+            2529: -14,-52
+            2530: -12,-53
+            2531: -11,-53
+            2532: -11,-52
+            2533: -11,-52
+            2534: -15,-52
+            2535: -10,-54
+            2536: -13,-54
+            2537: -15,-54
+            2538: -16,-54
+            2539: -14,-52
+            2540: -11,-52
+            2541: -10,-53
+            2542: -17,-53
+            2543: -16,-52
+            2544: -13,-54
+            2545: -15,-54
+            2546: -13,-53
+            2547: -11,-52
+            2552: -8,-54
+            2553: -7,-54
+            2554: -8,-53
+            2555: -8,-52
+            2556: -7,-52
+            2557: -7,-54
+            2558: -6,-54
+            2559: -6,-53
+            2560: -7,-53
+            2561: -6,-52
+            2562: -6,-52
+            2563: -6,-51
+            2564: -6,-49
+            2565: -5,-49
+            2566: -6,-49
+            2567: -6,-50
+            2568: -6,-51
             2569: -7,-53
-            2570: -6,-52
-            2571: -6,-52
-            2572: -6,-51
-            2573: -6,-49
-            2574: -5,-49
-            2575: -6,-49
-            2576: -6,-50
-            2577: -6,-51
-            2578: -7,-53
-            2580: -5,-48
-            2581: -5,-47
-            2582: -5,-46
-            2583: -5,-46
-            2584: -5,-45
-            2585: -5,-45
-            2586: -5,-43
-            2587: -5,-44
-            2588: -4,-43
-            2589: -4,-45
-            2590: -3,-43
-            2591: -4,-43
-            2592: -5,-43
-            2593: -3,-43
-            2727: 18,-3
-            2728: 18,-3
-            2729: 19,-3
-            2730: 19,-4
-            2731: 19,-5
-            2732: 19,-7
-            2733: 19,-7
-            2734: 20,-7
-            2735: 21,-7
-            2736: 21,-6
-            2737: 21,-5
-            2738: 21,-4
-            2739: 21,-4
-            2740: 22,-3
-            2741: 22,-4
-            2742: 22,-6
-            2743: 23,-6
-            2744: 24,-6
-            2745: 24,-5
-            2746: 25,-4
-            2747: 25,-3
-            2748: 25,-3
-            2749: 25,-5
-            2750: 23,-7
-            2751: 24,-3
-            2752: 24,-3
-            2753: 21,-3
-            2754: 22,-3
-            2755: 18,-5
-            2778: 23,-13
+            2571: -5,-48
+            2572: -5,-47
+            2573: -5,-46
+            2574: -5,-46
+            2575: -5,-45
+            2576: -5,-45
+            2577: -5,-43
+            2578: -5,-44
+            2579: -4,-43
+            2580: -4,-45
+            2581: -3,-43
+            2582: -4,-43
+            2583: -5,-43
+            2584: -3,-43
+            2718: 18,-3
+            2719: 18,-3
+            2720: 19,-3
+            2721: 19,-4
+            2722: 19,-5
+            2723: 19,-7
+            2724: 19,-7
+            2725: 20,-7
+            2726: 21,-7
+            2727: 21,-6
+            2728: 21,-5
+            2729: 21,-4
+            2730: 21,-4
+            2731: 22,-3
+            2732: 22,-4
+            2733: 22,-6
+            2734: 23,-6
+            2735: 24,-6
+            2736: 24,-5
+            2737: 25,-4
+            2738: 25,-3
+            2739: 25,-3
+            2740: 25,-5
+            2741: 23,-7
+            2742: 24,-3
+            2743: 24,-3
+            2744: 21,-3
+            2745: 22,-3
+            2746: 18,-5
+            2769: 23,-13
+            2770: 22,-13
+            2771: 22,-12
+            2772: 22,-11
+            2773: 22,-9
+            2774: 22,-9
+            2775: 23,-10
+            2776: 24,-11
+            2777: 24,-11
+            2778: 22,-10
             2779: 22,-13
             2780: 22,-12
             2781: 22,-11
-            2782: 22,-9
-            2783: 22,-9
-            2784: 23,-10
-            2785: 24,-11
-            2786: 24,-11
-            2787: 22,-10
-            2788: 22,-13
-            2789: 22,-12
-            2790: 22,-11
-            2791: 23,-11
-            2792: 24,-9
-            2793: 26,-10
-            2794: 26,-9
-            2795: 27,-9
-            2796: 26,-8
-            2797: 28,-8
-            2798: 29,-9
-            2799: 29,-8
-            2800: 30,-7
-            2801: 28,-7
-            2802: 28,-7
-            2803: 30,-9
-            2804: 30,-7
-            2815: 22,-16
-            2816: 22,-15
-            2817: 23,-16
-            2818: 23,-16
-            2819: 24,-15
-            2820: 25,-16
-            2821: 25,-16
-            2822: 26,-15
-            2823: 26,-14
-            2824: 25,-14
-            2825: 26,-12
-            2826: 26,-14
-            2827: 25,-14
-            2828: 25,-13
-            2829: 25,-13
-            2830: 25,-13
-            2831: 24,-15
-            3045: 24,6
-            3046: 23,6
-            3047: 15,6
-            3048: 15,6
-            3049: 18,8
-            3050: 18,7
-            3051: 17,7
-            3052: 20,11
-            3053: 20,6
-            3054: 24,8
-            3055: 26,6
-            3056: 28,8
-            3057: 28,6
-            3058: 29,5
-            3059: 29,4
-            3060: 31,7
-            3061: 34,7
-            3062: 35,5
-            3063: 33,7
-            3064: 29,8
-            3065: 29,10
-            3066: 28,9
-            3067: 30,10
-            3068: 30,8
-            3069: 26,8
-            3070: 20,11
-            3071: 17,11
-            3072: 15,11
-            3073: 17,8
-            3074: 17,7
-            3075: 21,7
-            3076: 23,10
-            3077: 23,10
-            3078: 25,11
-            3079: 24,13
-            3080: 23,13
-            3081: 24,14
-            3082: 26,14
-            3083: 26,13
-            3084: 23,15
-            3085: 24,15
-            3086: 26,15
-            3087: 26,16
-            3088: 23,16
-            3089: 22,16
-            3090: 20,16
-            3091: 19,16
-            3092: 20,18
-            3093: 21,18
-            3094: 21,18
-            3095: 23,19
-            3096: 25,18
-            3097: 25,16
-            3098: 26,18
-            3099: 24,18
-            3100: 22,17
-            3101: 22,20
-            3102: 26,18
-            3103: 22,18
-            3104: 20,16
-            3105: 19,16
-            3106: 27,16
-            3218: 43,21
-            3219: 43,21
-            3220: 44,21
-            3221: 42,23
-            3222: 42,23
-            3223: 42,24
-            3224: 42,24
-            3225: 43,24
-            3226: 43,23
-            3227: 43,22
-            3228: 42,22
-            3229: 42,21
-            3244: 10,21
-            3245: 10,22
-            3246: 8,22
-            3247: 8,22
-            3248: 8,21
-            3249: 7,21
-            3250: 5,21
-            3251: 4,21
-            3252: 5,22
-            3253: 5,22
-            3254: 6,22
-            3255: 6,21
-            3256: 10,22
-            3262: 12,23
-            3263: 12,22
-            3264: 12,22
-            3265: 13,22
-            3266: 12,20
-            3267: 12,20
-            3268: 12,17
-            3269: 12,19
-            3270: 12,19
-            3271: 13,22
-            3272: 13,22
-            3273: 13,19
-            3274: 13,17
-            3275: 13,16
-            3276: 13,14
-            3277: 13,12
-            3278: 13,11
-            3279: 12,12
-            3280: 12,14
-            3281: 12,15
-            3282: 12,14
-            3283: 12,13
-            3284: 13,9
-            3285: 13,8
-            3286: 12,8
-            3287: 12,8
-            3288: 11,8
-            3289: 11,9
-            3290: 12,9
-            3291: 13,8
-            3292: 13,7
-            3293: 13,6
-            3294: 13,5
-            3295: 13,4
-            3296: 14,4
-            3297: 15,4
-            3298: 12,12
-            3299: 12,15
-            3300: 17,23
-            3301: 17,22
-            3302: 16,21
-            3303: 16,20
-            3304: 17,20
-            3305: 19,21
-            3306: 18,22
-            3307: 17,23
-            3308: 16,22
-            3309: 15,21
-            3317: 16,25
-            3318: 16,27
-            3319: 17,27
-            3320: 18,27
-            3321: 18,26
-            3322: 18,25
-            3323: 20,25
-            3324: 20,25
-            3325: 21,25
-            3326: 19,27
-            3327: 23,25
-            3328: 24,25
-            3329: 25,25
-            3330: 25,27
-            3331: 23,27
-            3332: 21,27
-            3333: 21,27
-            3334: 21,27
-            3335: 21,27
-            3336: 21,27
-            3337: 21,27
-            3338: 25,26
-            3339: 26,25
-            3340: 26,25
-            3341: 24,25
-            3342: 20,25
-            3343: 20,27
-            3344: 18,27
-            3345: 18,27
-            3346: 20,26
-            3347: 21,25
-            3348: 20,25
-            3924: -23,14
-            3925: -23,15
-            3926: -22,15
-            3927: -22,16
-            3928: -19,15
-            3929: -20,15
-            3930: -19,14
-            3931: -18,14
-            3932: -17,15
-            3933: -17,16
-            3934: -19,16
-            3935: -19,14
-            3936: -19,14
-            3937: -20,14
-            3938: -21,14
-            3939: -22,14
-            3940: -21,16
-            3941: -18,16
-            3942: -17,15
-            3943: -21,16
-            3944: -22,16
-            3945: -21,17
-            3946: -21,17
-            3947: -23,15
-            3948: -23,16
-            3949: -17,14
-            3950: -22,14
-            3951: -17,16
-            3960: -25,15
-            3961: -26,15
-            3962: -25,16
-            3963: -25,16
-            3964: -25,17
-            3965: -25,18
-            3966: -26,18
-            3967: -26,18
-            3968: -26,20
-            3969: -28,19
-            3970: -28,19
-            3971: -30,19
-            3972: -29,20
-            3973: -30,21
-            3974: -28,21
-            3975: -27,21
-            3976: -27,20
-            3977: -28,21
-            3978: -28,20
-            3979: -26,21
-            3980: -25,20
-            3981: -24,20
-            3982: -24,19
-            3983: -24,19
-            3984: -26,19
-            3985: -28,23
-            3986: -28,24
-            3987: -28,24
-            3988: -28,26
-            3989: -28,26
-            3990: -28,25
-            3991: -28,26
-            3992: -28,25
-            3993: -26,16
-            3994: -25,15
-            3996: -32,19
-            3997: -33,19
-            3998: -34,19
-            3999: -33,20
-            4000: -34,21
-            4001: -34,20
-            4002: -32,21
-            4003: -32,20
-            4004: -28,15
-            4005: -29,15
-            4006: -30,16
-            4007: -29,17
-            4008: -29,16
-            4009: -29,16
-            4010: -28,17
-            4011: -28,17
-            4012: -30,15
-            4013: -29,17
-            4014: -29,17
-            4113: -13,22
-            4114: -12,22
-            4115: -12,24
-            4116: -10,22
-            4117: -9,24
-            4118: -7,24
-            4119: -8,22
-            4120: -7,22
-            4121: -9,23
-            4122: -4,22
-            4123: -3,23
-            4124: -4,24
-            4125: -3,25
-            4724: -7,42
-            4725: -5,42
-            4726: -4,42
-            4727: -5,43
-            4728: -7,43
-            4729: -6,44
-            4730: -4,44
-            4731: -4,45
-            4732: -5,43
-            4733: -6,43
-            4734: -6,44
+            2782: 23,-11
+            2783: 24,-9
+            2784: 26,-10
+            2785: 26,-9
+            2786: 27,-9
+            2787: 26,-8
+            2788: 28,-8
+            2789: 29,-9
+            2790: 29,-8
+            2791: 30,-7
+            2792: 28,-7
+            2793: 28,-7
+            2794: 30,-9
+            2795: 30,-7
+            2806: 22,-16
+            2807: 22,-15
+            2808: 23,-16
+            2809: 23,-16
+            2810: 24,-15
+            2811: 25,-16
+            2812: 25,-16
+            2813: 26,-15
+            2814: 26,-14
+            2815: 25,-14
+            2816: 26,-12
+            2817: 26,-14
+            2818: 25,-14
+            2819: 25,-13
+            2820: 25,-13
+            2821: 25,-13
+            2822: 24,-15
+            3036: 24,6
+            3037: 23,6
+            3038: 15,6
+            3039: 15,6
+            3040: 18,8
+            3041: 18,7
+            3042: 17,7
+            3043: 20,11
+            3044: 20,6
+            3045: 24,8
+            3046: 26,6
+            3047: 28,8
+            3048: 28,6
+            3049: 29,5
+            3050: 29,4
+            3051: 31,7
+            3052: 34,7
+            3053: 35,5
+            3054: 33,7
+            3055: 29,8
+            3056: 29,10
+            3057: 28,9
+            3058: 30,10
+            3059: 30,8
+            3060: 26,8
+            3061: 20,11
+            3062: 17,11
+            3063: 15,11
+            3064: 17,8
+            3065: 17,7
+            3066: 21,7
+            3067: 23,10
+            3068: 23,10
+            3069: 25,11
+            3070: 24,13
+            3071: 23,13
+            3072: 24,14
+            3073: 26,14
+            3074: 26,13
+            3075: 23,15
+            3076: 24,15
+            3077: 26,15
+            3078: 26,16
+            3079: 23,16
+            3080: 22,16
+            3081: 20,16
+            3082: 19,16
+            3083: 20,18
+            3084: 21,18
+            3085: 21,18
+            3086: 23,19
+            3087: 25,18
+            3088: 25,16
+            3089: 26,18
+            3090: 24,18
+            3091: 22,17
+            3092: 22,20
+            3093: 26,18
+            3094: 22,18
+            3095: 20,16
+            3096: 19,16
+            3097: 27,16
+            3209: 43,21
+            3210: 43,21
+            3211: 44,21
+            3212: 42,23
+            3213: 42,23
+            3214: 42,24
+            3215: 42,24
+            3216: 43,24
+            3217: 43,23
+            3218: 43,22
+            3219: 42,22
+            3220: 42,21
+            3235: 10,21
+            3236: 10,22
+            3237: 8,22
+            3238: 8,22
+            3239: 8,21
+            3240: 7,21
+            3241: 5,21
+            3242: 4,21
+            3243: 5,22
+            3244: 5,22
+            3245: 6,22
+            3246: 6,21
+            3247: 10,22
+            3253: 12,23
+            3254: 12,22
+            3255: 12,22
+            3256: 13,22
+            3257: 12,20
+            3258: 12,20
+            3259: 12,17
+            3260: 12,19
+            3261: 12,19
+            3262: 13,22
+            3263: 13,22
+            3264: 13,19
+            3265: 13,17
+            3266: 13,16
+            3267: 13,14
+            3268: 13,12
+            3269: 13,11
+            3270: 12,12
+            3271: 12,14
+            3272: 12,15
+            3273: 12,14
+            3274: 12,13
+            3275: 13,9
+            3276: 13,8
+            3277: 12,8
+            3278: 12,8
+            3279: 11,8
+            3280: 11,9
+            3281: 12,9
+            3282: 13,8
+            3283: 13,7
+            3284: 13,6
+            3285: 13,5
+            3286: 13,4
+            3287: 14,4
+            3288: 15,4
+            3289: 12,12
+            3290: 12,15
+            3291: 17,23
+            3292: 17,22
+            3293: 16,21
+            3294: 16,20
+            3295: 17,20
+            3296: 19,21
+            3297: 18,22
+            3298: 17,23
+            3299: 16,22
+            3300: 15,21
+            3308: 16,25
+            3309: 16,27
+            3310: 17,27
+            3311: 18,27
+            3312: 18,26
+            3313: 18,25
+            3314: 20,25
+            3315: 20,25
+            3316: 21,25
+            3317: 19,27
+            3318: 23,25
+            3319: 24,25
+            3320: 25,25
+            3321: 25,27
+            3322: 23,27
+            3323: 21,27
+            3324: 21,27
+            3325: 21,27
+            3326: 21,27
+            3327: 21,27
+            3328: 21,27
+            3329: 25,26
+            3330: 26,25
+            3331: 26,25
+            3332: 24,25
+            3333: 20,25
+            3334: 20,27
+            3335: 18,27
+            3336: 18,27
+            3337: 20,26
+            3338: 21,25
+            3339: 20,25
+            3915: -23,14
+            3916: -23,15
+            3917: -22,15
+            3918: -22,16
+            3919: -19,15
+            3920: -20,15
+            3921: -19,14
+            3922: -18,14
+            3923: -17,15
+            3924: -17,16
+            3925: -19,16
+            3926: -19,14
+            3927: -19,14
+            3928: -20,14
+            3929: -21,14
+            3930: -22,14
+            3931: -21,16
+            3932: -18,16
+            3933: -17,15
+            3934: -21,16
+            3935: -22,16
+            3936: -21,17
+            3937: -21,17
+            3938: -23,15
+            3939: -23,16
+            3940: -17,14
+            3941: -22,14
+            3942: -17,16
+            3951: -25,15
+            3952: -26,15
+            3953: -25,16
+            3954: -25,16
+            3955: -25,17
+            3956: -25,18
+            3957: -26,18
+            3958: -26,18
+            3959: -26,20
+            3960: -28,19
+            3961: -28,19
+            3962: -30,19
+            3963: -29,20
+            3964: -30,21
+            3965: -28,21
+            3966: -27,21
+            3967: -27,20
+            3968: -28,21
+            3969: -28,20
+            3970: -26,21
+            3971: -25,20
+            3972: -24,20
+            3973: -24,19
+            3974: -24,19
+            3975: -26,19
+            3976: -28,23
+            3977: -28,24
+            3978: -28,24
+            3979: -28,26
+            3980: -28,26
+            3981: -28,25
+            3982: -28,26
+            3983: -28,25
+            3984: -26,16
+            3985: -25,15
+            3987: -32,19
+            3988: -33,19
+            3989: -34,19
+            3990: -33,20
+            3991: -34,21
+            3992: -34,20
+            3993: -32,21
+            3994: -32,20
+            3995: -28,15
+            3996: -29,15
+            3997: -30,16
+            3998: -29,17
+            3999: -29,16
+            4000: -29,16
+            4001: -28,17
+            4002: -28,17
+            4003: -30,15
+            4004: -29,17
+            4005: -29,17
+            4104: -13,22
+            4105: -12,22
+            4106: -12,24
+            4107: -10,22
+            4108: -9,24
+            4109: -7,24
+            4110: -8,22
+            4111: -7,22
+            4112: -9,23
+            4113: -4,22
+            4114: -3,23
+            4115: -4,24
+            4116: -3,25
+            4715: -7,42
+            4716: -5,42
+            4717: -4,42
+            4718: -5,43
+            4719: -7,43
+            4720: -6,44
+            4721: -4,44
+            4722: -4,45
+            4723: -5,43
+            4724: -6,43
+            4725: -6,44
+            4726: -6,45
+            4727: -5,44
+            4728: -4,46
+            4729: -4,47
+            4730: -3,47
+            4731: -3,48
+            4732: -4,48
+            4733: -4,47
+            4734: -4,45
             4735: -6,45
-            4736: -5,44
-            4737: -4,46
-            4738: -4,47
-            4739: -3,47
-            4740: -3,48
-            4741: -4,48
-            4742: -4,47
-            4743: -4,45
-            4744: -6,45
-            4745: -3,44
-            4746: -8,45
-            4747: -9,45
-            4748: -11,45
-            4749: -12,45
-            4750: -12,46
-            4751: -12,47
-            4752: -12,48
-            4753: -11,46
-            4754: -12,47
-            4755: -12,47
-            4756: -7,45
-            4757: -7,43
-            4758: -4,43
-            5408: 36,-28
-            5409: 36,-28
-            5410: 36,-29
-            5411: 35,-33
-            5412: 35,-33
-            5413: 36,-34
-            5414: 36,-35
-            5415: 35,-35
-            5416: 34,-35
-            5417: 34,-33
-            5418: 34,-32
-            5419: 34,-31
-            5420: 34,-29
-            5421: 34,-28
-            5422: 34,-30
-            5423: 35,-32
-            5424: 36,-31
-            5425: 34,-33
-            5426: 35,-35
-            5427: 36,-33
-            5428: 34,-28
-            5429: 36,-31
-            5430: 35,-32
-            5431: 35,-29
-            5480: 19,-30
-            5481: 17,-30
-            5944: 13,-38
-            5945: 12,-37
-            5946: 11,-37
-            5947: 11,-36
-            5948: 13,-36
-            5949: 13,-36
-            5950: 14,-36
-            5951: 12,-36
-            5952: 11,-37
-            5953: 15,-36
-            5954: 16,-37
-            5955: 13,-37
-            5956: 14,-38
-            5957: 13,-39
-            5958: 11,-39
-            5959: 10,-39
-            5960: 11,-38
-            5961: 12,-38
-            5962: 10,-37
-            5963: 10,-35
-            5964: 12,-35
-            5965: 14,-35
-            5966: 15,-35
-            5967: 16,-36
-            5968: 15,-37
-            5969: 10,-39
-            5970: 10,-38
-            5978: 18,-35
-            5979: 19,-35
-            5980: 20,-35
-            5981: 21,-35
-            5982: 22,-35
-            5983: 23,-35
-            5984: 23,-36
-            5985: 24,-37
-            5986: 25,-36
-            5987: 26,-35
-            5988: 25,-35
-            5989: 26,-36
-            5990: 25,-37
-            5991: 23,-37
-            5992: 22,-38
-            5993: 23,-38
-            5994: 25,-38
-            5995: 27,-38
-            5996: 27,-36
-            5997: 27,-35
-            5998: 21,-37
-            5999: 20,-37
-            6000: 20,-38
-            6001: 18,-38
-            6002: 18,-38
-            6003: 18,-37
-            6004: 22,-37
-            6005: 24,-37
-            6006: 23,-36
-            6007: 24,-35
-            6008: 26,-35
-            6009: 26,-36
-            6010: 26,-38
-            6011: 26,-37
-            6012: 28,-38
-            6013: 29,-37
-            6014: 29,-37
-            6015: 29,-38
-            6016: 30,-37
-            6017: 30,-35
-            6018: 29,-35
-            6019: 31,-35
-            6020: 30,-34
-            6021: 31,-34
-            6022: 31,-35
-            6023: 32,-35
-            6024: 32,-34
-            6025: 30,-34
-            6026: 30,-38
-            6031: 36,-40
-            6032: 36,-39
-            6033: 35,-38
-            6034: 33,-37
-            6035: 35,-37
-            6036: 32,-37
-            6037: 32,-39
-            6038: 32,-40
-            6039: 34,-40
-            6040: 34,-39
-            6041: 33,-38
-            6042: 34,-37
-            6043: 35,-40
-            6044: 35,-39
-            6045: 36,-37
-            6046: 36,-37
-            6047: 33,-39
-            6262: -4,-54
-            6263: -4,-54
-            6264: -3,-53
-            6265: -1,-54
-            6266: -1,-54
-            6267: 0,-54
-            6268: 0,-53
-            6269: -1,-52
-            6270: 0,-51
-            6271: -1,-51
-            6272: -2,-52
-            6273: -3,-52
-            6274: -3,-51
-            6275: -4,-51
-            6276: -4,-52
-            6277: -4,-53
-            6278: -1,-53
-            6279: -1,-52
-            6280: -1,-53
-            6281: -3,-54
-            6282: -3,-53
-            6283: -3,-54
-            6284: -1,-53
-            6285: 0,-52
-            6286: -4,-51
-            6287: -2,-54
-            6288: 0,-53
-            6289: -1,-51
-            6290: -4,-52
-            6291: 0,-52
-            6292: -1,-53
-            6293: -3,-53
-            6294: -2,-53
-            6295: -2,-53
-            6296: 0,-52
-            6333: 3,-53
-            6334: 2,-54
-            6335: 4,-55
-            6336: 3,-56
-            6337: 3,-57
-            6338: 3,-58
-            6339: 3,-60
-            6340: 2,-61
-            6341: 4,-61
-            6342: 4,-59
-            6343: 2,-59
-            6344: 2,-58
-            6345: 4,-57
-            6346: 3,-54
-            6347: 5,-56
-            6348: 1,-58
-            6349: 3,-62
-            6350: 3,-61
-            6395: -8,-60
-            6396: -8,-60
-            6397: -7,-61
-            6398: -5,-61
-            6399: -2,-61
-            6400: -4,-61
-            6401: 0,-61
-            6402: 0,-60
-            6403: 0,-58
-            6404: -4,-56
-            6405: -6,-56
-            6406: -7,-56
-            6407: -8,-57
-            6408: -2,-56
-            6451: -15,-57
-            6452: -16,-57
-            6453: -15,-57
-            6454: -11,-57
-            6455: -11,-57
-            6456: -13,-61
-            6457: -15,-61
-            6458: -16,-61
-            6459: -15,-60
-            6460: -13,-60
-            6461: -14,-60
-            6462: -16,-61
-            6463: -21,-64
-            6464: -21,-63
-            6465: -19,-63
-            6466: -18,-63
-            6467: -19,-62
-            6468: -21,-62
-            6469: -19,-60
-            6470: -21,-60
-            6471: -20,-59
-            6472: -19,-59
-            6473: -19,-57
-            6474: -21,-59
-            6475: -21,-56
-            6476: -19,-56
-            6477: -18,-58
-            6478: -16,-59
-            6479: -15,-58
-            6480: -15,-59
-            6481: -13,-57
-            6482: -12,-58
-            6483: -11,-60
-            6484: -10,-59
-            6485: -9,-59
-            6486: -14,-59
-            6487: -11,-58
-            6488: -8,-59
-            6489: -6,-58
-            6490: -6,-59
-            6491: -4,-58
-            6492: -3,-59
-            6493: -1,-60
-            6494: -1,-57
-            6495: -6,-57
-            6496: -7,-58
-            6497: -7,-60
-            6498: -2,-60
-            6499: -2,-58
-            6710: -7,-76
-            6711: -8,-76
-            6712: -7,-75
-            6713: -6,-74
-            6714: -8,-73
-            6715: -6,-72
-            6716: -5,-71
-            6717: -7,-71
-            6718: -8,-72
-            6719: -7,-72
-            6720: -8,-69
-            6721: -7,-68
-            6722: -6,-70
-            6723: -7,-71
-            6724: -7,-68
-            6725: -8,-65
-            6726: -6,-64
-            6727: -6,-66
-            6728: -6,-68
-            6729: -6,-68
-            6730: -5,-64
-            6731: -5,-64
-            6732: -5,-65
-            6733: -3,-63
-            6734: -3,-64
-            6735: -4,-65
-            6736: -1,-64
-            6737: -1,-63
-            6738: -4,-65
-            6739: -3,-67
-            6740: -3,-66
-            6741: -2,-63
-            6742: -1,-63
-            6743: -1,-65
-            6744: 2,-64
-            6745: 0,-63
-            6746: 0,-64
-            6747: 4,-64
-            6748: 5,-64
-            6749: 5,-67
-            6750: 4,-66
-            6751: 4,-66
-            6752: 3,-64
-            6753: 5,-63
-            6754: 7,-64
-            6755: 7,-66
-            6756: 6,-68
-            6757: 8,-69
-            6758: 6,-67
-            6759: 7,-65
-            6760: 8,-64
-            6761: 8,-65
-            6762: 8,-67
-            6763: 8,-69
-            6764: 6,-69
-            6765: 6,-69
-            6766: 6,-71
-            6767: 9,-71
-            6768: 7,-70
-            6769: 6,-72
-            6770: 7,-72
-            6771: 8,-73
-            6772: 7,-74
-            6773: 5,-72
-            6774: 6,-74
-            6775: 7,-75
-            6776: 5,-77
-            6777: 5,-74
-            6778: 5,-73
-            6779: 5,-75
-            6780: 4,-76
-            6781: 3,-73
-            6782: 3,-73
-            6783: 3,-76
-            6784: 2,-76
-            6785: 2,-75
-            6786: -1,-74
-            6787: 0,-76
-            6788: 1,-77
-            6789: -2,-76
-            6790: -1,-73
-            6791: -2,-75
-            6792: -2,-77
-            6793: -3,-76
-            6794: -3,-74
-            6795: -5,-75
-            6796: -6,-76
-            6797: -6,-74
-            6798: -4,-75
-            6799: -2,-77
-            6800: -3,-73
-            6801: -3,-76
-            6802: 1,-74
-            6803: 0,-73
-            6804: 2,-76
-            6805: 4,-74
-            6806: 5,-73
-            6807: 8,-72
-            6808: 10,-71
-            6809: 10,-69
-            6810: 11,-69
-            6811: 13,-71
-            6812: 12,-69
-            6813: 13,-69
-            6814: 14,-67
-            6815: 12,-65
-            6816: 10,-65
-            6817: 11,-64
-            6818: 13,-65
-            6819: 14,-64
-            6820: 12,-63
-            6821: 9,-64
-            6822: 12,-62
-            6823: 11,-61
-            6824: 13,-60
-            6825: 13,-61
-            6826: 13,-58
-            6827: 11,-58
-            6828: 10,-60
-            6829: 13,-61
-            6830: 13,-61
-            6831: 11,-59
-            6832: 12,-58
-            6833: 13,-59
-            7224: 8,-38
-            7225: 8,-38
-            7226: 8,-35
-            7227: 7,-35
-            7228: 6,-35
-            7229: 4,-35
-            7230: 4,-35
-            7231: 4,-38
-            7232: 6,-37
-            7233: 7,-37
-            7234: 6,-38
-            7235: 4,-37
-            7236: 6,-35
-            7250: 38,-41
-            7251: 38,-41
-            7252: 38,-39
-            7253: 38,-38
-            7254: 39,-37
-            7255: 39,-37
-            7256: 39,-39
-            7257: 40,-40
-            7258: 40,-40
-            7259: 41,-40
-            7260: 41,-38
-            7261: 42,-37
-            7262: 43,-39
-            7263: 43,-40
-            7264: 44,-40
-            7265: 45,-39
-            7266: 45,-38
-            7267: 45,-38
-            7268: 46,-40
-            7269: 46,-41
-            7270: 47,-41
-            7271: 47,-38
-            7272: 46,-37
-            7273: 43,-37
-            7274: 43,-38
-            7275: 42,-38
-            7276: 41,-41
-            7277: 40,-39
-            7278: 39,-40
-            7279: 39,-40
-            7280: 38,-37
-            7281: 40,-39
-            7282: 45,-41
-            7283: 46,-41
-            7284: 47,-39
-            7285: 44,-41
-            7286: 42,-41
-            7287: 44,-39
-            7288: 42,-38
-            7289: 42,-38
-            7290: 38,-37
-            7291: 29,-12
-            7292: 28,-13
-            7293: 28,-13
-            7294: 28,-12
-            7295: 28,-11
-            7296: 30,-11
-            7297: 30,-12
-            7298: 29,-13
-            7304: 6,-14
-            7305: 5,-14
-            7306: 4,-14
-            7307: 4,-13
-            7308: 6,-12
-            7309: 6,-13
-            7310: 6,-14
-            7311: 4,-12
-            7312: 4,-13
-            7352: -48,-16
-            7353: -48,-17
-            7354: -48,-19
-            7355: -49,-20
-            7356: -46,-24
-            7357: -45,-22
-            7358: -43,-21
-            7359: -43,-23
-            7360: -42,-23
-            7361: -41,-23
-            7362: -44,-16
+            4736: -3,44
+            4737: -8,45
+            4738: -9,45
+            4739: -11,45
+            4740: -12,45
+            4741: -12,46
+            4742: -12,47
+            4743: -12,48
+            4744: -11,46
+            4745: -12,47
+            4746: -12,47
+            4747: -7,45
+            4748: -7,43
+            4749: -4,43
+            5399: 36,-28
+            5400: 36,-28
+            5401: 36,-29
+            5402: 35,-33
+            5403: 35,-33
+            5404: 36,-34
+            5405: 36,-35
+            5406: 35,-35
+            5407: 34,-35
+            5408: 34,-33
+            5409: 34,-32
+            5410: 34,-31
+            5411: 34,-29
+            5412: 34,-28
+            5413: 34,-30
+            5414: 35,-32
+            5415: 36,-31
+            5416: 34,-33
+            5417: 35,-35
+            5418: 36,-33
+            5419: 34,-28
+            5420: 36,-31
+            5421: 35,-32
+            5422: 35,-29
+            5471: 19,-30
+            5472: 17,-30
+            5935: 13,-38
+            5936: 12,-37
+            5937: 11,-37
+            5938: 11,-36
+            5939: 13,-36
+            5940: 13,-36
+            5941: 14,-36
+            5942: 12,-36
+            5943: 11,-37
+            5944: 15,-36
+            5945: 16,-37
+            5946: 13,-37
+            5947: 14,-38
+            5948: 13,-39
+            5949: 11,-39
+            5950: 10,-39
+            5951: 11,-38
+            5952: 12,-38
+            5953: 10,-37
+            5954: 10,-35
+            5955: 12,-35
+            5956: 14,-35
+            5957: 15,-35
+            5958: 16,-36
+            5959: 15,-37
+            5960: 10,-39
+            5961: 10,-38
+            5969: 18,-35
+            5970: 19,-35
+            5971: 20,-35
+            5972: 21,-35
+            5973: 22,-35
+            5974: 23,-35
+            5975: 23,-36
+            5976: 24,-37
+            5977: 25,-36
+            5978: 26,-35
+            5979: 25,-35
+            5980: 26,-36
+            5981: 25,-37
+            5982: 23,-37
+            5983: 22,-38
+            5984: 23,-38
+            5985: 25,-38
+            5986: 27,-38
+            5987: 27,-36
+            5988: 27,-35
+            5989: 21,-37
+            5990: 20,-37
+            5991: 20,-38
+            5992: 18,-38
+            5993: 18,-38
+            5994: 18,-37
+            5995: 22,-37
+            5996: 24,-37
+            5997: 23,-36
+            5998: 24,-35
+            5999: 26,-35
+            6000: 26,-36
+            6001: 26,-38
+            6002: 26,-37
+            6003: 28,-38
+            6004: 29,-37
+            6005: 29,-37
+            6006: 29,-38
+            6007: 30,-37
+            6008: 30,-35
+            6009: 29,-35
+            6010: 31,-35
+            6011: 30,-34
+            6012: 31,-34
+            6013: 31,-35
+            6014: 32,-35
+            6015: 32,-34
+            6016: 30,-34
+            6017: 30,-38
+            6022: 36,-40
+            6023: 36,-39
+            6024: 35,-38
+            6025: 33,-37
+            6026: 35,-37
+            6027: 32,-37
+            6028: 32,-39
+            6029: 32,-40
+            6030: 34,-40
+            6031: 34,-39
+            6032: 33,-38
+            6033: 34,-37
+            6034: 35,-40
+            6035: 35,-39
+            6036: 36,-37
+            6037: 36,-37
+            6038: 33,-39
+            6253: -4,-54
+            6254: -4,-54
+            6255: -3,-53
+            6256: -1,-54
+            6257: -1,-54
+            6258: 0,-54
+            6259: 0,-53
+            6260: -1,-52
+            6261: 0,-51
+            6262: -1,-51
+            6263: -2,-52
+            6264: -3,-52
+            6265: -3,-51
+            6266: -4,-51
+            6267: -4,-52
+            6268: -4,-53
+            6269: -1,-53
+            6270: -1,-52
+            6271: -1,-53
+            6272: -3,-54
+            6273: -3,-53
+            6274: -3,-54
+            6275: -1,-53
+            6276: 0,-52
+            6277: -4,-51
+            6278: -2,-54
+            6279: 0,-53
+            6280: -1,-51
+            6281: -4,-52
+            6282: 0,-52
+            6283: -1,-53
+            6284: -3,-53
+            6285: -2,-53
+            6286: -2,-53
+            6287: 0,-52
+            6324: 3,-53
+            6325: 2,-54
+            6326: 4,-55
+            6327: 3,-56
+            6328: 3,-57
+            6329: 3,-58
+            6330: 3,-60
+            6331: 2,-61
+            6332: 4,-61
+            6333: 4,-59
+            6334: 2,-59
+            6335: 2,-58
+            6336: 4,-57
+            6337: 3,-54
+            6338: 5,-56
+            6339: 1,-58
+            6340: 3,-62
+            6341: 3,-61
+            6386: -8,-60
+            6387: -8,-60
+            6388: -7,-61
+            6389: -5,-61
+            6390: -2,-61
+            6391: -4,-61
+            6392: 0,-61
+            6393: 0,-60
+            6394: 0,-58
+            6395: -4,-56
+            6396: -6,-56
+            6397: -7,-56
+            6398: -8,-57
+            6399: -2,-56
+            6442: -15,-57
+            6443: -16,-57
+            6444: -15,-57
+            6445: -11,-57
+            6446: -11,-57
+            6447: -13,-61
+            6448: -15,-61
+            6449: -16,-61
+            6450: -15,-60
+            6451: -13,-60
+            6452: -14,-60
+            6453: -16,-61
+            6454: -21,-64
+            6455: -21,-63
+            6456: -19,-63
+            6457: -18,-63
+            6458: -19,-62
+            6459: -21,-62
+            6460: -19,-60
+            6461: -21,-60
+            6462: -20,-59
+            6463: -19,-59
+            6464: -19,-57
+            6465: -21,-59
+            6466: -21,-56
+            6467: -19,-56
+            6468: -18,-58
+            6469: -16,-59
+            6470: -15,-58
+            6471: -15,-59
+            6472: -13,-57
+            6473: -12,-58
+            6474: -11,-60
+            6475: -10,-59
+            6476: -9,-59
+            6477: -14,-59
+            6478: -11,-58
+            6479: -8,-59
+            6480: -6,-58
+            6481: -6,-59
+            6482: -4,-58
+            6483: -3,-59
+            6484: -1,-60
+            6485: -1,-57
+            6486: -6,-57
+            6487: -7,-58
+            6488: -7,-60
+            6489: -2,-60
+            6490: -2,-58
+            6701: -7,-76
+            6702: -8,-76
+            6703: -7,-75
+            6704: -6,-74
+            6705: -8,-73
+            6706: -6,-72
+            6707: -5,-71
+            6708: -7,-71
+            6709: -8,-72
+            6710: -7,-72
+            6711: -8,-69
+            6712: -7,-68
+            6713: -6,-70
+            6714: -7,-71
+            6715: -7,-68
+            6716: -8,-65
+            6717: -6,-64
+            6718: -6,-66
+            6719: -6,-68
+            6720: -6,-68
+            6721: -5,-64
+            6722: -5,-64
+            6723: -5,-65
+            6724: -3,-63
+            6725: -3,-64
+            6726: -4,-65
+            6727: -1,-64
+            6728: -1,-63
+            6729: -4,-65
+            6730: -3,-67
+            6731: -3,-66
+            6732: -2,-63
+            6733: -1,-63
+            6734: -1,-65
+            6735: 2,-64
+            6736: 0,-63
+            6737: 0,-64
+            6738: 4,-64
+            6739: 5,-64
+            6740: 5,-67
+            6741: 4,-66
+            6742: 4,-66
+            6743: 3,-64
+            6744: 5,-63
+            6745: 7,-64
+            6746: 7,-66
+            6747: 6,-68
+            6748: 8,-69
+            6749: 6,-67
+            6750: 7,-65
+            6751: 8,-64
+            6752: 8,-65
+            6753: 8,-67
+            6754: 8,-69
+            6755: 6,-69
+            6756: 6,-69
+            6757: 6,-71
+            6758: 9,-71
+            6759: 7,-70
+            6760: 6,-72
+            6761: 7,-72
+            6762: 8,-73
+            6763: 7,-74
+            6764: 5,-72
+            6765: 6,-74
+            6766: 7,-75
+            6767: 5,-77
+            6768: 5,-74
+            6769: 5,-73
+            6770: 5,-75
+            6771: 4,-76
+            6772: 3,-73
+            6773: 3,-73
+            6774: 3,-76
+            6775: 2,-76
+            6776: 2,-75
+            6777: -1,-74
+            6778: 0,-76
+            6779: 1,-77
+            6780: -2,-76
+            6781: -1,-73
+            6782: -2,-75
+            6783: -2,-77
+            6784: -3,-76
+            6785: -3,-74
+            6786: -5,-75
+            6787: -6,-76
+            6788: -6,-74
+            6789: -4,-75
+            6790: -2,-77
+            6791: -3,-73
+            6792: -3,-76
+            6793: 1,-74
+            6794: 0,-73
+            6795: 2,-76
+            6796: 4,-74
+            6797: 5,-73
+            6798: 8,-72
+            6799: 10,-71
+            6800: 10,-69
+            6801: 11,-69
+            6802: 13,-71
+            6803: 12,-69
+            6804: 13,-69
+            6805: 14,-67
+            6806: 12,-65
+            6807: 10,-65
+            6808: 11,-64
+            6809: 13,-65
+            6810: 14,-64
+            6811: 12,-63
+            6812: 9,-64
+            6813: 12,-62
+            6814: 11,-61
+            6815: 13,-60
+            6816: 13,-61
+            6817: 13,-58
+            6818: 11,-58
+            6819: 10,-60
+            6820: 13,-61
+            6821: 13,-61
+            6822: 11,-59
+            6823: 12,-58
+            6824: 13,-59
+            7215: 8,-38
+            7216: 8,-38
+            7217: 8,-35
+            7218: 7,-35
+            7219: 6,-35
+            7220: 4,-35
+            7221: 4,-35
+            7222: 4,-38
+            7223: 6,-37
+            7224: 7,-37
+            7225: 6,-38
+            7226: 4,-37
+            7227: 6,-35
+            7241: 38,-41
+            7242: 38,-41
+            7243: 38,-39
+            7244: 38,-38
+            7245: 39,-37
+            7246: 39,-37
+            7247: 39,-39
+            7248: 40,-40
+            7249: 40,-40
+            7250: 41,-40
+            7251: 41,-38
+            7252: 42,-37
+            7253: 43,-39
+            7254: 43,-40
+            7255: 44,-40
+            7256: 45,-39
+            7257: 45,-38
+            7258: 45,-38
+            7259: 46,-40
+            7260: 46,-41
+            7261: 47,-41
+            7262: 47,-38
+            7263: 46,-37
+            7264: 43,-37
+            7265: 43,-38
+            7266: 42,-38
+            7267: 41,-41
+            7268: 40,-39
+            7269: 39,-40
+            7270: 39,-40
+            7271: 38,-37
+            7272: 40,-39
+            7273: 45,-41
+            7274: 46,-41
+            7275: 47,-39
+            7276: 44,-41
+            7277: 42,-41
+            7278: 44,-39
+            7279: 42,-38
+            7280: 42,-38
+            7281: 38,-37
+            7282: 29,-12
+            7283: 28,-13
+            7284: 28,-13
+            7285: 28,-12
+            7286: 28,-11
+            7287: 30,-11
+            7288: 30,-12
+            7289: 29,-13
+            7295: 6,-14
+            7296: 5,-14
+            7297: 4,-14
+            7298: 4,-13
+            7299: 6,-12
+            7300: 6,-13
+            7301: 6,-14
+            7302: 4,-12
+            7303: 4,-13
+            7343: -48,-16
+            7344: -48,-17
+            7345: -48,-19
+            7346: -49,-20
+            7347: -46,-24
+            7348: -45,-22
+            7349: -43,-21
+            7350: -43,-23
+            7351: -42,-23
+            7352: -41,-23
+            7353: -44,-16
+            7354: -45,-17
+            7355: -46,-18
+            7356: -46,-20
+            7357: -47,-22
+            7358: -47,-22
+            7359: -44,-21
+            7360: -42,-18
+            7361: -45,-17
+            7362: -46,-17
             7363: -45,-17
             7364: -46,-18
-            7365: -46,-20
-            7366: -47,-22
-            7367: -47,-22
-            7368: -44,-21
-            7369: -42,-18
-            7370: -45,-17
-            7371: -46,-17
-            7372: -45,-17
-            7373: -46,-18
-            7374: -45,-21
-            7375: -42,-22
-            7376: -41,-23
-            7413: -49,-21
-            7414: -49,-22
-            7415: -49,-23
-            7416: -48,-24
-            7417: -47,-23
-            7418: -47,-21
-            7419: -47,-18
-            7420: -48,-19
-            7421: -48,-18
-            7422: -48,-16
-            7423: -48,-16
-            7424: -49,-16
-            7425: -43,-16
-            7426: -41,-17
-            7427: -43,-18
-            7428: -44,-18
-            7429: -42,-20
-            7430: -40,-21
-            7431: -42,-19
-            7432: -43,-18
-            7433: -41,-21
-            7434: -41,-24
-            7435: -45,-24
-            7436: -45,-23
-            7437: -41,-20
+            7365: -45,-21
+            7366: -42,-22
+            7367: -41,-23
+            7404: -49,-21
+            7405: -49,-22
+            7406: -49,-23
+            7407: -48,-24
+            7408: -47,-23
+            7409: -47,-21
+            7410: -47,-18
+            7411: -48,-19
+            7412: -48,-18
+            7413: -48,-16
+            7414: -48,-16
+            7415: -49,-16
+            7416: -43,-16
+            7417: -41,-17
+            7418: -43,-18
+            7419: -44,-18
+            7420: -42,-20
+            7421: -40,-21
+            7422: -42,-19
+            7423: -43,-18
+            7424: -41,-21
+            7425: -41,-24
+            7426: -45,-24
+            7427: -45,-23
+            7428: -41,-20
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtHeavy
           decals:
-            7344: 43.129646,-38.225346
-            7345: 43,-38
+            7335: 43.129646,-38.225346
+            7336: 43,-38
         - node:
             color: '#FFFFFFFF'
             id: DirtHeavyMonotile
           decals:
-            1389: -39,-33
-            1390: -39,-33
-            1391: -39,-33
-            1392: -39,-33
-            1393: -39,-33
+            1380: -39,-33
+            1381: -39,-33
+            1382: -39,-33
+            1383: -39,-33
+            1384: -39,-33
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtHeavyMonotile
           decals:
-            7349: 47,-37
-            7350: 47,-37
+            7340: 47,-37
+            7341: 47,-37
         - node:
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            1826: -19,-34
-            1827: -19,-34
-            1828: -19,-34
-            1829: -18,-33
-            1830: -18,-32
-            1831: -18,-31
-            1832: -19,-31
-            1833: -17,-34
-            1834: -17,-33
-            1835: -17,-32
-            1836: -17,-31
-            1900: -17,-50
-            1901: -18,-50
-            1902: -18,-48
-            1903: -17,-48
-            1904: -17,-49
-            1905: -17,-46
-            1906: -18,-46
-            1907: -17,-45
-            1908: -16,-47
-            1909: -17,-46
-            1910: -17,-44
-            1911: -18,-43
-            1912: -17,-43
-            1913: -16,-43
-            1914: -16,-42
-            1915: -17,-40
-            1916: -18,-39
-            1917: -16,-40
-            1918: -16,-41
-            1919: -18,-37
-            1920: -17,-36
-            1921: -17,-37
-            1922: -17,-38
-            1923: -17,-36
-            1924: -17,-38
-            1925: -13,-33
-            1926: -13,-32
-            1927: -12,-32
-            1928: -12,-33
-            1929: -11,-31
-            1930: -13,-33
-            1931: -8,-40
-            1932: -9,-41
-            1933: -8,-43
-            1934: -8,-44
-            1935: -8,-45
-            1936: -9,-46
-            1937: -9,-44
-            1938: -8,-43
+            1817: -19,-34
+            1818: -19,-34
+            1819: -19,-34
+            1820: -18,-33
+            1821: -18,-32
+            1822: -18,-31
+            1823: -19,-31
+            1824: -17,-34
+            1825: -17,-33
+            1826: -17,-32
+            1827: -17,-31
+            1891: -17,-50
+            1892: -18,-50
+            1893: -18,-48
+            1894: -17,-48
+            1895: -17,-49
+            1896: -17,-46
+            1897: -18,-46
+            1898: -17,-45
+            1899: -16,-47
+            1900: -17,-46
+            1901: -17,-44
+            1902: -18,-43
+            1903: -17,-43
+            1904: -16,-43
+            1905: -16,-42
+            1906: -17,-40
+            1907: -18,-39
+            1908: -16,-40
+            1909: -16,-41
+            1910: -18,-37
+            1911: -17,-36
+            1912: -17,-37
+            1913: -17,-38
+            1914: -17,-36
+            1915: -17,-38
+            1916: -13,-33
+            1917: -13,-32
+            1918: -12,-32
+            1919: -12,-33
+            1920: -11,-31
+            1921: -13,-33
+            1922: -8,-40
+            1923: -9,-41
+            1924: -8,-43
+            1925: -8,-44
+            1926: -8,-45
+            1927: -9,-46
+            1928: -9,-44
+            1929: -8,-43
+            1930: -7,-41
+            1931: -7,-40
+            1932: -8,-42
+            1933: -9,-46
+            1934: -8,-45
+            1935: -8,-42
+            1936: -8,-43
+            1937: -8,-44
+            1938: -8,-42
             1939: -7,-41
-            1940: -7,-40
-            1941: -8,-42
-            1942: -9,-46
-            1943: -8,-45
-            1944: -8,-42
-            1945: -8,-43
-            1946: -8,-44
-            1947: -8,-42
-            1948: -7,-41
-            1949: -7,-44
-            1950: -7,-44
-            1951: -8,-44
-            1952: -7,-43
-            1953: -9,-43
-            1954: -7,-44
-            2320: -44,-48
-            2321: -44,-47
-            2322: -43,-46
-            2323: -43,-47
-            2324: -42,-48
-            2325: -42,-46
-            2326: -43,-47
-            2327: -43,-48
-            2328: -42,-46
-            2329: -40,-46
-            2330: -40,-47
-            2331: -44,-53
-            2332: -44,-53
-            2333: -44,-53
-            2334: -42,-53
+            1940: -7,-44
+            1941: -7,-44
+            1942: -8,-44
+            1943: -7,-43
+            1944: -9,-43
+            1945: -7,-44
+            2311: -44,-48
+            2312: -44,-47
+            2313: -43,-46
+            2314: -43,-47
+            2315: -42,-48
+            2316: -42,-46
+            2317: -43,-47
+            2318: -43,-48
+            2319: -42,-46
+            2320: -40,-46
+            2321: -40,-47
+            2322: -44,-53
+            2323: -44,-53
+            2324: -44,-53
+            2325: -42,-53
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            7346: 44,-37
-            7347: 40,-37
+            7337: 44,-37
+            7338: 40,-37
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtMedium
           decals:
-            7348: 41,-37
+            7339: 41,-37
         - node:
             color: '#FFFFFFFF'
             id: Flowersbr2
           decals:
-            6050: 14,-26
+            6041: 14,-26
         - node:
             color: '#FFFFFFFF'
             id: Flowersbr3
           decals:
-            6051: 14,-27
+            6042: 14,-27
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv1
           decals:
-            6059: 3,47
+            6050: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv2
           decals:
-            6058: 3,48
+            6049: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv3
           decals:
-            6057: 3,49
+            6048: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Flowersy1
@@ -3651,9 +3651,9 @@ entities:
             363: 5,-4
             403: 3,6
             404: -8,3
-            3691: 40,-9
-            3692: 34,-8
-            3700: 32,-3
+            3682: 40,-9
+            3683: 34,-8
+            3691: 32,-3
         - node:
             color: '#FFFFFFFF'
             id: Flowersy2
@@ -3806,113 +3806,113 @@ entities:
             259: -3,-4
             260: -4,-3
             454: -8,6
-            3740: 36,-3
-            3741: 36,-4
-            3742: 33,-3
-            3743: 33,-4
-            3744: 41,-4
-            3745: 42,-4
-            3746: 43,-4
-            3747: 44,-4
-            3748: 44,-5
-            3749: 44,-6
-            3750: 44,-7
-            3751: 44,-8
-            3752: 44,-9
-            3753: 44,-10
-            3754: 44,-11
-            3755: 44,-12
-            3756: 44,-13
-            3757: 43,-13
-            3758: 42,-13
-            3759: 41,-13
-            3760: 40,-13
-            3761: 39,-13
-            3762: 35,-13
-            3763: 34,-13
-            3764: 33,-13
-            3765: 32,-13
-            3768: 45,-13
-            3769: 45,-7
-            3770: 45,-5
-            4843: 0,49
-            4844: 1,49
-            4845: 0,50
-            4846: 1,50
-            4847: 1,51
-            4848: 0,51
-            4849: 0,52
-            4850: 1,52
-            4851: 1,53
-            4852: 0,53
-            4853: 2,53
-            4854: 2,52
-            4855: 2,51
-            4856: -1,53
-            4857: -1,52
-            4858: -1,51
-            4863: 2,54
-            4864: 2,55
-            4865: 1,55
-            4866: 0,55
-            4867: -1,55
-            4868: -1,54
-            4869: -1,57
-            4870: -1,56
-            4871: 0,56
-            4872: 1,56
-            4873: 2,56
-            4874: 2,57
-            4879: -1,58
-            4880: -1,59
-            4881: -1,60
-            4882: -1,61
-            4883: -1,62
-            4884: 0,62
-            4885: 1,62
-            4886: 2,62
-            4887: 2,61
-            4888: 2,60
-            4889: 2,59
-            4890: 2,58
-            4891: 1,58
-            4892: 0,58
-            4893: 0,59
-            4894: 0,60
-            4895: 0,61
-            4896: 1,61
-            4897: 1,60
-            4898: 1,59
-            4899: -2,60
-            4900: -2,59
-            4901: -2,61
-            4902: -2,62
-            4903: 3,62
-            4904: 3,61
-            4905: 3,60
-            4906: 3,59
-            4907: 4,60
-            4908: 4,61
-            4909: -3,61
-            4910: -3,60
-            4911: -4,61
-            4912: 5,61
-            4913: 6,61
-            4914: 6,60
-            4915: 6,59
-            4916: 6,58
-            4917: -5,61
-            4918: -5,60
-            4919: -6,60
-            4920: -6,59
-            4921: -6,58
-            4922: -5,58
-            4923: -5,59
-            4924: -5,62
-            4925: 6,62
-            4993: 7,58
-            4994: 7,59
-            4995: 7,60
+            3731: 36,-3
+            3732: 36,-4
+            3733: 33,-3
+            3734: 33,-4
+            3735: 41,-4
+            3736: 42,-4
+            3737: 43,-4
+            3738: 44,-4
+            3739: 44,-5
+            3740: 44,-6
+            3741: 44,-7
+            3742: 44,-8
+            3743: 44,-9
+            3744: 44,-10
+            3745: 44,-11
+            3746: 44,-12
+            3747: 44,-13
+            3748: 43,-13
+            3749: 42,-13
+            3750: 41,-13
+            3751: 40,-13
+            3752: 39,-13
+            3753: 35,-13
+            3754: 34,-13
+            3755: 33,-13
+            3756: 32,-13
+            3759: 45,-13
+            3760: 45,-7
+            3761: 45,-5
+            4834: 0,49
+            4835: 1,49
+            4836: 0,50
+            4837: 1,50
+            4838: 1,51
+            4839: 0,51
+            4840: 0,52
+            4841: 1,52
+            4842: 1,53
+            4843: 0,53
+            4844: 2,53
+            4845: 2,52
+            4846: 2,51
+            4847: -1,53
+            4848: -1,52
+            4849: -1,51
+            4854: 2,54
+            4855: 2,55
+            4856: 1,55
+            4857: 0,55
+            4858: -1,55
+            4859: -1,54
+            4860: -1,57
+            4861: -1,56
+            4862: 0,56
+            4863: 1,56
+            4864: 2,56
+            4865: 2,57
+            4870: -1,58
+            4871: -1,59
+            4872: -1,60
+            4873: -1,61
+            4874: -1,62
+            4875: 0,62
+            4876: 1,62
+            4877: 2,62
+            4878: 2,61
+            4879: 2,60
+            4880: 2,59
+            4881: 2,58
+            4882: 1,58
+            4883: 0,58
+            4884: 0,59
+            4885: 0,60
+            4886: 0,61
+            4887: 1,61
+            4888: 1,60
+            4889: 1,59
+            4890: -2,60
+            4891: -2,59
+            4892: -2,61
+            4893: -2,62
+            4894: 3,62
+            4895: 3,61
+            4896: 3,60
+            4897: 3,59
+            4898: 4,60
+            4899: 4,61
+            4900: -3,61
+            4901: -3,60
+            4902: -4,61
+            4903: 5,61
+            4904: 6,61
+            4905: 6,60
+            4906: 6,59
+            4907: 6,58
+            4908: -5,61
+            4909: -5,60
+            4910: -6,60
+            4911: -6,59
+            4912: -6,58
+            4913: -5,58
+            4914: -5,59
+            4915: -5,62
+            4916: 6,62
+            4984: 7,58
+            4985: 7,59
+            4986: 7,60
         - node:
             color: '#222222E6'
             id: FullTileOverlayGreyscale
@@ -3936,163 +3936,163 @@ entities:
             492: -9,14
             493: -9,15
             494: -9,16
-            4630: 1,26
-            4805: 1,46
-            4806: 2,46
-            4807: 3,46
-            4808: 4,46
-            4809: 4,47
-            4810: 4,48
-            4811: 4,49
-            4812: 4,50
-            4813: 3,50
-            4814: 5,47
-            4934: 0,59
-            4935: 1,59
-            4936: -1,53
-            4937: -1,52
-            4938: 0,52
-            4939: 1,52
-            4940: 2,52
-            4941: 2,53
-            4951: 2,50
-            4952: 2,54
-            4953: -1,54
-            4954: -1,55
-            4955: -1,56
-            4956: -1,57
-            4957: 2,57
-            4958: 2,56
-            4959: 2,55
-            4960: -1,58
-            4961: -1,59
-            4962: 2,58
-            4963: 2,59
-            4964: -2,59
-            4965: 3,59
-            4966: -2,60
-            4967: -3,60
-            4968: 3,60
-            4969: 4,60
-            4970: -3,61
-            4971: -4,61
-            4972: 4,61
-            4973: 5,61
-            5050: 3,70
-            5051: 2,70
-            5052: 0,70
-            5053: -1,70
-            5054: -2,70
-            5055: 4,70
-            5056: -3,70
-            5057: -4,70
-            5058: -5,70
-            5059: -6,70
-            5060: -3,69
-            5061: -4,69
-            5062: -5,69
-            5063: 5,70
-            5064: 5,69
-            5065: 6,69
-            5066: 6,70
-            5067: 7,69
-            5068: 7,70
-            5069: 8,70
-            5076: -5,71
-            5077: 7,71
-            5078: 7,72
-            5079: -5,72
-            5099: 3,85
-            5100: 2,85
-            5101: 1,85
-            5102: 0,85
-            5103: -1,85
-            5106: -2,84
-            5107: -3,84
-            5108: -4,84
-            5109: -5,84
-            5110: -5,83
-            5111: -5,82
-            5112: -5,81
-            5113: -5,80
-            5114: -5,79
-            5115: -5,78
-            5116: -5,75
-            5117: -5,74
-            5118: -5,73
-            6502: 3,26
-            6508: 4,26
-            6510: 4,27
-            6511: 4,25
-            6513: 4,24
+            4621: 1,26
+            4796: 1,46
+            4797: 2,46
+            4798: 3,46
+            4799: 4,46
+            4800: 4,47
+            4801: 4,48
+            4802: 4,49
+            4803: 4,50
+            4804: 3,50
+            4805: 5,47
+            4925: 0,59
+            4926: 1,59
+            4927: -1,53
+            4928: -1,52
+            4929: 0,52
+            4930: 1,52
+            4931: 2,52
+            4932: 2,53
+            4942: 2,50
+            4943: 2,54
+            4944: -1,54
+            4945: -1,55
+            4946: -1,56
+            4947: -1,57
+            4948: 2,57
+            4949: 2,56
+            4950: 2,55
+            4951: -1,58
+            4952: -1,59
+            4953: 2,58
+            4954: 2,59
+            4955: -2,59
+            4956: 3,59
+            4957: -2,60
+            4958: -3,60
+            4959: 3,60
+            4960: 4,60
+            4961: -3,61
+            4962: -4,61
+            4963: 4,61
+            4964: 5,61
+            5041: 3,70
+            5042: 2,70
+            5043: 0,70
+            5044: -1,70
+            5045: -2,70
+            5046: 4,70
+            5047: -3,70
+            5048: -4,70
+            5049: -5,70
+            5050: -6,70
+            5051: -3,69
+            5052: -4,69
+            5053: -5,69
+            5054: 5,70
+            5055: 5,69
+            5056: 6,69
+            5057: 6,70
+            5058: 7,69
+            5059: 7,70
+            5060: 8,70
+            5067: -5,71
+            5068: 7,71
+            5069: 7,72
+            5070: -5,72
+            5090: 3,85
+            5091: 2,85
+            5092: 1,85
+            5093: 0,85
+            5094: -1,85
+            5097: -2,84
+            5098: -3,84
+            5099: -4,84
+            5100: -5,84
+            5101: -5,83
+            5102: -5,82
+            5103: -5,81
+            5104: -5,80
+            5105: -5,79
+            5106: -5,78
+            5107: -5,75
+            5108: -5,74
+            5109: -5,73
+            6493: 3,26
+            6499: 4,26
+            6501: 4,27
+            6502: 4,25
+            6504: 4,24
         - node:
             color: '#50BCB193'
             id: FullTileOverlayGreyscale
           decals:
-            3353: 29,17
-            3354: 29,18
-            3355: 29,19
-            3356: 29,20
-            3357: 29,21
-            3358: 29,22
-            3359: 29,23
-            3360: 30,23
-            3361: 32,23
-            3362: 32,23
-            3363: 33,23
-            3364: 34,23
-            3365: 29,24
-            3366: 29,25
-            3367: 29,26
-            3368: 29,27
-            3369: 29,28
-            3370: 30,28
-            3371: 31,28
-            3391: 40,28
-            3392: 38,27
-            3393: 38,26
-            3394: 38,25
-            3395: 41,28
-            3396: 42,28
-            3397: 43,28
-            3398: 43,27
-            3399: 43,29
-            3400: 43,30
-            3445: 43,31
-            3446: 43,32
-            3447: 44,32
-            3448: 45,32
-            3449: 43,33
-            3450: 43,34
-            3451: 43,35
-            3452: 42,35
-            3453: 41,35
-            3454: 43,36
-            3455: 43,37
-            3456: 43,38
-            3457: 42,38
-            3458: 41,38
-            3459: 43,39
-            3460: 44,39
-            3461: 45,39
-            3462: 29,29
-            3463: 29,30
-            3464: 29,31
-            3465: 28,31
-            3466: 27,31
-            3467: 26,31
-            3468: 29,32
-            3469: 29,33
-            3470: 29,34
-            3471: 29,35
-            3472: 30,35
-            3473: 31,35
-            3474: 29,36
-            3475: 29,37
-            3476: 29,38
-            3477: 30,38
-            3478: 31,38
-            3479: 29,39
+            3344: 29,17
+            3345: 29,18
+            3346: 29,19
+            3347: 29,20
+            3348: 29,21
+            3349: 29,22
+            3350: 29,23
+            3351: 30,23
+            3352: 32,23
+            3353: 32,23
+            3354: 33,23
+            3355: 34,23
+            3356: 29,24
+            3357: 29,25
+            3358: 29,26
+            3359: 29,27
+            3360: 29,28
+            3361: 30,28
+            3362: 31,28
+            3382: 40,28
+            3383: 38,27
+            3384: 38,26
+            3385: 38,25
+            3386: 41,28
+            3387: 42,28
+            3388: 43,28
+            3389: 43,27
+            3390: 43,29
+            3391: 43,30
+            3436: 43,31
+            3437: 43,32
+            3438: 44,32
+            3439: 45,32
+            3440: 43,33
+            3441: 43,34
+            3442: 43,35
+            3443: 42,35
+            3444: 41,35
+            3445: 43,36
+            3446: 43,37
+            3447: 43,38
+            3448: 42,38
+            3449: 41,38
+            3450: 43,39
+            3451: 44,39
+            3452: 45,39
+            3453: 29,29
+            3454: 29,30
+            3455: 29,31
+            3456: 28,31
+            3457: 27,31
+            3458: 26,31
+            3459: 29,32
+            3460: 29,33
+            3461: 29,34
+            3462: 29,35
+            3463: 30,35
+            3464: 31,35
+            3465: 29,36
+            3466: 29,37
+            3467: 29,38
+            3468: 30,38
+            3469: 31,38
+            3470: 29,39
         - node:
             color: '#52B4E996'
             id: FullTileOverlayGreyscale
@@ -4100,160 +4100,160 @@ entities:
             555: 9,-11
             586: 5,-16
             587: 9,-13
-            2777: 24,-11
-            5205: 18,-22
-            5468: 31,-30
-            5566: 3,-25
-            5567: 4,-25
-            5568: 5,-25
-            5569: 6,-25
-            5570: 7,-25
-            5571: 8,-25
-            5572: 9,-25
-            5573: 10,-25
-            5574: 11,-25
-            5575: 10,-28
-            5576: 4,-28
-            5577: 4,-22
-            5578: 10,-22
-            5778: 12,-25
-            5779: 13,-25
-            5780: 13,-24
-            5781: 13,-23
-            5782: 13,-22
-            5783: 13,-21
-            5784: 13,-20
-            5785: 13,-19
-            5786: 13,-18
-            5787: 13,-17
-            5788: 13,-16
-            5789: 13,-15
-            5790: 13,-14
-            5791: 13,-13
-            5792: 14,-25
-            5793: 15,-25
-            5794: 16,-25
-            5795: 17,-25
-            5796: 18,-25
-            5797: 19,-25
-            5798: 20,-25
-            5799: 21,-25
-            5800: 21,-26
-            5801: 21,-27
-            5802: 21,-28
-            5803: 20,-28
-            5804: 19,-28
-            5805: 18,-28
-            5806: 17,-28
-            5807: 16,-28
-            5808: 15,-28
-            5809: 14,-28
-            5810: 13,-28
-            5811: 13,-27
-            5812: 13,-26
-            5813: 18,-24
-            5814: 18,-23
-            5815: 13,-29
-            5816: 13,-30
-            5817: 13,-31
-            5822: 25,-24
-            5823: 31,-24
-            5853: 37,-24
-            5854: 37,-23
-            5855: 37,-22
-            5856: 37,-21
-            5857: 37,-20
-            5858: 37,-19
-            5859: 37,-18
-            5860: 37,-17
-            5861: 37,-16
-            5862: 37,-15
-            5863: 37,-14
-            5864: 38,-17
-            5865: 39,-17
-            5902: 31,-23
-            5939: 25,-23
-            5975: 25,-35
-            6075: 1,-25
-            6076: 2,-25
-            7219: 4,-38
-            7220: 7,-35
-            7237: 38,-37
-            7238: 45,-40
-            7239: 42,-39
-            7300: 4,-14
+            2768: 24,-11
+            5196: 18,-22
+            5459: 31,-30
+            5557: 3,-25
+            5558: 4,-25
+            5559: 5,-25
+            5560: 6,-25
+            5561: 7,-25
+            5562: 8,-25
+            5563: 9,-25
+            5564: 10,-25
+            5565: 11,-25
+            5566: 10,-28
+            5567: 4,-28
+            5568: 4,-22
+            5569: 10,-22
+            5769: 12,-25
+            5770: 13,-25
+            5771: 13,-24
+            5772: 13,-23
+            5773: 13,-22
+            5774: 13,-21
+            5775: 13,-20
+            5776: 13,-19
+            5777: 13,-18
+            5778: 13,-17
+            5779: 13,-16
+            5780: 13,-15
+            5781: 13,-14
+            5782: 13,-13
+            5783: 14,-25
+            5784: 15,-25
+            5785: 16,-25
+            5786: 17,-25
+            5787: 18,-25
+            5788: 19,-25
+            5789: 20,-25
+            5790: 21,-25
+            5791: 21,-26
+            5792: 21,-27
+            5793: 21,-28
+            5794: 20,-28
+            5795: 19,-28
+            5796: 18,-28
+            5797: 17,-28
+            5798: 16,-28
+            5799: 15,-28
+            5800: 14,-28
+            5801: 13,-28
+            5802: 13,-27
+            5803: 13,-26
+            5804: 18,-24
+            5805: 18,-23
+            5806: 13,-29
+            5807: 13,-30
+            5808: 13,-31
+            5813: 25,-24
+            5814: 31,-24
+            5844: 37,-24
+            5845: 37,-23
+            5846: 37,-22
+            5847: 37,-21
+            5848: 37,-20
+            5849: 37,-19
+            5850: 37,-18
+            5851: 37,-17
+            5852: 37,-16
+            5853: 37,-15
+            5854: 37,-14
+            5855: 38,-17
+            5856: 39,-17
+            5893: 31,-23
+            5930: 25,-23
+            5966: 25,-35
+            6066: 1,-25
+            6067: 2,-25
+            7210: 4,-38
+            7211: 7,-35
+            7228: 38,-37
+            7229: 45,-40
+            7230: 42,-39
+            7291: 4,-14
         - node:
             color: '#9FED5815'
             id: FullTileOverlayGreyscale
           decals:
-            3184: 40,19
-            3185: 41,19
-            3186: 42,19
-            3187: 43,19
+            3175: 40,19
+            3176: 41,19
+            3177: 42,19
+            3178: 43,19
         - node:
             color: '#9FED5896'
             id: FullTileOverlayGreyscale
           decals:
-            2879: 29,1
-            2880: 29,2
-            2881: 29,3
-            2983: 29,4
-            2984: 29,5
-            2985: 29,6
-            2986: 29,7
-            2987: 29,8
-            3011: 28,7
-            3013: 36,7
-            3014: 34,7
-            3015: 33,7
-            3016: 32,7
-            3017: 31,7
-            3018: 30,7
-            3107: 28,14
-            3108: 29,14
-            3112: 30,16
-            3113: 31,16
-            3118: 33,14
-            3119: 33,15
-            3120: 33,16
-            3121: 33,17
-            3122: 33,18
-            3123: 33,19
-            3124: 33,20
-            3125: 36,18
-            3126: 36,17
-            3127: 36,16
-            3128: 36,15
-            3129: 36,14
-            3139: 37,13
-            3140: 38,13
-            3141: 38,12
-            3142: 37,12
-            3143: 37,19
-            3144: 38,18
-            3145: 39,18
-            3182: 31,14
-            3183: 31,15
-            3310: 19,27
-            4996: 7,58
-            4997: 7,59
-            4998: 7,60
-            5362: 40,-27
-            5363: 40,-28
-            5364: 40,-29
-            5365: 40,-30
-            5366: 40,-31
-            5367: 40,-32
-            5368: 39,-32
-            5369: 38,-32
-            5370: 41,-32
-            5371: 42,-32
-            5372: 43,-32
-            5373: 44,-32
-            5374: 45,-32
-            5375: 45,-31
-            5376: 45,-30
-            5893: 40,-26
+            2870: 29,1
+            2871: 29,2
+            2872: 29,3
+            2974: 29,4
+            2975: 29,5
+            2976: 29,6
+            2977: 29,7
+            2978: 29,8
+            3002: 28,7
+            3004: 36,7
+            3005: 34,7
+            3006: 33,7
+            3007: 32,7
+            3008: 31,7
+            3009: 30,7
+            3098: 28,14
+            3099: 29,14
+            3103: 30,16
+            3104: 31,16
+            3109: 33,14
+            3110: 33,15
+            3111: 33,16
+            3112: 33,17
+            3113: 33,18
+            3114: 33,19
+            3115: 33,20
+            3116: 36,18
+            3117: 36,17
+            3118: 36,16
+            3119: 36,15
+            3120: 36,14
+            3130: 37,13
+            3131: 38,13
+            3132: 38,12
+            3133: 37,12
+            3134: 37,19
+            3135: 38,18
+            3136: 39,18
+            3173: 31,14
+            3174: 31,15
+            3301: 19,27
+            4987: 7,58
+            4988: 7,59
+            4989: 7,60
+            5353: 40,-27
+            5354: 40,-28
+            5355: 40,-29
+            5356: 40,-30
+            5357: 40,-31
+            5358: 40,-32
+            5359: 39,-32
+            5360: 38,-32
+            5361: 41,-32
+            5362: 42,-32
+            5363: 43,-32
+            5364: 44,-32
+            5365: 45,-32
+            5366: 45,-31
+            5367: 45,-30
+            5884: 40,-26
         - node:
             color: '#A4610696'
             id: FullTileOverlayGreyscale
@@ -4429,12 +4429,12 @@ entities:
             1132: -39,4
             1133: -38,4
             1134: -37,4
-            2679: -34,8
-            2680: -34,6
-            7398: -42,-21
-            7399: -41,-20
-            7403: -47,-17
-            7412: -47,-21
+            2670: -34,8
+            2671: -34,6
+            7389: -42,-21
+            7390: -41,-20
+            7394: -47,-17
+            7403: -47,-21
         - node:
             color: '#D381C996'
             id: FullTileOverlayGreyscale
@@ -4460,83 +4460,83 @@ entities:
             1286: -34,-18
             1297: -38,-24
             1298: -37,-24
-            1383: -40,-33
-            1384: -39,-33
-            1386: -40,-30
-            1491: -30,-26
-            1492: -30,-27
-            1493: -30,-28
-            1494: -30,-29
-            1495: -30,-30
-            1496: -30,-31
-            1497: -30,-32
-            1498: -31,-32
-            1499: -32,-32
-            1500: -33,-32
-            1501: -34,-32
-            1502: -34,-33
-            1503: -34,-34
-            1504: -34,-35
-            1505: -29,-31
-            1506: -28,-31
-            1597: -34,-36
-            1598: -34,-37
-            1599: -34,-38
-            1600: -34,-39
-            1601: -34,-40
-            1602: -34,-41
-            1603: -34,-42
-            1604: -34,-43
-            1641: -27,-31
-            1642: -26,-31
-            1643: -26,-30
-            1644: -26,-29
-            1645: -26,-28
-            1646: -25,-28
-            1652: -28,-23
-            1653: -23,-26
-            1774: -24,-28
-            1775: -23,-28
-            1776: -23,-27
-            1777: -22,-28
-            1778: -22,-29
-            1779: -21,-28
-            1780: -20,-28
-            1781: -19,-28
-            1782: -18,-28
-            1783: -17,-28
-            1784: -17,-27
-            1785: -17,-26
-            1786: -16,-28
-            1787: -15,-28
-            1788: -14,-28
-            1789: -13,-28
-            1790: -12,-28
-            1791: -11,-28
-            1792: -10,-28
-            1793: -9,-28
-            1794: -11,-27
-            1795: -11,-26
-            1796: -11,-25
-            1797: -11,-24
-            1798: -11,-23
-            2078: -8,-28
-            2079: -7,-28
-            2080: -6,-28
-            2081: -5,-28
-            2082: -4,-28
-            2083: -3,-28
-            2084: -2,-28
-            2085: -8,-29
-            2086: -8,-30
-            2106: -42,-43
-            2107: -43,-43
-            2356: -24,-45
-            2361: -21,-47
-            2367: -21,-50
-            2460: -26,-55
-            2461: -26,-56
-            2462: -23,-57
+            1374: -40,-33
+            1375: -39,-33
+            1377: -40,-30
+            1482: -30,-26
+            1483: -30,-27
+            1484: -30,-28
+            1485: -30,-29
+            1486: -30,-30
+            1487: -30,-31
+            1488: -30,-32
+            1489: -31,-32
+            1490: -32,-32
+            1491: -33,-32
+            1492: -34,-32
+            1493: -34,-33
+            1494: -34,-34
+            1495: -34,-35
+            1496: -29,-31
+            1497: -28,-31
+            1588: -34,-36
+            1589: -34,-37
+            1590: -34,-38
+            1591: -34,-39
+            1592: -34,-40
+            1593: -34,-41
+            1594: -34,-42
+            1595: -34,-43
+            1632: -27,-31
+            1633: -26,-31
+            1634: -26,-30
+            1635: -26,-29
+            1636: -26,-28
+            1637: -25,-28
+            1643: -28,-23
+            1644: -23,-26
+            1765: -24,-28
+            1766: -23,-28
+            1767: -23,-27
+            1768: -22,-28
+            1769: -22,-29
+            1770: -21,-28
+            1771: -20,-28
+            1772: -19,-28
+            1773: -18,-28
+            1774: -17,-28
+            1775: -17,-27
+            1776: -17,-26
+            1777: -16,-28
+            1778: -15,-28
+            1779: -14,-28
+            1780: -13,-28
+            1781: -12,-28
+            1782: -11,-28
+            1783: -10,-28
+            1784: -9,-28
+            1785: -11,-27
+            1786: -11,-26
+            1787: -11,-25
+            1788: -11,-24
+            1789: -11,-23
+            2069: -8,-28
+            2070: -7,-28
+            2071: -6,-28
+            2072: -5,-28
+            2073: -4,-28
+            2074: -3,-28
+            2075: -2,-28
+            2076: -8,-29
+            2077: -8,-30
+            2097: -42,-43
+            2098: -43,-43
+            2347: -24,-45
+            2352: -21,-47
+            2358: -21,-50
+            2451: -26,-55
+            2452: -26,-56
+            2453: -23,-57
         - node:
             color: '#D4D4D428'
             id: FullTileOverlayGreyscale
@@ -4544,64 +4544,64 @@ entities:
             1218: -40,-11
             1219: -40,-12
             1220: -40,-10
-            2117: -43,-41
-            2118: -43,-40
-            2119: -39,-42
-            2120: -38,-42
-            2121: -38,-42
-            2123: -45,-39
-            2124: -45,-40
-            2125: -45,-41
-            2144: -43,-31
-            2145: -43,-30
-            2146: -44,-30
-            2147: -44,-31
-            2148: -45,-31
-            2149: -45,-30
-            2150: -44,-32
-            2191: -37,-48
-            2192: -37,-47
-            2207: -34,-45
-            2208: -34,-46
-            2209: -34,-47
-            2210: -34,-48
-            2211: -34,-49
-            2212: -35,-49
-            2213: -35,-48
-            2215: -33,-48
-            2216: -32,-48
-            2219: -34,-50
-            2220: -34,-51
-            2221: -35,-51
-            2222: -35,-50
-            2223: -36,-50
-            2224: -37,-50
-            2225: -38,-50
-            2226: -39,-50
-            2227: -40,-50
-            2228: -40,-51
-            2229: -40,-52
-            2230: -40,-53
-            2265: -41,-51
-            2266: -42,-51
-            2267: -43,-51
-            2268: -43,-50
-            2269: -42,-50
-            3703: 37,-14
-            3704: 37,-13
-            3705: 37,-12
-            4326: -20,30
-            7339: -45,-42
-            7340: -40,-42
-            7341: -41,-42
+            2108: -43,-41
+            2109: -43,-40
+            2110: -39,-42
+            2111: -38,-42
+            2112: -38,-42
+            2114: -45,-39
+            2115: -45,-40
+            2116: -45,-41
+            2135: -43,-31
+            2136: -43,-30
+            2137: -44,-30
+            2138: -44,-31
+            2139: -45,-31
+            2140: -45,-30
+            2141: -44,-32
+            2182: -37,-48
+            2183: -37,-47
+            2198: -34,-45
+            2199: -34,-46
+            2200: -34,-47
+            2201: -34,-48
+            2202: -34,-49
+            2203: -35,-49
+            2204: -35,-48
+            2206: -33,-48
+            2207: -32,-48
+            2210: -34,-50
+            2211: -34,-51
+            2212: -35,-51
+            2213: -35,-50
+            2214: -36,-50
+            2215: -37,-50
+            2216: -38,-50
+            2217: -39,-50
+            2218: -40,-50
+            2219: -40,-51
+            2220: -40,-52
+            2221: -40,-53
+            2256: -41,-51
+            2257: -42,-51
+            2258: -43,-51
+            2259: -43,-50
+            2260: -42,-50
+            3694: 37,-14
+            3695: 37,-13
+            3696: 37,-12
+            4317: -20,30
+            7330: -45,-42
+            7331: -40,-42
+            7332: -41,-42
         - node:
             angle: 1.5707963267948966 rad
             color: '#D4D4D428'
             id: FullTileOverlayGreyscale
           decals:
-            2135: -45,-37
-            2136: -45,-36
-            2137: -45,-35
+            2126: -45,-37
+            2127: -45,-36
+            2128: -45,-35
         - node:
             color: '#DE3A3A96'
             id: FullTileOverlayGreyscale
@@ -4609,260 +4609,260 @@ entities:
             495: -15,14
             496: -15,15
             497: -15,16
-            3890: 44,-14
-            3891: 45,-15
-            3892: 46,-15
-            3893: 47,-15
-            3917: -18,14
-            3920: -19,16
-            3921: -22,15
-            3952: -28,22
-            4015: -1,19
-            4016: 0,19
-            4026: -2,19
-            4027: -3,19
-            4028: -4,19
-            4029: -5,19
-            4030: -6,19
-            4031: -7,19
-            4032: -8,19
-            4033: -9,19
-            4034: -10,19
-            4035: -11,19
-            4036: -12,19
-            4037: -13,19
-            4038: -14,19
-            4039: -15,19
-            4040: -16,19
-            4041: -16,20
-            4085: -22,25
-            4086: -22,24
-            4087: -21,24
-            4088: -21,25
-            4089: -20,25
-            4090: -20,24
-            4091: -19,24
-            4092: -19,25
-            4132: -15,21
-            4133: -17,21
-            4134: -17,24
-            4135: -15,24
-            4136: -16,25
-            4137: -16,26
-            4177: -16,27
-            4178: -16,28
-            4179: -17,28
-            4180: -16,29
-            4181: -15,28
-            4182: -14,28
-            4183: -13,28
-            4184: -12,28
-            4185: -11,28
-            4186: -10,28
-            4187: -9,28
-            4188: -8,28
-            4189: -7,28
-            4190: -6,28
-            4191: -5,28
-            4192: -4,28
-            4193: -4,29
-            4194: -13,29
-            4195: -7,30
-            4196: -6,30
-            4197: -4,30
-            4227: -4,31
-            4228: -13,30
-            4229: -12,36
-            4230: -12,35
-            4231: -12,34
-            4232: -11,34
-            4233: -11,35
-            4234: -10,36
-            4235: -13,36
-            4236: -13,37
-            4265: -16,30
-            4266: -16,31
-            4267: -16,32
-            4268: -17,32
-            4269: -17,33
-            4270: -16,33
-            4271: -16,34
-            4272: -17,34
-            4273: -17,35
-            4274: -16,35
-            4322: -20,35
-            4323: -20,34
-            4324: -20,33
-            4325: -20,32
-            4333: -10,37
-            4334: -10,38
-            4335: -10,39
-            4336: -10,40
-            4375: -32,26
-            4376: -31,26
-            4377: -30,26
-            4378: -30,25
-            4379: -32,25
-            4380: -31,25
-            4419: -42,22
-            4420: -41,22
-            4421: -40,22
-            4422: -40,21
-            4423: -40,20
-            4424: -41,20
-            4425: -42,20
-            4426: -43,20
-            4427: -39,20
-            4428: -38,20
-            4429: -37,20
-            4430: -38,19
-            4431: -37,21
-            4432: -37,22
-            4433: -37,23
-            4434: -37,24
-            4435: -37,25
-            4436: -37,26
-            4437: -37,27
-            4471: -37,28
-            4472: -37,29
-            4473: -38,29
-            4474: -39,29
-            4475: -36,29
-            4476: -35,29
-            4483: -24,37
-            4484: -24,36
-            4485: -24,35
-            4486: -24,34
-            4487: -24,33
-            4488: -24,32
-            4489: -24,31
-            4490: -24,30
-            4491: -24,29
-            4492: -25,29
-            4493: -26,29
-            4494: -27,29
-            4495: -28,29
-            4496: -29,29
-            4497: -30,29
-            4498: -31,29
-            4499: -32,29
-            4500: -33,29
-            4501: -34,29
-            4502: -25,35
-            4503: -26,35
-            4504: -24,28
-            4505: -24,27
-            4506: -24,26
-            4507: -23,28
-            4508: -22,28
-            4509: -21,28
-            4510: -20,28
-            4511: -19,28
-            4512: -18,28
-            4566: -3,35
-            4567: -5,35
-            4568: -5,32
-            4569: -3,32
-            4570: -2,37
-            4571: -2,38
-            4597: -1,37
-            4598: -1,38
-            4599: 0,38
-            4600: 0,37
-            4990: -6,58
-            4991: -6,59
-            4992: -6,60
+            3881: 44,-14
+            3882: 45,-15
+            3883: 46,-15
+            3884: 47,-15
+            3908: -18,14
+            3911: -19,16
+            3912: -22,15
+            3943: -28,22
+            4006: -1,19
+            4007: 0,19
+            4017: -2,19
+            4018: -3,19
+            4019: -4,19
+            4020: -5,19
+            4021: -6,19
+            4022: -7,19
+            4023: -8,19
+            4024: -9,19
+            4025: -10,19
+            4026: -11,19
+            4027: -12,19
+            4028: -13,19
+            4029: -14,19
+            4030: -15,19
+            4031: -16,19
+            4032: -16,20
+            4076: -22,25
+            4077: -22,24
+            4078: -21,24
+            4079: -21,25
+            4080: -20,25
+            4081: -20,24
+            4082: -19,24
+            4083: -19,25
+            4123: -15,21
+            4124: -17,21
+            4125: -17,24
+            4126: -15,24
+            4127: -16,25
+            4128: -16,26
+            4168: -16,27
+            4169: -16,28
+            4170: -17,28
+            4171: -16,29
+            4172: -15,28
+            4173: -14,28
+            4174: -13,28
+            4175: -12,28
+            4176: -11,28
+            4177: -10,28
+            4178: -9,28
+            4179: -8,28
+            4180: -7,28
+            4181: -6,28
+            4182: -5,28
+            4183: -4,28
+            4184: -4,29
+            4185: -13,29
+            4186: -7,30
+            4187: -6,30
+            4188: -4,30
+            4218: -4,31
+            4219: -13,30
+            4220: -12,36
+            4221: -12,35
+            4222: -12,34
+            4223: -11,34
+            4224: -11,35
+            4225: -10,36
+            4226: -13,36
+            4227: -13,37
+            4256: -16,30
+            4257: -16,31
+            4258: -16,32
+            4259: -17,32
+            4260: -17,33
+            4261: -16,33
+            4262: -16,34
+            4263: -17,34
+            4264: -17,35
+            4265: -16,35
+            4313: -20,35
+            4314: -20,34
+            4315: -20,33
+            4316: -20,32
+            4324: -10,37
+            4325: -10,38
+            4326: -10,39
+            4327: -10,40
+            4366: -32,26
+            4367: -31,26
+            4368: -30,26
+            4369: -30,25
+            4370: -32,25
+            4371: -31,25
+            4410: -42,22
+            4411: -41,22
+            4412: -40,22
+            4413: -40,21
+            4414: -40,20
+            4415: -41,20
+            4416: -42,20
+            4417: -43,20
+            4418: -39,20
+            4419: -38,20
+            4420: -37,20
+            4421: -38,19
+            4422: -37,21
+            4423: -37,22
+            4424: -37,23
+            4425: -37,24
+            4426: -37,25
+            4427: -37,26
+            4428: -37,27
+            4462: -37,28
+            4463: -37,29
+            4464: -38,29
+            4465: -39,29
+            4466: -36,29
+            4467: -35,29
+            4474: -24,37
+            4475: -24,36
+            4476: -24,35
+            4477: -24,34
+            4478: -24,33
+            4479: -24,32
+            4480: -24,31
+            4481: -24,30
+            4482: -24,29
+            4483: -25,29
+            4484: -26,29
+            4485: -27,29
+            4486: -28,29
+            4487: -29,29
+            4488: -30,29
+            4489: -31,29
+            4490: -32,29
+            4491: -33,29
+            4492: -34,29
+            4493: -25,35
+            4494: -26,35
+            4495: -24,28
+            4496: -24,27
+            4497: -24,26
+            4498: -23,28
+            4499: -22,28
+            4500: -21,28
+            4501: -20,28
+            4502: -19,28
+            4503: -18,28
+            4557: -3,35
+            4558: -5,35
+            4559: -5,32
+            4560: -3,32
+            4561: -2,37
+            4562: -2,38
+            4588: -1,37
+            4589: -1,38
+            4590: 0,38
+            4591: 0,37
+            4981: -6,58
+            4982: -6,59
+            4983: -6,60
         - node:
             color: '#EFB34195'
             id: FullTileOverlayGreyscale
           decals:
-            6297: 8,-59
-            6298: 8,-60
-            6299: 8,-61
-            6300: 6,-59
-            6301: 6,-60
-            6302: 6,-61
+            6288: 8,-59
+            6289: 8,-60
+            6290: 8,-61
+            6291: 6,-59
+            6292: 6,-60
+            6293: 6,-61
         - node:
             color: '#EFB34196'
             id: FullTileOverlayGreyscale
           decals:
-            2529: -11,-53
-            2558: -5,-49
-            4926: -2,62
-            4927: -1,62
-            4928: 0,62
-            4929: 1,62
-            4930: 2,62
-            4931: 3,62
-            6221: 6,-47
-            6238: 7,-48
-            6239: 7,-49
-            6240: 7,-50
-            6241: 7,-51
-            6242: 7,-52
-            6243: 8,-48
-            6244: 6,-51
-            6245: 5,-51
-            6246: 7,-53
-            6247: 8,-53
-            6248: 7,-54
-            6249: 7,-55
-            6250: 7,-56
-            6251: 7,-57
-            6252: 6,-56
-            6253: 9,-48
-            6254: 9,-53
-            6255: -4,-53
-            6256: -1,-52
-            6527: 14,-67
-            6528: 13,-67
-            6529: 12,-67
-            6530: 11,-67
-            6531: 10,-67
-            6551: 6,-68
-            6552: 6,-67
-            6553: 6,-66
-            6554: 6,-65
-            6555: 6,-64
-            6556: 5,-64
-            6557: 4,-64
-            6558: 3,-64
-            6559: 2,-64
-            6560: 1,-64
-            6561: 0,-64
-            6562: -1,-64
-            6563: -2,-64
-            6564: -3,-64
-            6565: -4,-64
-            6566: -5,-64
-            6567: -6,-64
-            6568: -6,-65
-            6569: -6,-66
-            6570: -6,-67
-            6571: -6,-68
-            6572: -6,-72
-            6573: -6,-73
-            6574: 6,-72
-            6575: 6,-73
-            6857: 20,-52
-            6858: 20,-51
-            6859: 21,-51
-            6860: 21,-52
-            6861: 29,-53
-            6862: 29,-52
-            6863: 30,-52
-            6864: 30,-53
-            6865: 25,-63
-            6866: 26,-63
-            6867: 27,-63
-            6868: 28,-63
-            6869: 29,-63
-            7096: 10,-48
+            2520: -11,-53
+            2549: -5,-49
+            4917: -2,62
+            4918: -1,62
+            4919: 0,62
+            4920: 1,62
+            4921: 2,62
+            4922: 3,62
+            6212: 6,-47
+            6229: 7,-48
+            6230: 7,-49
+            6231: 7,-50
+            6232: 7,-51
+            6233: 7,-52
+            6234: 8,-48
+            6235: 6,-51
+            6236: 5,-51
+            6237: 7,-53
+            6238: 8,-53
+            6239: 7,-54
+            6240: 7,-55
+            6241: 7,-56
+            6242: 7,-57
+            6243: 6,-56
+            6244: 9,-48
+            6245: 9,-53
+            6246: -4,-53
+            6247: -1,-52
+            6518: 14,-67
+            6519: 13,-67
+            6520: 12,-67
+            6521: 11,-67
+            6522: 10,-67
+            6542: 6,-68
+            6543: 6,-67
+            6544: 6,-66
+            6545: 6,-65
+            6546: 6,-64
+            6547: 5,-64
+            6548: 4,-64
+            6549: 3,-64
+            6550: 2,-64
+            6551: 1,-64
+            6552: 0,-64
+            6553: -1,-64
+            6554: -2,-64
+            6555: -3,-64
+            6556: -4,-64
+            6557: -5,-64
+            6558: -6,-64
+            6559: -6,-65
+            6560: -6,-66
+            6561: -6,-67
+            6562: -6,-68
+            6563: -6,-72
+            6564: -6,-73
+            6565: 6,-72
+            6566: 6,-73
+            6848: 20,-52
+            6849: 20,-51
+            6850: 21,-51
+            6851: 21,-52
+            6852: 29,-53
+            6853: 29,-52
+            6854: 30,-52
+            6855: 30,-53
+            6856: 25,-63
+            6857: 26,-63
+            6858: 27,-63
+            6859: 28,-63
+            6860: 29,-63
+            7087: 10,-48
         - node:
             color: '#FF924493'
             id: FullTileOverlayGreyscale
           decals:
-            5339: 30,-20
+            5330: 30,-20
         - node:
             color: '#FFFFFFFF'
             id: FullTileOverlayGreyscale
@@ -4871,388 +4871,388 @@ entities:
             1271: -34,-17
             1284: -34,-18
             1285: -33,-18
-            1440: -30,-27
-            1441: -30,-26
-            1442: -30,-28
-            1443: -30,-29
-            1444: -30,-30
-            1445: -30,-31
-            1446: -30,-32
-            1447: -31,-32
-            1448: -32,-32
-            1449: -33,-32
-            1450: -34,-32
-            1451: -35,-32
-            1452: -36,-32
-            1453: -36,-31
-            1454: -35,-31
-            1455: -34,-31
-            1456: -33,-31
-            1457: -32,-31
-            1458: -31,-31
-            1459: -36,-30
-            1460: -36,-29
-            1461: -36,-28
-            1462: -34,-33
-            1463: -34,-34
-            1464: -34,-35
-            1465: -29,-32
-            1466: -29,-31
-            1467: -28,-31
-            1570: -34,-36
-            1571: -34,-37
-            1572: -34,-38
-            1573: -34,-39
-            1574: -34,-40
-            1575: -34,-41
-            1576: -34,-42
-            1577: -34,-43
-            1578: -35,-43
-            1579: -35,-44
-            1580: -34,-44
-            1623: -27,-31
-            1624: -26,-31
-            1625: -26,-30
-            1626: -26,-29
-            1627: -26,-28
-            1628: -25,-28
-            1650: -28,-23
-            1651: -23,-26
-            1715: -23,-28
-            1716: -23,-27
-            1717: -22,-28
-            1718: -21,-28
-            1719: -20,-28
-            1720: -19,-28
-            1721: -18,-28
-            1722: -17,-28
-            1723: -17,-27
-            1724: -17,-26
-            1725: -22,-29
-            1726: -16,-28
-            1727: -15,-28
-            1728: -14,-28
-            1729: -13,-28
-            1730: -12,-28
-            1731: -11,-28
-            1732: -11,-27
-            1733: -11,-26
-            1734: -11,-25
-            1735: -11,-24
-            1736: -11,-23
-            1737: -11,-22
-            1738: -10,-28
-            1739: -9,-28
-            1744: -24,-28
-            1799: -22,-30
-            1800: -22,-31
-            1801: -22,-32
-            1802: -22,-33
-            1803: -22,-34
-            1804: -21,-33
-            1805: -21,-34
-            1867: -8,-28
-            1868: -8,-29
-            1869: -8,-30
-            1870: -8,-31
-            1871: -8,-32
-            1872: -8,-33
-            1873: -8,-34
-            1874: -8,-35
-            1884: -8,-36
-            1885: -8,-37
-            1886: -9,-37
-            1887: -9,-36
-            1888: -10,-36
-            1889: -10,-37
-            1890: -11,-37
-            1891: -11,-36
-            1892: -12,-36
-            1893: -12,-37
-            1894: -13,-37
-            1895: -13,-36
-            1896: -13,-38
-            1897: -12,-38
-            1898: -12,-39
-            1899: -13,-39
-            1956: -13,-50
-            1957: -12,-50
-            1958: -12,-49
-            1959: -13,-49
-            1960: -13,-48
-            1961: -12,-48
-            1962: -12,-47
-            1963: -13,-47
-            1964: -13,-46
-            1965: -12,-46
-            1966: -12,-45
-            1967: -13,-45
-            1968: -13,-44
-            1969: -12,-44
-            1970: -12,-43
-            1971: -13,-43
-            1972: -13,-42
-            1973: -12,-42
-            1974: -12,-41
-            1975: -13,-41
-            1976: -13,-40
-            1977: -12,-40
-            2062: -7,-28
-            2063: -6,-28
-            2064: -5,-28
-            2065: -4,-28
-            2066: -3,-28
-            2067: -2,-28
-            5154: 13,-13
-            5155: 13,-14
-            5156: 13,-15
-            5157: 13,-16
-            5158: 13,-17
-            5159: 15,-15
-            5160: 16,-15
-            5161: 17,-15
-            5162: 17,-16
-            5163: 16,-16
-            5164: 15,-16
-            5193: 17,-20
-            5194: 18,-20
-            5195: 19,-20
-            5196: 19,-21
-            5197: 18,-21
-            5198: 17,-21
-            5206: 25,-22
-            5207: 26,-22
-            5208: 26,-21
-            5209: 25,-21
-            5210: 24,-21
-            5211: 23,-21
-            5212: 22,-21
-            5213: 22,-20
-            5214: 23,-20
-            5215: 24,-20
-            5216: 25,-20
-            5217: 26,-20
-            5218: 26,-19
-            5219: 25,-19
-            5220: 24,-19
-            5221: 23,-19
-            5222: 22,-19
-            5223: 22,-18
-            5224: 23,-18
-            5225: 24,-18
-            5226: 25,-18
-            5227: 26,-18
-            5257: 28,-16
-            5258: 28,-17
-            5259: 28,-18
-            5260: 28,-19
-            5261: 28,-20
-            5262: 28,-21
-            5263: 30,-22
-            5264: 31,-22
-            5265: 31,-22
-            5266: 32,-22
-            5267: 33,-22
-            5268: 34,-21
-            5269: 33,-21
-            5270: 32,-21
-            5271: 31,-21
-            5272: 30,-21
-            5273: 29,-21
-            5274: 29,-20
-            5275: 30,-20
-            5276: 31,-20
-            5277: 32,-20
-            5278: 33,-20
-            5279: 34,-20
-            5280: 34,-19
-            5281: 33,-19
-            5282: 32,-19
-            5283: 31,-19
-            5284: 30,-19
-            5285: 29,-19
-            5286: 29,-18
-            5287: 30,-18
-            5288: 31,-18
-            5289: 32,-18
-            5290: 33,-18
-            5291: 34,-18
-            5292: 34,-17
-            5293: 33,-17
-            5294: 32,-17
-            5295: 31,-17
-            5296: 30,-17
-            5297: 29,-17
-            5298: 29,-16
-            5299: 30,-16
-            5300: 31,-16
-            5301: 32,-16
-            5302: 33,-16
-            5303: 34,-16
-            5311: 34,-22
-            5315: 29,-22
-            5316: 28,-22
-            5432: 26,-27
-            5433: 27,-27
-            5434: 26,-28
-            5435: 27,-28
-            5436: 27,-29
-            5437: 27,-30
-            5438: 26,-30
-            5439: 26,-29
-            5440: 26,-31
-            5441: 26,-32
-            5442: 27,-32
-            5443: 27,-31
-            5444: 25,-29
-            5445: 31,-31
-            5446: 31,-30
-            5447: 31,-29
-            5448: 32,-29
-            5482: 5,-29
-            5483: 6,-29
-            5484: 6,-30
-            5485: 5,-30
-            5486: 5,-31
-            5487: 6,-31
-            5488: 6,-32
-            5489: 5,-32
-            5490: 7,-32
-            5491: 7,-31
-            5492: 8,-31
-            5493: 8,-32
-            5494: 9,-32
-            5495: 9,-31
-            5496: 10,-31
-            5497: 10,-32
-            5498: 11,-32
-            5499: 11,-31
-            5516: 8,-21
-            5517: 9,-21
-            5518: 8,-20
-            5519: 8,-19
-            5520: 9,-19
-            5521: 10,-20
-            5522: 10,-19
-            5523: 11,-19
-            5528: 9,-20
-            5531: 3,-26
-            5532: 3,-25
-            5533: 3,-24
-            5534: 4,-24
-            5535: 4,-25
-            5536: 4,-26
-            5537: 5,-25
-            5538: 6,-25
-            5539: 7,-25
-            5540: 8,-25
-            5541: 9,-25
-            5542: 10,-25
-            5543: 10,-26
-            5544: 10,-24
-            5545: 10,-23
-            5546: 9,-23
-            5547: 8,-23
-            5548: 7,-23
-            5549: 6,-23
-            5550: 5,-23
-            5551: 4,-23
-            5552: 4,-22
-            5553: 10,-22
-            5554: 10,-27
-            5555: 10,-28
-            5556: 9,-27
-            5557: 8,-27
-            5558: 7,-27
-            5559: 6,-27
-            5560: 5,-27
-            5561: 4,-27
-            5562: 4,-28
-            5563: 11,-26
-            5564: 11,-25
-            5565: 11,-24
-            5625: 13,-18
-            5626: 13,-19
-            5627: 13,-20
-            5628: 13,-21
-            5629: 13,-22
-            5630: 13,-23
-            5631: 13,-24
-            5632: 13,-25
-            5633: 13,-26
-            5634: 13,-27
-            5635: 13,-28
-            5636: 13,-29
-            5637: 13,-30
-            5638: 13,-31
-            5639: 12,-31
-            5640: 12,-25
-            5641: 14,-20
-            5642: 14,-21
-            5643: 14,-25
-            5644: 15,-25
-            5645: 16,-25
-            5646: 17,-25
-            5647: 18,-25
-            5648: 19,-25
-            5649: 20,-25
-            5650: 14,-28
-            5651: 15,-28
-            5652: 16,-28
-            5653: 18,-28
-            5654: 17,-28
-            5655: 19,-28
-            5656: 20,-28
-            5657: 18,-23
-            5658: 18,-24
-            5659: 21,-28
-            5660: 21,-27
-            5661: 21,-26
-            5662: 21,-25
-            5663: 22,-28
-            5664: 22,-27
-            5665: 22,-26
-            5666: 34,-25
-            5667: 35,-25
-            5668: 25,-24
-            5671: 31,-24
-            5672: 36,-25
-            5673: 37,-25
-            5674: 38,-25
-            5675: 39,-25
-            5676: 40,-25
-            5677: 40,-26
-            5678: 41,-25
-            5679: 42,-25
-            5680: 37,-24
-            5681: 37,-23
-            5682: 37,-22
-            5683: 37,-21
-            5684: 37,-20
-            5685: 37,-19
-            5686: 37,-18
-            5687: 37,-17
-            5688: 37,-16
-            5689: 37,-15
-            5690: 37,-14
-            5691: 38,-17
-            5692: 39,-17
-            5818: 12,-32
-            5819: 13,-32
-            5826: 22,-25
-            5827: 23,-25
-            5828: 24,-25
-            5829: 25,-25
-            5830: 26,-25
-            5831: 27,-25
-            5832: 28,-25
-            5833: 29,-25
-            5834: 30,-25
-            5835: 31,-25
-            5836: 32,-25
-            5837: 33,-25
-            5901: 31,-23
-            5938: 25,-23
+            1431: -30,-27
+            1432: -30,-26
+            1433: -30,-28
+            1434: -30,-29
+            1435: -30,-30
+            1436: -30,-31
+            1437: -30,-32
+            1438: -31,-32
+            1439: -32,-32
+            1440: -33,-32
+            1441: -34,-32
+            1442: -35,-32
+            1443: -36,-32
+            1444: -36,-31
+            1445: -35,-31
+            1446: -34,-31
+            1447: -33,-31
+            1448: -32,-31
+            1449: -31,-31
+            1450: -36,-30
+            1451: -36,-29
+            1452: -36,-28
+            1453: -34,-33
+            1454: -34,-34
+            1455: -34,-35
+            1456: -29,-32
+            1457: -29,-31
+            1458: -28,-31
+            1561: -34,-36
+            1562: -34,-37
+            1563: -34,-38
+            1564: -34,-39
+            1565: -34,-40
+            1566: -34,-41
+            1567: -34,-42
+            1568: -34,-43
+            1569: -35,-43
+            1570: -35,-44
+            1571: -34,-44
+            1614: -27,-31
+            1615: -26,-31
+            1616: -26,-30
+            1617: -26,-29
+            1618: -26,-28
+            1619: -25,-28
+            1641: -28,-23
+            1642: -23,-26
+            1706: -23,-28
+            1707: -23,-27
+            1708: -22,-28
+            1709: -21,-28
+            1710: -20,-28
+            1711: -19,-28
+            1712: -18,-28
+            1713: -17,-28
+            1714: -17,-27
+            1715: -17,-26
+            1716: -22,-29
+            1717: -16,-28
+            1718: -15,-28
+            1719: -14,-28
+            1720: -13,-28
+            1721: -12,-28
+            1722: -11,-28
+            1723: -11,-27
+            1724: -11,-26
+            1725: -11,-25
+            1726: -11,-24
+            1727: -11,-23
+            1728: -11,-22
+            1729: -10,-28
+            1730: -9,-28
+            1735: -24,-28
+            1790: -22,-30
+            1791: -22,-31
+            1792: -22,-32
+            1793: -22,-33
+            1794: -22,-34
+            1795: -21,-33
+            1796: -21,-34
+            1858: -8,-28
+            1859: -8,-29
+            1860: -8,-30
+            1861: -8,-31
+            1862: -8,-32
+            1863: -8,-33
+            1864: -8,-34
+            1865: -8,-35
+            1875: -8,-36
+            1876: -8,-37
+            1877: -9,-37
+            1878: -9,-36
+            1879: -10,-36
+            1880: -10,-37
+            1881: -11,-37
+            1882: -11,-36
+            1883: -12,-36
+            1884: -12,-37
+            1885: -13,-37
+            1886: -13,-36
+            1887: -13,-38
+            1888: -12,-38
+            1889: -12,-39
+            1890: -13,-39
+            1947: -13,-50
+            1948: -12,-50
+            1949: -12,-49
+            1950: -13,-49
+            1951: -13,-48
+            1952: -12,-48
+            1953: -12,-47
+            1954: -13,-47
+            1955: -13,-46
+            1956: -12,-46
+            1957: -12,-45
+            1958: -13,-45
+            1959: -13,-44
+            1960: -12,-44
+            1961: -12,-43
+            1962: -13,-43
+            1963: -13,-42
+            1964: -12,-42
+            1965: -12,-41
+            1966: -13,-41
+            1967: -13,-40
+            1968: -12,-40
+            2053: -7,-28
+            2054: -6,-28
+            2055: -5,-28
+            2056: -4,-28
+            2057: -3,-28
+            2058: -2,-28
+            5145: 13,-13
+            5146: 13,-14
+            5147: 13,-15
+            5148: 13,-16
+            5149: 13,-17
+            5150: 15,-15
+            5151: 16,-15
+            5152: 17,-15
+            5153: 17,-16
+            5154: 16,-16
+            5155: 15,-16
+            5184: 17,-20
+            5185: 18,-20
+            5186: 19,-20
+            5187: 19,-21
+            5188: 18,-21
+            5189: 17,-21
+            5197: 25,-22
+            5198: 26,-22
+            5199: 26,-21
+            5200: 25,-21
+            5201: 24,-21
+            5202: 23,-21
+            5203: 22,-21
+            5204: 22,-20
+            5205: 23,-20
+            5206: 24,-20
+            5207: 25,-20
+            5208: 26,-20
+            5209: 26,-19
+            5210: 25,-19
+            5211: 24,-19
+            5212: 23,-19
+            5213: 22,-19
+            5214: 22,-18
+            5215: 23,-18
+            5216: 24,-18
+            5217: 25,-18
+            5218: 26,-18
+            5248: 28,-16
+            5249: 28,-17
+            5250: 28,-18
+            5251: 28,-19
+            5252: 28,-20
+            5253: 28,-21
+            5254: 30,-22
+            5255: 31,-22
+            5256: 31,-22
+            5257: 32,-22
+            5258: 33,-22
+            5259: 34,-21
+            5260: 33,-21
+            5261: 32,-21
+            5262: 31,-21
+            5263: 30,-21
+            5264: 29,-21
+            5265: 29,-20
+            5266: 30,-20
+            5267: 31,-20
+            5268: 32,-20
+            5269: 33,-20
+            5270: 34,-20
+            5271: 34,-19
+            5272: 33,-19
+            5273: 32,-19
+            5274: 31,-19
+            5275: 30,-19
+            5276: 29,-19
+            5277: 29,-18
+            5278: 30,-18
+            5279: 31,-18
+            5280: 32,-18
+            5281: 33,-18
+            5282: 34,-18
+            5283: 34,-17
+            5284: 33,-17
+            5285: 32,-17
+            5286: 31,-17
+            5287: 30,-17
+            5288: 29,-17
+            5289: 29,-16
+            5290: 30,-16
+            5291: 31,-16
+            5292: 32,-16
+            5293: 33,-16
+            5294: 34,-16
+            5302: 34,-22
+            5306: 29,-22
+            5307: 28,-22
+            5423: 26,-27
+            5424: 27,-27
+            5425: 26,-28
+            5426: 27,-28
+            5427: 27,-29
+            5428: 27,-30
+            5429: 26,-30
+            5430: 26,-29
+            5431: 26,-31
+            5432: 26,-32
+            5433: 27,-32
+            5434: 27,-31
+            5435: 25,-29
+            5436: 31,-31
+            5437: 31,-30
+            5438: 31,-29
+            5439: 32,-29
+            5473: 5,-29
+            5474: 6,-29
+            5475: 6,-30
+            5476: 5,-30
+            5477: 5,-31
+            5478: 6,-31
+            5479: 6,-32
+            5480: 5,-32
+            5481: 7,-32
+            5482: 7,-31
+            5483: 8,-31
+            5484: 8,-32
+            5485: 9,-32
+            5486: 9,-31
+            5487: 10,-31
+            5488: 10,-32
+            5489: 11,-32
+            5490: 11,-31
+            5507: 8,-21
+            5508: 9,-21
+            5509: 8,-20
+            5510: 8,-19
+            5511: 9,-19
+            5512: 10,-20
+            5513: 10,-19
+            5514: 11,-19
+            5519: 9,-20
+            5522: 3,-26
+            5523: 3,-25
+            5524: 3,-24
+            5525: 4,-24
+            5526: 4,-25
+            5527: 4,-26
+            5528: 5,-25
+            5529: 6,-25
+            5530: 7,-25
+            5531: 8,-25
+            5532: 9,-25
+            5533: 10,-25
+            5534: 10,-26
+            5535: 10,-24
+            5536: 10,-23
+            5537: 9,-23
+            5538: 8,-23
+            5539: 7,-23
+            5540: 6,-23
+            5541: 5,-23
+            5542: 4,-23
+            5543: 4,-22
+            5544: 10,-22
+            5545: 10,-27
+            5546: 10,-28
+            5547: 9,-27
+            5548: 8,-27
+            5549: 7,-27
+            5550: 6,-27
+            5551: 5,-27
+            5552: 4,-27
+            5553: 4,-28
+            5554: 11,-26
+            5555: 11,-25
+            5556: 11,-24
+            5616: 13,-18
+            5617: 13,-19
+            5618: 13,-20
+            5619: 13,-21
+            5620: 13,-22
+            5621: 13,-23
+            5622: 13,-24
+            5623: 13,-25
+            5624: 13,-26
+            5625: 13,-27
+            5626: 13,-28
+            5627: 13,-29
+            5628: 13,-30
+            5629: 13,-31
+            5630: 12,-31
+            5631: 12,-25
+            5632: 14,-20
+            5633: 14,-21
+            5634: 14,-25
+            5635: 15,-25
+            5636: 16,-25
+            5637: 17,-25
+            5638: 18,-25
+            5639: 19,-25
+            5640: 20,-25
+            5641: 14,-28
+            5642: 15,-28
+            5643: 16,-28
+            5644: 18,-28
+            5645: 17,-28
+            5646: 19,-28
+            5647: 20,-28
+            5648: 18,-23
+            5649: 18,-24
+            5650: 21,-28
+            5651: 21,-27
+            5652: 21,-26
+            5653: 21,-25
+            5654: 22,-28
+            5655: 22,-27
+            5656: 22,-26
+            5657: 34,-25
+            5658: 35,-25
+            5659: 25,-24
+            5662: 31,-24
+            5663: 36,-25
+            5664: 37,-25
+            5665: 38,-25
+            5666: 39,-25
+            5667: 40,-25
+            5668: 40,-26
+            5669: 41,-25
+            5670: 42,-25
+            5671: 37,-24
+            5672: 37,-23
+            5673: 37,-22
+            5674: 37,-21
+            5675: 37,-20
+            5676: 37,-19
+            5677: 37,-18
+            5678: 37,-17
+            5679: 37,-16
+            5680: 37,-15
+            5681: 37,-14
+            5682: 38,-17
+            5683: 39,-17
+            5809: 12,-32
+            5810: 13,-32
+            5817: 22,-25
+            5818: 23,-25
+            5819: 24,-25
+            5820: 25,-25
+            5821: 26,-25
+            5822: 27,-25
+            5823: 28,-25
+            5824: 29,-25
+            5825: 30,-25
+            5826: 31,-25
+            5827: 32,-25
+            5828: 33,-25
+            5892: 31,-23
+            5929: 25,-23
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale
@@ -5267,99 +5267,99 @@ entities:
             291: 6,-9
             292: 7,-8
             293: 8,-8
-            3779: 34,-11
-            3780: 35,-11
-            3781: 36,-11
-            3782: 37,-11
-            3783: 38,-11
-            3784: 39,-11
-            3785: 40,-11
-            3786: 41,-11
-            3835: 42,-5
-            3836: 41,-5
-            3837: 40,-5
-            3838: 39,-5
-            3839: 38,-5
-            3840: 37,-5
-            3841: 36,-5
-            3842: 33,-5
+            3770: 34,-11
+            3771: 35,-11
+            3772: 36,-11
+            3773: 37,-11
+            3774: 38,-11
+            3775: 39,-11
+            3776: 40,-11
+            3777: 41,-11
+            3826: 42,-5
+            3827: 41,-5
+            3828: 40,-5
+            3829: 39,-5
+            3830: 38,-5
+            3831: 37,-5
+            3832: 36,-5
+            3833: 33,-5
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale
           decals:
-            5104: 3,84
-            5105: -1,84
-            6500: 2,26
-            6516: 5,27
-            6517: 6,27
-            6518: 7,27
-            6519: 8,27
+            5095: 3,84
+            5096: -1,84
+            6491: 2,26
+            6507: 5,27
+            6508: 6,27
+            6509: 7,27
+            6510: 8,27
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale
           decals:
-            3382: 39,27
-            3383: 37,27
-            3384: 36,27
-            3385: 35,27
-            3386: 34,27
-            3387: 33,27
-            3388: 32,27
+            3373: 39,27
+            3374: 37,27
+            3375: 36,27
+            3376: 35,27
+            3377: 34,27
+            3378: 33,27
+            3379: 32,27
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale
           decals:
-            5466: 31,-31
-            5530: 9,-19
-            5586: 10,-23
-            5587: 9,-23
-            5588: 8,-23
-            5589: 7,-23
-            5590: 5,-23
-            5591: 4,-23
-            5592: 6,-23
-            5840: 22,-25
-            5841: 23,-25
-            5842: 24,-25
-            5843: 25,-25
-            5844: 28,-25
-            5845: 29,-25
-            5846: 30,-25
-            5847: 31,-25
-            5848: 32,-25
-            5849: 33,-25
-            5850: 34,-25
-            5851: 35,-25
-            5852: 36,-25
-            5866: 38,-25
-            5867: 39,-25
-            5868: 40,-25
-            5869: 41,-25
-            5870: 42,-25
-            5873: 37,-25
-            7301: 5,-12
+            5457: 31,-31
+            5521: 9,-19
+            5577: 10,-23
+            5578: 9,-23
+            5579: 8,-23
+            5580: 7,-23
+            5581: 5,-23
+            5582: 4,-23
+            5583: 6,-23
+            5831: 22,-25
+            5832: 23,-25
+            5833: 24,-25
+            5834: 25,-25
+            5835: 28,-25
+            5836: 29,-25
+            5837: 30,-25
+            5838: 31,-25
+            5839: 32,-25
+            5840: 33,-25
+            5841: 34,-25
+            5842: 35,-25
+            5843: 36,-25
+            5857: 38,-25
+            5858: 39,-25
+            5859: 40,-25
+            5860: 41,-25
+            5861: 42,-25
+            5864: 37,-25
+            7292: 5,-12
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale
           decals:
-            2989: 27,6
-            2990: 26,6
-            2991: 25,6
-            2992: 24,6
-            2993: 23,6
-            2994: 22,6
-            2995: 21,6
-            2996: 20,6
-            2997: 19,6
-            2998: 18,6
-            2999: 17,6
-            3130: 35,18
-            3131: 34,18
+            2980: 27,6
+            2981: 26,6
+            2982: 25,6
+            2983: 24,6
+            2984: 23,6
+            2985: 22,6
+            2986: 21,6
+            2987: 20,6
+            2988: 19,6
+            2989: 18,6
+            2990: 17,6
+            3121: 35,18
+            3122: 34,18
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale
           decals:
-            7396: -43,-18
+            7387: -43,-18
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale
@@ -5394,16 +5394,16 @@ entities:
             884: -31,0
             885: -32,0
             1237: -33,0
-            1605: -34,-44
-            1606: -35,-44
-            2092: -36,-44
-            2093: -37,-44
-            2094: -38,-44
-            2095: -39,-44
-            2096: -40,-44
-            2097: -41,-44
-            2098: -42,-44
-            2099: -43,-44
+            1596: -34,-44
+            1597: -35,-44
+            2083: -36,-44
+            2084: -37,-44
+            2085: -38,-44
+            2086: -39,-44
+            2087: -40,-44
+            2088: -41,-44
+            2089: -42,-44
+            2090: -43,-44
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale
@@ -5412,196 +5412,196 @@ entities:
             460: -14,2
             461: -18,2
             462: -19,2
-            2151: -43,-32
-            2152: -45,-32
-            2197: -37,-49
-            2608: -20,2
-            2609: -21,2
-            2610: -22,2
-            2611: -23,2
-            2612: -24,2
-            2613: -25,2
-            2614: -26,2
-            2615: -27,2
-            2616: -28,2
-            2617: -29,2
-            2618: -30,2
-            2619: -31,2
-            2620: -32,2
-            2711: 13,2
-            2712: 15,2
-            2713: 16,2
-            2714: 17,2
-            3497: 27,2
-            3498: 26,2
-            3499: 25,2
-            3500: 24,2
-            3501: 23,2
-            3502: 22,2
-            3503: 21,2
-            3504: 20,2
-            3505: 19,2
-            3506: 18,2
-            3516: 31,2
-            3517: 32,2
-            3518: 33,2
-            3519: 34,2
-            3520: 35,2
-            3530: 35,8
-            3531: 34,8
-            3532: 33,8
-            3533: 32,8
-            3534: 31,8
-            3540: 17,10
-            3541: 18,10
-            3542: 19,10
-            3587: 27,33
-            3603: 31,30
-            3604: 32,30
-            3605: 33,30
-            3606: 34,30
-            3607: 35,30
-            3608: 36,30
-            3609: 37,30
-            3610: 38,30
-            3611: 39,30
-            3726: 34,-6
-            3727: 35,-6
-            3728: 36,-6
-            3729: 37,-6
-            3730: 38,-6
-            3731: 39,-6
-            3732: 40,-6
-            3733: 41,-6
-            4042: -3,20
-            4043: -4,20
-            4044: -5,20
-            4045: -6,20
-            4046: -7,20
-            4047: -8,20
-            4048: -9,20
-            4049: -10,20
-            4050: -11,20
-            4051: -12,20
-            4052: -13,20
-            4053: -14,20
-            4175: -25,25
-            4176: -26,25
-            4217: -6,29
-            4218: -7,29
-            4219: -8,29
-            4220: -9,29
-            4221: -10,29
-            4222: -11,29
-            4279: -17,36
-            4280: -16,36
-            4316: -20,36
-            4392: -39,37
-            4393: -40,37
-            4394: -41,37
-            4395: -42,37
-            4479: -38,30
-            4480: -37,30
-            4481: -36,30
-            4513: -34,30
-            4514: -33,30
-            4515: -32,30
-            4516: -31,30
-            4517: -30,30
-            4518: -29,30
-            4519: -28,30
-            4520: -27,30
-            4521: -26,30
-            4536: -22,29
-            4537: -21,29
-            4538: -20,29
-            4539: -19,29
-            4540: -18,29
-            6174: 8,-40
-            6175: 7,-40
-            6176: 6,-40
-            6177: 5,-40
-            6178: 4,-40
-            6386: -1,-56
-            6387: -2,-56
-            6388: -3,-56
-            6389: -4,-56
-            6390: -5,-56
-            6391: -6,-56
-            6392: -7,-56
-            6934: 29,-64
-            6935: 28,-64
-            6936: 27,-64
-            6937: 26,-64
-            6938: 25,-64
-            6945: 30,-54
-            6946: 29,-54
-            6971: 23,-50
-            6972: 24,-50
-            6973: 25,-50
-            6974: 26,-50
-            6975: 27,-50
-            6976: 28,-50
-            6977: 29,-50
-            6978: 30,-50
-            6979: 31,-50
-            7187: 11,-41
-            7188: 12,-41
-            7189: 14,-41
-            7190: 13,-41
-            7191: 15,-41
-            7192: 16,-41
-            7193: 17,-41
-            7194: 18,-41
-            7195: 19,-41
-            7196: 20,-41
-            7197: 21,-41
-            7198: 22,-41
-            7199: 23,-41
-            7200: 24,-41
-            7201: 25,-41
-            7202: 26,-41
-            7203: 27,-41
-            7204: 28,-41
-            7205: 29,-41
-            7209: 31,-42
+            2142: -43,-32
+            2143: -45,-32
+            2188: -37,-49
+            2599: -20,2
+            2600: -21,2
+            2601: -22,2
+            2602: -23,2
+            2603: -24,2
+            2604: -25,2
+            2605: -26,2
+            2606: -27,2
+            2607: -28,2
+            2608: -29,2
+            2609: -30,2
+            2610: -31,2
+            2611: -32,2
+            2702: 13,2
+            2703: 15,2
+            2704: 16,2
+            2705: 17,2
+            3488: 27,2
+            3489: 26,2
+            3490: 25,2
+            3491: 24,2
+            3492: 23,2
+            3493: 22,2
+            3494: 21,2
+            3495: 20,2
+            3496: 19,2
+            3497: 18,2
+            3507: 31,2
+            3508: 32,2
+            3509: 33,2
+            3510: 34,2
+            3511: 35,2
+            3521: 35,8
+            3522: 34,8
+            3523: 33,8
+            3524: 32,8
+            3525: 31,8
+            3531: 17,10
+            3532: 18,10
+            3533: 19,10
+            3578: 27,33
+            3594: 31,30
+            3595: 32,30
+            3596: 33,30
+            3597: 34,30
+            3598: 35,30
+            3599: 36,30
+            3600: 37,30
+            3601: 38,30
+            3602: 39,30
+            3717: 34,-6
+            3718: 35,-6
+            3719: 36,-6
+            3720: 37,-6
+            3721: 38,-6
+            3722: 39,-6
+            3723: 40,-6
+            3724: 41,-6
+            4033: -3,20
+            4034: -4,20
+            4035: -5,20
+            4036: -6,20
+            4037: -7,20
+            4038: -8,20
+            4039: -9,20
+            4040: -10,20
+            4041: -11,20
+            4042: -12,20
+            4043: -13,20
+            4044: -14,20
+            4166: -25,25
+            4167: -26,25
+            4208: -6,29
+            4209: -7,29
+            4210: -8,29
+            4211: -9,29
+            4212: -10,29
+            4213: -11,29
+            4270: -17,36
+            4271: -16,36
+            4307: -20,36
+            4383: -39,37
+            4384: -40,37
+            4385: -41,37
+            4386: -42,37
+            4470: -38,30
+            4471: -37,30
+            4472: -36,30
+            4504: -34,30
+            4505: -33,30
+            4506: -32,30
+            4507: -31,30
+            4508: -30,30
+            4509: -29,30
+            4510: -28,30
+            4511: -27,30
+            4512: -26,30
+            4527: -22,29
+            4528: -21,29
+            4529: -20,29
+            4530: -19,29
+            4531: -18,29
+            6165: 8,-40
+            6166: 7,-40
+            6167: 6,-40
+            6168: 5,-40
+            6169: 4,-40
+            6377: -1,-56
+            6378: -2,-56
+            6379: -3,-56
+            6380: -4,-56
+            6381: -5,-56
+            6382: -6,-56
+            6383: -7,-56
+            6925: 29,-64
+            6926: 28,-64
+            6927: 27,-64
+            6928: 26,-64
+            6929: 25,-64
+            6936: 30,-54
+            6937: 29,-54
+            6962: 23,-50
+            6963: 24,-50
+            6964: 25,-50
+            6965: 26,-50
+            6966: 27,-50
+            6967: 28,-50
+            6968: 29,-50
+            6969: 30,-50
+            6970: 31,-50
+            7178: 11,-41
+            7179: 12,-41
+            7180: 14,-41
+            7181: 13,-41
+            7182: 15,-41
+            7183: 16,-41
+            7184: 17,-41
+            7185: 18,-41
+            7186: 19,-41
+            7187: 20,-41
+            7188: 21,-41
+            7189: 22,-41
+            7190: 23,-41
+            7191: 24,-41
+            7192: 25,-41
+            7193: 26,-41
+            7194: 27,-41
+            7195: 28,-41
+            7196: 29,-41
+            7200: 31,-42
         - node:
             color: '#D4D4D496'
             id: HalfTileOverlayGreyscale
           decals:
-            5403: 36,-29
+            5394: 36,-29
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale
           decals:
-            2763: 29,-3
-            2764: 28,-3
-            3907: 45,-17
-            4131: -16,23
-            4245: -8,34
-            4247: -10,35
-            4573: -4,34
-            4574: -4,40
-            4575: -5,40
-            4576: -6,40
-            5515: 5,-19
-            6229: 3,-49
+            2754: 29,-3
+            2755: 28,-3
+            3898: 45,-17
+            4122: -16,23
+            4236: -8,34
+            4238: -10,35
+            4564: -4,34
+            4565: -4,40
+            4566: -5,40
+            4567: -6,40
+            5506: 5,-19
+            6220: 3,-49
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale
           decals:
-            6154: 1,-42
-            6155: 2,-42
-            6164: 9,-42
-            6165: 8,-42
-            6166: 7,-42
-            6167: 4,-42
-            6215: 0,-47
-            6216: 1,-47
-            6217: 2,-47
-            6218: 3,-47
-            6219: 4,-47
-            6220: 5,-47
+            6145: 1,-42
+            6146: 2,-42
+            6155: 9,-42
+            6156: 8,-42
+            6157: 7,-42
+            6158: 4,-42
+            6206: 0,-47
+            6207: 1,-47
+            6208: 2,-47
+            6209: 3,-47
+            6210: 4,-47
+            6211: 5,-47
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale
@@ -5618,75 +5618,75 @@ entities:
             833: -28,-6
             834: -27,-6
             1283: -33,-24
-            1484: -32,-33
-            1485: -31,-33
-            1486: -30,-33
-            1487: -29,-33
-            1633: -26,-32
-            1634: -27,-32
-            1647: -24,-29
-            1764: -20,-29
-            1765: -19,-29
-            1766: -18,-29
-            1767: -17,-29
-            1768: -16,-29
-            1769: -15,-29
-            1770: -14,-29
-            1771: -13,-29
-            1772: -12,-29
-            1773: -11,-29
-            2069: -10,-29
-            2070: -6,-29
-            2075: -4,-29
-            2076: -3,-29
-            2832: 14,0
-            2833: 15,0
-            2834: 16,0
-            2835: 17,0
-            2836: 18,0
-            2837: 19,0
-            2838: 20,0
-            2839: 21,0
-            2840: 22,0
-            2841: 23,0
-            2842: 24,0
-            2843: 25,0
-            2844: 26,0
-            2845: 27,0
-            2846: 28,0
-            2847: 29,0
-            2848: 30,0
-            2849: 31,0
-            2850: 32,0
-            2851: 33,0
-            2968: 23,9
-            2969: 24,9
-            2970: 25,9
-            5170: 15,-17
-            5171: 16,-17
-            5172: 17,-17
-            5173: 19,-16
-            5709: 15,-29
-            5710: 16,-29
-            5711: 17,-29
-            5712: 18,-29
-            5713: 19,-29
-            5714: 20,-29
-            5715: 21,-29
-            5716: 22,-29
-            5720: 24,-26
-            5721: 25,-26
-            5724: 28,-26
-            5725: 29,-26
-            5726: 30,-26
-            5727: 31,-26
-            5728: 32,-26
-            5729: 33,-26
-            5730: 34,-26
-            5731: 35,-26
-            5732: 36,-26
-            5733: 37,-26
-            5874: 38,-26
+            1475: -32,-33
+            1476: -31,-33
+            1477: -30,-33
+            1478: -29,-33
+            1624: -26,-32
+            1625: -27,-32
+            1638: -24,-29
+            1755: -20,-29
+            1756: -19,-29
+            1757: -18,-29
+            1758: -17,-29
+            1759: -16,-29
+            1760: -15,-29
+            1761: -14,-29
+            1762: -13,-29
+            1763: -12,-29
+            1764: -11,-29
+            2060: -10,-29
+            2061: -6,-29
+            2066: -4,-29
+            2067: -3,-29
+            2823: 14,0
+            2824: 15,0
+            2825: 16,0
+            2826: 17,0
+            2827: 18,0
+            2828: 19,0
+            2829: 20,0
+            2830: 21,0
+            2831: 22,0
+            2832: 23,0
+            2833: 24,0
+            2834: 25,0
+            2835: 26,0
+            2836: 27,0
+            2837: 28,0
+            2838: 29,0
+            2839: 30,0
+            2840: 31,0
+            2841: 32,0
+            2842: 33,0
+            2959: 23,9
+            2960: 24,9
+            2961: 25,9
+            5161: 15,-17
+            5162: 16,-17
+            5163: 17,-17
+            5164: 19,-16
+            5700: 15,-29
+            5701: 16,-29
+            5702: 17,-29
+            5703: 18,-29
+            5704: 19,-29
+            5705: 20,-29
+            5706: 21,-29
+            5707: 22,-29
+            5711: 24,-26
+            5712: 25,-26
+            5715: 28,-26
+            5716: 29,-26
+            5717: 30,-26
+            5718: 31,-26
+            5719: 32,-26
+            5720: 33,-26
+            5721: 34,-26
+            5722: 35,-26
+            5723: 36,-26
+            5724: 37,-26
+            5865: 38,-26
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale180
@@ -5703,68 +5703,68 @@ entities:
             270: -2,-4
             304: 8,9
             305: 7,9
-            3787: 41,-6
-            3788: 40,-6
-            3789: 39,-6
-            3790: 38,-6
-            3791: 37,-6
-            3792: 36,-6
-            3793: 35,-6
-            3794: 34,-6
-            3818: 33,-12
-            3819: 34,-12
-            3820: 35,-12
-            3823: 39,-12
-            3824: 40,-12
-            3825: 41,-12
-            3826: 42,-12
+            3778: 41,-6
+            3779: 40,-6
+            3780: 39,-6
+            3781: 38,-6
+            3782: 37,-6
+            3783: 36,-6
+            3784: 35,-6
+            3785: 34,-6
+            3809: 33,-12
+            3810: 34,-12
+            3811: 35,-12
+            3814: 39,-12
+            3815: 40,-12
+            3816: 41,-12
+            3817: 42,-12
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale180
           decals:
-            5070: 6,71
-            5071: 8,71
-            5072: 9,71
-            5073: -4,71
-            5074: -6,71
-            5075: -7,71
-            6501: 2,26
-            6520: 5,24
-            6521: 6,24
-            6522: 7,24
-            6523: 8,24
+            5061: 6,71
+            5062: 8,71
+            5063: 9,71
+            5064: -4,71
+            5065: -6,71
+            5066: -7,71
+            6492: 2,26
+            6511: 5,24
+            6512: 6,24
+            6513: 7,24
+            6514: 8,24
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale180
           decals:
-            3374: 32,29
-            3375: 33,29
-            3376: 34,29
-            3377: 35,29
-            3378: 36,29
-            3379: 37,29
-            3380: 38,29
-            3381: 39,29
+            3365: 32,29
+            3366: 33,29
+            3367: 34,29
+            3368: 35,29
+            3369: 36,29
+            3370: 37,29
+            3371: 38,29
+            3372: 39,29
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale180
           decals:
-            5467: 31,-29
-            5529: 9,-20
-            5579: 10,-27
-            5580: 9,-27
-            5581: 8,-27
-            5582: 7,-27
-            5583: 6,-27
-            5584: 5,-27
-            5585: 4,-27
-            5871: 42,-25
-            5872: 41,-25
-            5942: 13,-36
-            5974: 24,-37
-            7221: 8,-38
-            7246: 43,-38
-            7247: 42,-38
+            5458: 31,-29
+            5520: 9,-20
+            5570: 10,-27
+            5571: 9,-27
+            5572: 8,-27
+            5573: 7,-27
+            5574: 6,-27
+            5575: 5,-27
+            5576: 4,-27
+            5862: 42,-25
+            5863: 41,-25
+            5933: 13,-36
+            5965: 24,-37
+            7212: 8,-38
+            7237: 43,-38
+            7238: 42,-38
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale180
@@ -5778,51 +5778,51 @@ entities:
             68: 11,1
             69: 12,1
             70: 13,1
-            2864: 14,1
-            2865: 15,1
-            2866: 16,1
-            2867: 17,1
-            2868: 18,1
-            2869: 19,1
-            2870: 20,1
-            2871: 21,1
-            2872: 22,1
-            2873: 23,1
-            2874: 24,1
-            2875: 25,1
-            2876: 26,1
-            2877: 27,1
-            2878: 28,1
-            3000: 17,7
-            3001: 18,7
-            3002: 19,7
-            3003: 20,7
-            3004: 21,7
-            3005: 22,7
-            3006: 23,7
-            3007: 24,7
-            3008: 25,7
-            3009: 26,7
-            3010: 27,7
-            3132: 35,14
-            3133: 34,14
-            5877: 22,-25
-            5878: 23,-25
-            5879: 24,-25
-            5880: 25,-25
-            5881: 28,-25
-            5882: 29,-25
-            5883: 30,-25
-            5884: 31,-25
-            5885: 32,-25
-            5886: 33,-25
-            5887: 34,-25
-            5888: 35,-25
-            5889: 36,-25
-            5890: 37,-25
-            5891: 38,-25
-            5892: 39,-25
-            5894: 40,-25
+            2855: 14,1
+            2856: 15,1
+            2857: 16,1
+            2858: 17,1
+            2859: 18,1
+            2860: 19,1
+            2861: 20,1
+            2862: 21,1
+            2863: 22,1
+            2864: 23,1
+            2865: 24,1
+            2866: 25,1
+            2867: 26,1
+            2868: 27,1
+            2869: 28,1
+            2991: 17,7
+            2992: 18,7
+            2993: 19,7
+            2994: 20,7
+            2995: 21,7
+            2996: 22,7
+            2997: 23,7
+            2998: 24,7
+            2999: 25,7
+            3000: 26,7
+            3001: 27,7
+            3123: 35,14
+            3124: 34,14
+            5868: 22,-25
+            5869: 23,-25
+            5870: 24,-25
+            5871: 25,-25
+            5872: 28,-25
+            5873: 29,-25
+            5874: 30,-25
+            5875: 31,-25
+            5876: 32,-25
+            5877: 33,-25
+            5878: 34,-25
+            5879: 35,-25
+            5880: 36,-25
+            5881: 37,-25
+            5882: 38,-25
+            5883: 39,-25
+            5885: 40,-25
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale180
@@ -5867,16 +5867,16 @@ entities:
             id: HalfTileOverlayGreyscale180
           decals:
             545: 9,11
-            1607: -35,-43
-            2100: -37,-43
-            2101: -36,-43
-            2102: -38,-43
-            2103: -39,-43
-            2104: -40,-43
-            2105: -41,-43
-            2108: -43,-42
-            2423: -21,-53
-            2465: -27,-57
+            1598: -35,-43
+            2091: -37,-43
+            2092: -36,-43
+            2093: -38,-43
+            2094: -39,-43
+            2095: -40,-43
+            2096: -41,-43
+            2099: -43,-42
+            2414: -21,-53
+            2456: -27,-57
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale180
@@ -5885,239 +5885,239 @@ entities:
             464: -14,-1
             465: -18,-1
             466: -19,-1
-            2126: -43,-39
-            2198: -37,-46
-            2214: -35,-47
-            2217: -33,-47
-            2218: -32,-47
-            2604: -23,-1
-            2605: -24,-1
-            2606: -25,-1
-            2607: -26,-1
-            2634: -36,6
-            2663: -32,-1
-            2666: -27,-1
-            2667: -28,-1
-            2707: 13,-1
-            2708: 15,-1
-            2709: 16,-1
-            2710: 17,-1
-            3480: 18,-1
-            3481: 19,-1
-            3482: 20,-1
-            3483: 21,-1
-            3484: 22,-1
-            3485: 23,-1
-            3486: 24,-1
-            3487: 25,-1
-            3488: 26,-1
-            3489: 27,-1
-            3490: 28,-1
-            3491: 29,-1
-            3492: 30,-1
-            3493: 31,-1
-            3494: 32,-1
-            3495: 33,-1
-            3526: 32,6
-            3527: 33,6
-            3528: 34,6
-            3529: 35,6
-            3586: 27,29
-            3649: 41,27
-            3654: 36,26
-            3655: 35,26
-            3656: 34,26
-            3657: 33,26
-            3658: 32,26
-            3659: 31,26
-            3706: 37,-11
-            3707: 38,-11
-            3708: 39,-11
-            3709: 40,-11
-            3710: 41,-11
-            3711: 36,-11
-            3712: 35,-11
-            3713: 34,-11
-            4058: -16,18
-            4059: -15,18
-            4060: -14,18
-            4061: -13,18
-            4062: -12,18
-            4063: -11,18
-            4064: -10,18
-            4065: -9,18
-            4066: -8,18
-            4067: -7,18
-            4068: -6,18
-            4069: -5,18
-            4070: -4,18
-            4071: -3,18
-            4173: -25,23
-            4174: -26,23
-            4200: -14,27
-            4201: -13,27
-            4202: -12,27
-            4203: -11,27
-            4204: -10,27
-            4205: -9,27
-            4206: -8,27
-            4207: -7,27
-            4208: -6,27
-            4209: -5,27
-            4210: -4,27
-            4285: -17,31
-            4317: -20,31
-            4447: -39,19
-            4448: -40,19
-            4449: -41,19
-            4450: -42,19
-            4451: -43,19
-            4541: -18,27
-            4542: -19,27
-            4543: -20,27
-            4544: -21,27
-            4545: -22,27
-            4549: -26,28
-            4550: -27,28
-            4551: -28,28
-            4552: -29,28
-            4553: -30,28
-            4554: -31,28
-            4555: -32,28
-            4556: -33,28
-            4557: -34,28
-            6136: 0,-43
-            6137: 1,-43
-            6138: 2,-43
-            6179: 4,-43
-            6180: 7,-43
-            6181: 8,-43
-            6376: -7,-61
-            6377: -6,-61
-            6378: -5,-61
-            6379: -4,-61
-            6380: -3,-61
-            6381: -2,-61
-            6382: -1,-61
-            6927: 25,-62
-            6928: 26,-62
-            6929: 27,-62
-            6930: 28,-62
-            6931: 29,-62
-            6943: 29,-51
-            6944: 30,-51
-            6955: 16,-49
-            6956: 17,-49
-            6957: 18,-49
-            6958: 19,-49
-            6959: 20,-49
-            6960: 21,-49
-            6961: 22,-49
-            6962: 23,-49
-            6963: 24,-49
-            6964: 25,-49
-            6965: 26,-49
-            6966: 27,-49
-            6967: 28,-49
-            6968: 29,-49
-            6969: 30,-49
-            6970: 31,-49
-            6996: 31,-65
-            6997: 30,-65
-            6998: 29,-65
-            6999: 28,-65
-            7000: 27,-65
-            7001: 26,-65
-            7002: 25,-65
-            7003: 24,-65
-            7004: 23,-65
+            2117: -43,-39
+            2189: -37,-46
+            2205: -35,-47
+            2208: -33,-47
+            2209: -32,-47
+            2595: -23,-1
+            2596: -24,-1
+            2597: -25,-1
+            2598: -26,-1
+            2625: -36,6
+            2654: -32,-1
+            2657: -27,-1
+            2658: -28,-1
+            2698: 13,-1
+            2699: 15,-1
+            2700: 16,-1
+            2701: 17,-1
+            3471: 18,-1
+            3472: 19,-1
+            3473: 20,-1
+            3474: 21,-1
+            3475: 22,-1
+            3476: 23,-1
+            3477: 24,-1
+            3478: 25,-1
+            3479: 26,-1
+            3480: 27,-1
+            3481: 28,-1
+            3482: 29,-1
+            3483: 30,-1
+            3484: 31,-1
+            3485: 32,-1
+            3486: 33,-1
+            3517: 32,6
+            3518: 33,6
+            3519: 34,6
+            3520: 35,6
+            3577: 27,29
+            3640: 41,27
+            3645: 36,26
+            3646: 35,26
+            3647: 34,26
+            3648: 33,26
+            3649: 32,26
+            3650: 31,26
+            3697: 37,-11
+            3698: 38,-11
+            3699: 39,-11
+            3700: 40,-11
+            3701: 41,-11
+            3702: 36,-11
+            3703: 35,-11
+            3704: 34,-11
+            4049: -16,18
+            4050: -15,18
+            4051: -14,18
+            4052: -13,18
+            4053: -12,18
+            4054: -11,18
+            4055: -10,18
+            4056: -9,18
+            4057: -8,18
+            4058: -7,18
+            4059: -6,18
+            4060: -5,18
+            4061: -4,18
+            4062: -3,18
+            4164: -25,23
+            4165: -26,23
+            4191: -14,27
+            4192: -13,27
+            4193: -12,27
+            4194: -11,27
+            4195: -10,27
+            4196: -9,27
+            4197: -8,27
+            4198: -7,27
+            4199: -6,27
+            4200: -5,27
+            4201: -4,27
+            4276: -17,31
+            4308: -20,31
+            4438: -39,19
+            4439: -40,19
+            4440: -41,19
+            4441: -42,19
+            4442: -43,19
+            4532: -18,27
+            4533: -19,27
+            4534: -20,27
+            4535: -21,27
+            4536: -22,27
+            4540: -26,28
+            4541: -27,28
+            4542: -28,28
+            4543: -29,28
+            4544: -30,28
+            4545: -31,28
+            4546: -32,28
+            4547: -33,28
+            4548: -34,28
+            6127: 0,-43
+            6128: 1,-43
+            6129: 2,-43
+            6170: 4,-43
+            6171: 7,-43
+            6172: 8,-43
+            6367: -7,-61
+            6368: -6,-61
+            6369: -5,-61
+            6370: -4,-61
+            6371: -3,-61
+            6372: -2,-61
+            6373: -1,-61
+            6918: 25,-62
+            6919: 26,-62
+            6920: 27,-62
+            6921: 28,-62
+            6922: 29,-62
+            6934: 29,-51
+            6935: 30,-51
+            6946: 16,-49
+            6947: 17,-49
+            6948: 18,-49
+            6949: 19,-49
+            6950: 20,-49
+            6951: 21,-49
+            6952: 22,-49
+            6953: 23,-49
+            6954: 24,-49
+            6955: 25,-49
+            6956: 26,-49
+            6957: 27,-49
+            6958: 28,-49
+            6959: 29,-49
+            6960: 30,-49
+            6961: 31,-49
+            6987: 31,-65
+            6988: 30,-65
+            6989: 29,-65
+            6990: 28,-65
+            6991: 27,-65
+            6992: 26,-65
+            6993: 25,-65
+            6994: 24,-65
+            6995: 23,-65
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale180
           decals:
-            2761: 29,-5
-            2762: 28,-5
-            3900: 44,-19
-            3901: 45,-19
-            4130: -16,22
-            4250: -10,31
-            4251: -11,31
-            4252: -12,31
-            4253: -8,32
-            4572: -4,33
-            4580: -6,36
-            4581: -5,36
-            4582: -4,36
-            5514: 5,-20
-            6227: 3,-51
+            2752: 29,-5
+            2753: 28,-5
+            3891: 44,-19
+            3892: 45,-19
+            4121: -16,22
+            4241: -10,31
+            4242: -11,31
+            4243: -12,31
+            4244: -8,32
+            4563: -4,33
+            4571: -6,36
+            4572: -5,36
+            4573: -4,36
+            5505: 5,-20
+            6218: 3,-51
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale180
           decals:
-            6156: 2,-41
-            6157: 8,-41
-            6158: 7,-41
-            6159: 6,-41
-            6160: 5,-41
-            6161: 4,-41
-            6162: 3,-41
-            6163: 9,-41
-            6206: 4,-46
-            6207: 3,-46
-            6208: 2,-46
-            6209: 1,-46
-            6210: 0,-46
-            6211: -1,-46
+            6147: 2,-41
+            6148: 8,-41
+            6149: 7,-41
+            6150: 6,-41
+            6151: 5,-41
+            6152: 4,-41
+            6153: 3,-41
+            6154: 9,-41
+            6197: 4,-46
+            6198: 3,-46
+            6199: 2,-46
+            6200: 1,-46
+            6201: 0,-46
+            6202: -1,-46
         - node:
             color: '#FF924493'
             id: HalfTileOverlayGreyscale180
           decals:
-            5341: 30,-19
+            5332: 30,-19
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale180
           decals:
             831: -28,-5
             832: -27,-5
-            1475: -32,-30
-            1476: -28,-30
-            1477: -34,-27
-            1478: -35,-27
-            1479: -36,-27
-            1639: -26,-27
-            1640: -25,-27
-            1745: -21,-27
-            1746: -20,-27
-            1747: -19,-27
-            1748: -15,-27
-            1749: -14,-27
-            1750: -13,-27
-            1755: -9,-27
-            2071: -6,-27
-            2072: -7,-27
-            2073: -8,-27
-            2859: 34,1
-            2860: 33,1
-            2861: 32,1
-            2862: 31,1
-            2863: 30,1
-            5169: 16,-14
-            5174: 19,-15
-            5738: 39,-24
-            5739: 40,-24
-            5740: 41,-24
-            5747: 20,-24
-            5748: 21,-24
-            5749: 22,-24
-            5750: 23,-24
-            5751: 28,-24
-            5752: 29,-24
-            5753: 33,-24
-            5754: 34,-24
-            5755: 35,-24
-            5756: 16,-24
-            5757: 15,-24
-            5900: 27,-24
+            1466: -32,-30
+            1467: -28,-30
+            1468: -34,-27
+            1469: -35,-27
+            1470: -36,-27
+            1630: -26,-27
+            1631: -25,-27
+            1736: -21,-27
+            1737: -20,-27
+            1738: -19,-27
+            1739: -15,-27
+            1740: -14,-27
+            1741: -13,-27
+            1746: -9,-27
+            2062: -6,-27
+            2063: -7,-27
+            2064: -8,-27
+            2850: 34,1
+            2851: 33,1
+            2852: 32,1
+            2853: 31,1
+            2854: 30,1
+            5160: 16,-14
+            5165: 19,-15
+            5729: 39,-24
+            5730: 40,-24
+            5731: 41,-24
+            5738: 20,-24
+            5739: 21,-24
+            5740: 22,-24
+            5741: 23,-24
+            5742: 28,-24
+            5743: 29,-24
+            5744: 33,-24
+            5745: 34,-24
+            5746: 35,-24
+            5747: 16,-24
+            5748: 15,-24
+            5891: 27,-24
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale270
@@ -6134,19 +6134,19 @@ entities:
             301: 10,6
             302: 9,7
             303: 9,8
-            3766: 36,-13
-            3775: 42,-7
-            3776: 42,-8
-            3777: 42,-9
-            3778: 42,-10
-            3811: 32,-6
-            3812: 32,-7
-            3813: 32,-8
-            3814: 32,-9
-            3815: 32,-10
-            3816: 32,-11
-            4842: 1,48
-            4982: 5,60
+            3757: 36,-13
+            3766: 42,-7
+            3767: 42,-8
+            3768: 42,-9
+            3769: 42,-10
+            3802: 32,-6
+            3803: 32,-7
+            3804: 32,-8
+            3805: 32,-9
+            3806: 32,-10
+            3807: 32,-11
+            4833: 1,48
+            4973: 5,60
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale270
@@ -6160,54 +6160,54 @@ entities:
             50: 1,11
             51: 1,12
             52: 1,13
-            4618: 1,14
-            4619: 1,15
-            4620: 1,16
-            4621: 1,17
-            4622: 1,18
-            4623: 1,19
-            4624: 1,20
-            4625: 1,21
-            4626: 1,22
-            4627: 1,23
-            4628: 1,24
-            4629: 1,25
-            4631: 1,27
-            4632: 1,28
-            4633: 1,29
-            4634: 1,30
-            4635: 1,31
-            4636: 1,32
-            4637: 1,33
-            4638: 1,34
-            4639: 1,35
-            4640: 1,36
-            4641: 1,37
-            4642: 1,38
-            4815: 1,45
-            4816: 1,44
-            4817: 1,43
-            4818: 1,42
-            4819: 1,41
-            4820: 1,40
-            4821: 1,39
-            4822: 1,47
-            4946: 1,51
-            4947: 1,50
-            4948: 1,49
-            4949: 1,48
-            4988: 5,60
+            4609: 1,14
+            4610: 1,15
+            4611: 1,16
+            4612: 1,17
+            4613: 1,18
+            4614: 1,19
+            4615: 1,20
+            4616: 1,21
+            4617: 1,22
+            4618: 1,23
+            4619: 1,24
+            4620: 1,25
+            4622: 1,27
+            4623: 1,28
+            4624: 1,29
+            4625: 1,30
+            4626: 1,31
+            4627: 1,32
+            4628: 1,33
+            4629: 1,34
+            4630: 1,35
+            4631: 1,36
+            4632: 1,37
+            4633: 1,38
+            4806: 1,45
+            4807: 1,44
+            4808: 1,43
+            4809: 1,42
+            4810: 1,41
+            4811: 1,40
+            4812: 1,39
+            4813: 1,47
+            4937: 1,51
+            4938: 1,50
+            4939: 1,49
+            4940: 1,48
+            4979: 5,60
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale270
           decals:
-            3041: 29,9
-            3042: 29,10
-            3043: 29,11
-            3044: 29,12
-            3350: 29,13
-            3351: 29,15
-            3352: 29,16
+            3032: 29,9
+            3033: 29,10
+            3034: 29,11
+            3035: 29,12
+            3341: 29,13
+            3342: 29,15
+            3343: 29,16
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale270
@@ -6222,39 +6222,39 @@ entities:
             87: 1,-11
             88: 1,-12
             588: 8,-14
-            2775: 22,-11
-            2776: 22,-10
-            5454: 27,-27
-            5455: 27,-28
-            5456: 27,-29
-            5457: 27,-30
-            5458: 27,-31
-            5824: 27,-26
-            5838: 27,-25
-            5940: 11,-36
-            5941: 14,-36
-            6063: 1,-13
-            6064: 1,-14
-            6065: 1,-15
-            6066: 1,-16
-            6067: 1,-17
-            6068: 1,-18
-            6069: 1,-19
-            6070: 1,-20
-            6071: 1,-21
-            6072: 1,-22
-            6073: 1,-23
-            6074: 1,-24
-            7223: 4,-35
-            7245: 39,-40
-            7248: 41,-38
+            2766: 22,-11
+            2767: 22,-10
+            5445: 27,-27
+            5446: 27,-28
+            5447: 27,-29
+            5448: 27,-30
+            5449: 27,-31
+            5815: 27,-26
+            5829: 27,-25
+            5931: 11,-36
+            5932: 14,-36
+            6054: 1,-13
+            6055: 1,-14
+            6056: 1,-15
+            6057: 1,-16
+            6058: 1,-17
+            6059: 1,-18
+            6060: 1,-19
+            6061: 1,-20
+            6062: 1,-21
+            6063: 1,-22
+            6064: 1,-23
+            6065: 1,-24
+            7214: 4,-35
+            7236: 39,-40
+            7239: 41,-38
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale270
           decals:
-            3114: 32,16
-            3115: 32,17
-            3116: 32,15
+            3105: 32,16
+            3106: 32,17
+            3107: 32,15
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale270
@@ -6270,7 +6270,7 @@ entities:
             1185: -38,-12
             1186: -38,-13
             1187: -38,-14
-            7397: -43,-19
+            7388: -43,-19
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale270
@@ -6278,12 +6278,12 @@ entities:
             547: 9,14
             1299: -39,-23
             1321: -40,-26
-            2111: -44,-41
-            2112: -44,-40
-            2113: -44,-39
-            2359: -22,-39
-            2360: -21,-42
-            2362: -21,-48
+            2102: -44,-41
+            2103: -44,-40
+            2104: -44,-39
+            2350: -22,-39
+            2351: -21,-42
+            2353: -21,-48
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale270
@@ -6292,287 +6292,287 @@ entities:
             1251: -32,15
             1252: -32,16
             1253: -32,17
-            2138: -44,-37
-            2139: -44,-36
-            2199: -36,-47
-            2200: -36,-48
-            2247: -32,-50
-            2248: -32,-51
-            2252: -32,-52
-            2624: -36,9
-            2625: -35,11
-            2626: -35,12
-            2635: -35,5
-            2636: -35,4
-            2637: -35,3
-            2638: -35,2
-            2639: -35,1
-            2640: -35,0
-            2641: -35,-1
-            2642: -35,-2
-            2643: -35,-3
-            2644: -35,-4
-            2645: -35,-5
-            2646: -35,-6
-            2647: -35,-7
-            2648: -35,-8
-            2649: -35,-9
-            2650: -35,-10
-            2651: -35,-11
-            2652: -35,-12
-            2653: -35,-13
-            2654: -35,-14
-            2682: -1,-12
-            2683: -1,-14
-            2684: -1,-15
-            2685: -1,-16
-            2686: -1,-17
-            2687: -1,-18
-            2688: -1,-19
-            2689: -1,-20
-            2694: -1,-26
-            2715: -1,13
-            2716: -1,15
-            2717: -1,16
-            2718: -1,17
-            3260: 12,20
-            3261: 12,23
-            3316: 23,25
-            3511: 28,3
-            3512: 28,4
-            3535: 16,6
-            3536: 16,7
-            3537: 16,8
-            3538: 16,9
-            3549: 28,9
-            3550: 28,10
-            3551: 28,11
-            3552: 28,12
-            3564: 28,16
-            3565: 28,17
-            3566: 28,18
-            3567: 28,20
-            3578: 28,22
-            3579: 28,23
-            3580: 28,24
-            3581: 28,25
-            3582: 28,26
-            3583: 28,27
-            3584: 28,28
-            3589: 28,34
-            3590: 28,35
-            3591: 28,36
-            3592: 28,37
-            3593: 28,38
-            3594: 28,39
-            3615: 42,30
-            3616: 42,31
-            3617: 42,32
-            3618: 42,33
-            3623: 42,40
-            3624: 42,41
-            3625: 42,42
-            3626: 42,43
-            3627: 42,44
-            3628: 42,45
-            3629: 42,46
-            3716: 33,-10
-            3717: 33,-9
-            3718: 33,-8
-            3719: 33,-7
-            3734: 35,-3
-            3735: 35,-4
-            3736: 35,-5
-            4055: -17,20
-            4056: -17,19
-            4138: -17,25
-            4139: -17,26
-            4215: -5,30
-            4286: -18,32
-            4287: -18,33
-            4288: -18,34
-            4289: -18,35
-            4318: -21,32
-            4319: -21,33
-            4320: -21,34
-            4321: -21,35
-            4390: -38,38
-            4397: -43,36
-            4398: -43,35
-            4399: -43,34
-            4400: -43,33
-            4401: -43,32
-            4402: -43,31
-            4452: -38,26
-            4453: -38,25
-            4454: -38,24
-            4455: -38,23
-            4456: -38,22
-            4525: -25,33
-            4526: -25,32
-            4527: -25,31
-            4547: -25,27
-            4701: -1,21
-            4702: -1,22
-            4703: -1,23
-            4704: -1,24
-            4705: -1,25
-            4706: -1,26
-            4707: -1,27
-            4708: -1,28
-            4709: -1,29
-            4710: -1,30
-            4711: -1,31
-            4712: -1,32
-            4713: -1,33
-            4714: -1,34
-            4715: -1,35
-            4718: -1,40
-            4719: -1,41
-            4825: -1,42
-            4826: -1,43
-            4827: -1,44
-            4828: -1,45
-            4829: -1,46
-            4830: -1,47
-            5352: 40,-18
-            5353: 40,-17
-            5354: 40,-16
-            6121: -1,-30
-            6122: -1,-31
-            6123: -1,-32
-            6124: -1,-33
-            6125: -1,-34
-            6126: -1,-35
-            6127: -1,-36
-            6128: -1,-37
-            6129: -1,-38
-            6130: -1,-38
-            6131: -1,-39
-            6132: -1,-40
-            6133: -1,-41
-            6134: -1,-42
-            6182: -3,-47
-            6183: -3,-46
-            6374: -8,-60
-            6394: -8,-57
-            6526: 28,19
-            6933: 30,-63
-            6947: 31,-53
-            6948: 31,-52
-            7006: 22,-64
-            7007: 22,-63
-            7008: 22,-62
-            7009: 22,-61
-            7010: 22,-60
-            7011: 22,-59
-            7012: 22,-58
-            7013: 22,-57
-            7014: 22,-56
-            7015: 22,-55
-            7180: 10,-47
-            7181: 10,-46
-            7182: 10,-45
-            7183: 10,-44
-            7184: 10,-43
-            7185: 10,-42
+            2129: -44,-37
+            2130: -44,-36
+            2190: -36,-47
+            2191: -36,-48
+            2238: -32,-50
+            2239: -32,-51
+            2243: -32,-52
+            2615: -36,9
+            2616: -35,11
+            2617: -35,12
+            2626: -35,5
+            2627: -35,4
+            2628: -35,3
+            2629: -35,2
+            2630: -35,1
+            2631: -35,0
+            2632: -35,-1
+            2633: -35,-2
+            2634: -35,-3
+            2635: -35,-4
+            2636: -35,-5
+            2637: -35,-6
+            2638: -35,-7
+            2639: -35,-8
+            2640: -35,-9
+            2641: -35,-10
+            2642: -35,-11
+            2643: -35,-12
+            2644: -35,-13
+            2645: -35,-14
+            2673: -1,-12
+            2674: -1,-14
+            2675: -1,-15
+            2676: -1,-16
+            2677: -1,-17
+            2678: -1,-18
+            2679: -1,-19
+            2680: -1,-20
+            2685: -1,-26
+            2706: -1,13
+            2707: -1,15
+            2708: -1,16
+            2709: -1,17
+            3251: 12,20
+            3252: 12,23
+            3307: 23,25
+            3502: 28,3
+            3503: 28,4
+            3526: 16,6
+            3527: 16,7
+            3528: 16,8
+            3529: 16,9
+            3540: 28,9
+            3541: 28,10
+            3542: 28,11
+            3543: 28,12
+            3555: 28,16
+            3556: 28,17
+            3557: 28,18
+            3558: 28,20
+            3569: 28,22
+            3570: 28,23
+            3571: 28,24
+            3572: 28,25
+            3573: 28,26
+            3574: 28,27
+            3575: 28,28
+            3580: 28,34
+            3581: 28,35
+            3582: 28,36
+            3583: 28,37
+            3584: 28,38
+            3585: 28,39
+            3606: 42,30
+            3607: 42,31
+            3608: 42,32
+            3609: 42,33
+            3614: 42,40
+            3615: 42,41
+            3616: 42,42
+            3617: 42,43
+            3618: 42,44
+            3619: 42,45
+            3620: 42,46
+            3707: 33,-10
+            3708: 33,-9
+            3709: 33,-8
+            3710: 33,-7
+            3725: 35,-3
+            3726: 35,-4
+            3727: 35,-5
+            4046: -17,20
+            4047: -17,19
+            4129: -17,25
+            4130: -17,26
+            4206: -5,30
+            4277: -18,32
+            4278: -18,33
+            4279: -18,34
+            4280: -18,35
+            4309: -21,32
+            4310: -21,33
+            4311: -21,34
+            4312: -21,35
+            4381: -38,38
+            4388: -43,36
+            4389: -43,35
+            4390: -43,34
+            4391: -43,33
+            4392: -43,32
+            4393: -43,31
+            4443: -38,26
+            4444: -38,25
+            4445: -38,24
+            4446: -38,23
+            4447: -38,22
+            4516: -25,33
+            4517: -25,32
+            4518: -25,31
+            4538: -25,27
+            4692: -1,21
+            4693: -1,22
+            4694: -1,23
+            4695: -1,24
+            4696: -1,25
+            4697: -1,26
+            4698: -1,27
+            4699: -1,28
+            4700: -1,29
+            4701: -1,30
+            4702: -1,31
+            4703: -1,32
+            4704: -1,33
+            4705: -1,34
+            4706: -1,35
+            4709: -1,40
+            4710: -1,41
+            4816: -1,42
+            4817: -1,43
+            4818: -1,44
+            4819: -1,45
+            4820: -1,46
+            4821: -1,47
+            5343: 40,-18
+            5344: 40,-17
+            5345: 40,-16
+            6112: -1,-30
+            6113: -1,-31
+            6114: -1,-32
+            6115: -1,-33
+            6116: -1,-34
+            6117: -1,-35
+            6118: -1,-36
+            6119: -1,-37
+            6120: -1,-38
+            6121: -1,-38
+            6122: -1,-39
+            6123: -1,-40
+            6124: -1,-41
+            6125: -1,-42
+            6173: -3,-47
+            6174: -3,-46
+            6365: -8,-60
+            6385: -8,-57
+            6517: 28,19
+            6924: 30,-63
+            6938: 31,-53
+            6939: 31,-52
+            6997: 22,-64
+            6998: 22,-63
+            6999: 22,-62
+            7000: 22,-61
+            7001: 22,-60
+            7002: 22,-59
+            7003: 22,-58
+            7004: 22,-57
+            7005: 22,-56
+            7006: 22,-55
+            7171: 10,-47
+            7172: 10,-46
+            7173: 10,-45
+            7174: 10,-44
+            7175: 10,-43
+            7176: 10,-42
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale270
           decals:
-            2765: 27,-4
-            3902: 43,-16
-            3903: 43,-17
-            3904: 43,-18
-            4237: -13,35
-            4238: -13,34
-            4239: -13,33
-            4240: -13,32
-            4577: -7,39
-            4578: -7,38
-            4579: -7,37
-            5003: -5,58
-            5004: -5,59
-            5005: -5,60
-            5006: -5,61
-            6228: 2,-50
+            2756: 27,-4
+            3893: 43,-16
+            3894: 43,-17
+            3895: 43,-18
+            4228: -13,35
+            4229: -13,34
+            4230: -13,33
+            4231: -13,32
+            4568: -7,39
+            4569: -7,38
+            4570: -7,37
+            4994: -5,58
+            4995: -5,59
+            4996: -5,60
+            4997: -5,61
+            6219: 2,-50
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale270
           decals:
-            6099: 1,-26
-            6100: 1,-27
-            6101: 1,-28
-            6102: 1,-29
-            6103: 1,-30
-            6104: 1,-31
-            6105: 1,-32
-            6106: 1,-33
-            6107: 1,-34
-            6139: 1,-35
-            6140: 1,-36
-            6141: 1,-37
-            6142: 1,-38
-            6143: 1,-39
-            6144: 1,-40
-            6170: 6,-43
-            6171: 6,-44
-            6203: 6,-45
-            6306: 2,-58
+            6090: 1,-26
+            6091: 1,-27
+            6092: 1,-28
+            6093: 1,-29
+            6094: 1,-30
+            6095: 1,-31
+            6096: 1,-32
+            6097: 1,-33
+            6098: 1,-34
+            6130: 1,-35
+            6131: 1,-36
+            6132: 1,-37
+            6133: 1,-38
+            6134: 1,-39
+            6135: 1,-40
+            6161: 6,-43
+            6162: 6,-44
+            6194: 6,-45
+            6297: 2,-58
         - node:
             color: '#FF924493'
             id: HalfTileOverlayGreyscale270
           decals:
-            5340: 31,-20
+            5331: 31,-20
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale270
           decals:
             1273: -33,-16
-            1482: -33,-34
-            1483: -33,-35
-            1488: -33,-29
-            1489: -33,-28
-            1587: -33,-36
-            1588: -33,-37
-            1589: -33,-38
-            1590: -33,-39
-            1591: -33,-40
-            1592: -33,-41
-            1593: -33,-42
-            1594: -33,-43
-            1595: -33,-44
-            1631: -25,-30
-            1632: -25,-31
-            1756: -10,-25
-            1757: -10,-24
-            1758: -10,-23
-            1759: -10,-22
-            2855: 35,-2
-            2856: 35,-1
-            2857: 35,0
-            2971: 26,10
-            2972: 26,11
-            5165: 14,-15
-            5166: 14,-16
-            5452: 32,-30
-            5453: 32,-31
-            5669: 27,-26
-            5705: 14,-32
-            5706: 14,-31
-            5707: 14,-30
-            5717: 23,-28
-            5718: 23,-27
-            5722: 26,-26
-            5759: 14,-23
-            5760: 14,-22
-            5761: 38,-23
-            5762: 38,-22
-            5763: 38,-21
-            5764: 38,-20
-            5765: 38,-19
-            5768: 38,-15
-            5820: 19,-23
+            1473: -33,-34
+            1474: -33,-35
+            1479: -33,-29
+            1480: -33,-28
+            1578: -33,-36
+            1579: -33,-37
+            1580: -33,-38
+            1581: -33,-39
+            1582: -33,-40
+            1583: -33,-41
+            1584: -33,-42
+            1585: -33,-43
+            1586: -33,-44
+            1622: -25,-30
+            1623: -25,-31
+            1747: -10,-25
+            1748: -10,-24
+            1749: -10,-23
+            1750: -10,-22
+            2846: 35,-2
+            2847: 35,-1
+            2848: 35,0
+            2962: 26,10
+            2963: 26,11
+            5156: 14,-15
+            5157: 14,-16
+            5443: 32,-30
+            5444: 32,-31
+            5660: 27,-26
+            5696: 14,-32
+            5697: 14,-31
+            5698: 14,-30
+            5708: 23,-28
+            5709: 23,-27
+            5713: 26,-26
+            5750: 14,-23
+            5751: 14,-22
+            5752: 38,-23
+            5753: 38,-22
+            5754: 38,-21
+            5755: 38,-20
+            5756: 38,-19
+            5759: 38,-15
+            5811: 19,-23
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale90
@@ -6589,74 +6589,74 @@ entities:
             282: -8,-6
             283: -8,-7
             455: -9,6
-            3767: 38,-13
-            3771: 33,-10
-            3772: 33,-9
-            3773: 33,-8
-            3774: 33,-7
-            3828: 43,-11
-            3829: 43,-10
-            3830: 43,-9
-            3831: 43,-8
-            3832: 43,-7
-            3833: 43,-6
-            4841: 0,48
-            4983: -4,60
+            3758: 38,-13
+            3762: 33,-10
+            3763: 33,-9
+            3764: 33,-8
+            3765: 33,-7
+            3819: 43,-11
+            3820: 43,-10
+            3821: 43,-9
+            3822: 43,-8
+            3823: 43,-7
+            3824: 43,-6
+            4832: 0,48
+            4974: -4,60
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale90
           decals:
-            4721: -12,47
-            4722: -6,44
-            4797: 0,39
-            4798: 0,40
-            4799: 0,41
-            4800: 0,42
-            4801: 0,43
-            4802: 0,44
-            4803: 0,45
-            4804: 0,46
-            4823: 0,47
-            4942: 0,51
-            4943: 0,50
-            4944: 0,49
-            4945: 0,48
-            4950: 1,50
-            4989: -4,60
+            4712: -12,47
+            4713: -6,44
+            4788: 0,39
+            4789: 0,40
+            4790: 0,41
+            4791: 0,42
+            4792: 0,43
+            4793: 0,44
+            4794: 0,45
+            4795: 0,46
+            4814: 0,47
+            4933: 0,51
+            4934: 0,50
+            4935: 0,49
+            4936: 0,48
+            4941: 1,50
+            4980: -4,60
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale90
           decals:
             590: 9,-16
-            2725: 21,-3
-            2812: 26,-12
-            5459: 26,-27
-            5460: 26,-28
-            5461: 26,-29
-            5462: 26,-30
-            5463: 26,-31
-            5825: 26,-26
-            5839: 26,-25
+            2716: 21,-3
+            2803: 26,-12
+            5450: 26,-27
+            5451: 26,-28
+            5452: 26,-29
+            5453: 26,-30
+            5454: 26,-31
+            5816: 26,-26
+            5830: 26,-25
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale90
           decals:
-            3021: 29,9
-            3022: 29,10
-            3023: 29,11
-            3024: 29,12
-            3109: 29,13
-            3110: 29,15
-            3111: 29,16
-            3136: 37,17
-            3137: 37,16
-            3138: 37,15
-            3312: 18,25
-            4999: 6,58
-            5000: 6,59
-            5001: 6,60
-            5002: 6,61
-            5407: 35,-33
+            3012: 29,9
+            3013: 29,10
+            3014: 29,11
+            3015: 29,12
+            3100: 29,13
+            3101: 29,15
+            3102: 29,16
+            3127: 37,17
+            3128: 37,16
+            3129: 37,15
+            3303: 18,25
+            4990: 6,58
+            4991: 6,59
+            4992: 6,60
+            4993: 6,61
+            5398: 35,-33
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale90
@@ -6664,7 +6664,7 @@ entities:
             894: -28,7
             901: -28,5
             902: -28,6
-            7400: -41,-21
+            7391: -41,-21
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale90
@@ -6673,12 +6673,12 @@ entities:
             549: 10,13
             550: 10,12
             1349: -46,-28
-            2114: -42,-41
-            2115: -42,-40
-            2116: -42,-39
-            2366: -20,-50
-            2424: -20,-53
-            2442: -28,-53
+            2105: -42,-41
+            2106: -42,-40
+            2107: -42,-39
+            2357: -20,-50
+            2415: -20,-53
+            2433: -28,-53
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale90
@@ -6687,176 +6687,176 @@ entities:
             1247: -36,15
             1248: -36,16
             1249: -36,17
-            2140: -46,-37
-            2141: -46,-36
-            2201: -38,-48
-            2202: -38,-47
-            2249: -33,-52
-            2250: -33,-51
-            2251: -33,-50
-            2621: -33,3
-            2622: -33,4
-            2623: -33,8
-            2655: -33,-7
-            2656: -33,-6
-            2657: -33,-5
-            2658: -33,-4
-            2659: -33,-3
-            2660: -33,-2
-            2696: 2,-23
-            2697: 2,-22
-            2698: 2,-21
-            2699: 2,-20
-            2700: 2,-19
-            2701: 2,-18
-            2702: 2,-17
-            2703: 2,-16
-            2704: 2,-15
-            2705: 2,-14
-            2706: 2,-12
-            2720: 2,15
-            2721: 2,16
-            2722: 2,13
-            3513: 30,4
-            3514: 30,3
-            3522: 36,1
-            3523: 36,0
-            3524: 36,-1
-            3544: 20,9
-            3553: 30,12
-            3554: 30,11
-            3555: 30,10
-            3556: 30,9
-            3559: 30,13
-            3560: 30,14
-            3568: 30,20
-            3574: 30,18
-            3577: 30,25
-            3599: 30,33
-            3600: 30,32
-            3601: 30,31
-            3630: 44,46
-            3631: 44,45
-            3632: 44,44
-            3633: 44,43
-            3634: 44,42
-            3635: 44,41
-            3638: 44,37
-            3639: 44,36
-            3640: 44,35
-            3641: 44,34
-            3644: 44,30
-            3645: 44,29
-            3646: 44,28
-            3647: 44,27
-            3720: 42,-10
-            3721: 42,-9
-            3722: 42,-8
-            3723: 42,-7
-            3737: 34,-3
-            3738: 34,-4
-            3739: 34,-5
-            4024: 2,20
-            4140: -15,25
-            4141: -15,26
-            4172: -24,24
-            4212: -3,28
-            4213: -3,29
-            4214: -3,30
-            4281: -15,35
-            4282: -15,34
-            4283: -15,33
-            4284: -15,32
-            4381: -37,32
-            4382: -37,33
-            4383: -37,34
-            4384: -37,35
-            4385: -37,36
-            4386: -37,37
-            4387: -37,38
-            4438: -36,26
-            4439: -36,25
-            4440: -36,24
-            4441: -36,23
-            4442: -36,22
-            4443: -36,21
-            4444: -36,20
-            4459: -39,22
-            4528: -23,36
-            4529: -23,35
-            4530: -23,34
-            4531: -23,33
-            4532: -23,32
-            4533: -23,31
-            4534: -23,30
-            4682: 2,21
-            4683: 2,22
-            4684: 2,23
-            4685: 2,29
-            4686: 2,30
-            4687: 2,31
-            4688: 2,32
-            4689: 2,33
-            4690: 2,34
-            4691: 2,35
-            4692: 2,36
-            4693: 2,37
-            4694: 2,38
-            4695: 2,39
-            4696: 2,40
-            4697: 2,41
-            4698: 2,42
-            4699: 2,43
-            4700: 2,44
-            5355: 41,-16
-            5356: 41,-17
-            5357: 41,-18
-            6109: 2,-28
-            6110: 2,-29
-            6111: 2,-30
-            6112: 2,-31
-            6113: 2,-32
-            6114: 2,-33
-            6115: 2,-34
-            6116: 2,-35
-            6117: 2,-36
-            6118: 2,-37
-            6119: 2,-38
-            6120: 2,-39
-            6383: 0,-58
-            6384: 0,-57
-            6503: 2,28
-            6505: 2,24
-            6525: 30,19
-            6940: 24,-63
-            6949: 28,-52
-            6950: 28,-53
-            6982: 32,-51
-            6983: 32,-52
-            6984: 32,-53
-            6985: 32,-54
-            6986: 32,-64
-            6987: 32,-63
-            6988: 32,-62
-            6989: 32,-61
-            6990: 32,-60
-            6991: 32,-59
-            6992: 32,-58
-            6993: 32,-57
-            6994: 32,-56
-            7210: 32,-43
-            7211: 32,-44
-            7212: 32,-45
-            7213: 32,-48
-            7214: 32,-47
-            7215: 32,-46
+            2131: -46,-37
+            2132: -46,-36
+            2192: -38,-48
+            2193: -38,-47
+            2240: -33,-52
+            2241: -33,-51
+            2242: -33,-50
+            2612: -33,3
+            2613: -33,4
+            2614: -33,8
+            2646: -33,-7
+            2647: -33,-6
+            2648: -33,-5
+            2649: -33,-4
+            2650: -33,-3
+            2651: -33,-2
+            2687: 2,-23
+            2688: 2,-22
+            2689: 2,-21
+            2690: 2,-20
+            2691: 2,-19
+            2692: 2,-18
+            2693: 2,-17
+            2694: 2,-16
+            2695: 2,-15
+            2696: 2,-14
+            2697: 2,-12
+            2711: 2,15
+            2712: 2,16
+            2713: 2,13
+            3504: 30,4
+            3505: 30,3
+            3513: 36,1
+            3514: 36,0
+            3515: 36,-1
+            3535: 20,9
+            3544: 30,12
+            3545: 30,11
+            3546: 30,10
+            3547: 30,9
+            3550: 30,13
+            3551: 30,14
+            3559: 30,20
+            3565: 30,18
+            3568: 30,25
+            3590: 30,33
+            3591: 30,32
+            3592: 30,31
+            3621: 44,46
+            3622: 44,45
+            3623: 44,44
+            3624: 44,43
+            3625: 44,42
+            3626: 44,41
+            3629: 44,37
+            3630: 44,36
+            3631: 44,35
+            3632: 44,34
+            3635: 44,30
+            3636: 44,29
+            3637: 44,28
+            3638: 44,27
+            3711: 42,-10
+            3712: 42,-9
+            3713: 42,-8
+            3714: 42,-7
+            3728: 34,-3
+            3729: 34,-4
+            3730: 34,-5
+            4015: 2,20
+            4131: -15,25
+            4132: -15,26
+            4163: -24,24
+            4203: -3,28
+            4204: -3,29
+            4205: -3,30
+            4272: -15,35
+            4273: -15,34
+            4274: -15,33
+            4275: -15,32
+            4372: -37,32
+            4373: -37,33
+            4374: -37,34
+            4375: -37,35
+            4376: -37,36
+            4377: -37,37
+            4378: -37,38
+            4429: -36,26
+            4430: -36,25
+            4431: -36,24
+            4432: -36,23
+            4433: -36,22
+            4434: -36,21
+            4435: -36,20
+            4450: -39,22
+            4519: -23,36
+            4520: -23,35
+            4521: -23,34
+            4522: -23,33
+            4523: -23,32
+            4524: -23,31
+            4525: -23,30
+            4673: 2,21
+            4674: 2,22
+            4675: 2,23
+            4676: 2,29
+            4677: 2,30
+            4678: 2,31
+            4679: 2,32
+            4680: 2,33
+            4681: 2,34
+            4682: 2,35
+            4683: 2,36
+            4684: 2,37
+            4685: 2,38
+            4686: 2,39
+            4687: 2,40
+            4688: 2,41
+            4689: 2,42
+            4690: 2,43
+            4691: 2,44
+            5346: 41,-16
+            5347: 41,-17
+            5348: 41,-18
+            6100: 2,-28
+            6101: 2,-29
+            6102: 2,-30
+            6103: 2,-31
+            6104: 2,-32
+            6105: 2,-33
+            6106: 2,-34
+            6107: 2,-35
+            6108: 2,-36
+            6109: 2,-37
+            6110: 2,-38
+            6111: 2,-39
+            6374: 0,-58
+            6375: 0,-57
+            6494: 2,28
+            6496: 2,24
+            6516: 30,19
+            6931: 24,-63
+            6940: 28,-52
+            6941: 28,-53
+            6973: 32,-51
+            6974: 32,-52
+            6975: 32,-53
+            6976: 32,-54
+            6977: 32,-64
+            6978: 32,-63
+            6979: 32,-62
+            6980: 32,-61
+            6981: 32,-60
+            6982: 32,-59
+            6983: 32,-58
+            6984: 32,-57
+            6985: 32,-56
+            7201: 32,-43
+            7202: 32,-44
+            7203: 32,-45
+            7204: 32,-48
+            7205: 32,-47
+            7206: 32,-46
         - node:
             color: '#D4D4D496'
             id: HalfTileOverlayGreyscale90
           decals:
-            2723: 19,-5
-            2724: 24,-3
-            2814: 25,-15
+            2714: 19,-5
+            2715: 24,-3
+            2805: 25,-15
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale90
@@ -6872,35 +6872,35 @@ entities:
             61: 0,13
             903: -22,4
             909: -20,11
-            2766: 30,-4
-            3905: 44,-16
-            3906: 46,-18
-            4017: 0,18
-            4018: 0,17
-            4019: 0,16
-            4020: 0,15
-            4021: 0,14
-            4583: -3,37
-            4584: -3,38
-            4585: -3,39
-            4601: 0,36
-            4602: 0,35
-            4603: 0,34
-            4604: 0,33
-            4605: 0,32
-            4606: 0,31
-            4607: 0,30
-            4608: 0,29
-            4609: 0,28
-            4610: 0,27
-            4611: 0,26
-            4612: 0,25
-            4613: 0,24
-            4614: 0,23
-            4615: 0,22
-            4616: 0,21
-            4617: 0,20
-            6230: 4,-50
+            2757: 30,-4
+            3896: 44,-16
+            3897: 46,-18
+            4008: 0,18
+            4009: 0,17
+            4010: 0,16
+            4011: 0,15
+            4012: 0,14
+            4574: -3,37
+            4575: -3,38
+            4576: -3,39
+            4592: 0,36
+            4593: 0,35
+            4594: 0,34
+            4595: 0,33
+            4596: 0,32
+            4597: 0,31
+            4598: 0,30
+            4599: 0,29
+            4600: 0,28
+            4601: 0,27
+            4602: 0,26
+            4603: 0,25
+            4604: 0,24
+            4605: 0,23
+            4606: 0,22
+            4607: 0,21
+            4608: 0,20
+            6221: 4,-50
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale90
@@ -6914,47 +6914,47 @@ entities:
             95: 0,-10
             96: 0,-11
             97: 0,-12
-            6077: 0,-14
-            6078: 0,-15
-            6079: 0,-16
-            6080: 0,-17
-            6081: 0,-13
-            6082: 0,-18
-            6083: 0,-19
-            6084: 0,-20
-            6085: 0,-21
-            6086: 0,-22
-            6087: 0,-23
-            6088: 0,-24
-            6089: 0,-25
-            6090: 0,-26
-            6091: 0,-27
-            6092: 0,-28
-            6093: 0,-29
-            6094: 0,-30
-            6095: 0,-31
-            6096: 0,-32
-            6097: 0,-33
-            6098: 0,-34
-            6146: 0,-35
-            6147: 0,-36
-            6148: 0,-37
-            6149: 0,-38
-            6150: 0,-39
-            6151: 0,-40
-            6152: 0,-41
-            6172: 5,-43
-            6173: 5,-44
-            6202: 5,-45
-            6213: -2,-47
-            6307: 4,-54
-            6308: 4,-55
-            6309: 4,-56
-            6310: 4,-57
-            6311: 4,-58
-            6312: 4,-59
-            6313: 4,-60
-            6314: 4,-61
+            6068: 0,-14
+            6069: 0,-15
+            6070: 0,-16
+            6071: 0,-17
+            6072: 0,-13
+            6073: 0,-18
+            6074: 0,-19
+            6075: 0,-20
+            6076: 0,-21
+            6077: 0,-22
+            6078: 0,-23
+            6079: 0,-24
+            6080: 0,-25
+            6081: 0,-26
+            6082: 0,-27
+            6083: 0,-28
+            6084: 0,-29
+            6085: 0,-30
+            6086: 0,-31
+            6087: 0,-32
+            6088: 0,-33
+            6089: 0,-34
+            6137: 0,-35
+            6138: 0,-36
+            6139: 0,-37
+            6140: 0,-38
+            6141: 0,-39
+            6142: 0,-40
+            6143: 0,-41
+            6163: 5,-43
+            6164: 5,-44
+            6193: 5,-45
+            6204: -2,-47
+            6298: 4,-54
+            6299: 4,-55
+            6300: 4,-56
+            6301: 4,-57
+            6302: 4,-58
+            6303: 4,-59
+            6304: 4,-60
+            6305: 4,-61
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale90
@@ -6962,50 +6962,50 @@ entities:
             1274: -35,-16
             1275: -35,-17
             1276: -35,-18
-            1480: -35,-34
-            1481: -35,-35
-            1490: -35,-33
-            1507: -31,-27
-            1508: -31,-28
-            1581: -35,-36
-            1582: -35,-37
-            1583: -35,-38
-            1584: -35,-39
-            1585: -35,-40
-            1586: -35,-41
-            1629: -27,-29
-            1630: -27,-28
-            1760: -12,-22
-            1761: -12,-23
-            1762: -12,-24
-            1763: -12,-25
-            2853: 34,-1
-            2854: 34,-2
-            2966: 22,11
-            2967: 22,10
-            5449: 30,-31
-            5450: 30,-30
-            5451: 30,-29
-            5670: 26,-26
-            5695: 12,-20
-            5696: 12,-21
-            5697: 12,-22
-            5698: 12,-23
-            5701: 12,-27
-            5702: 12,-28
-            5703: 12,-29
-            5704: 12,-30
-            5723: 27,-26
-            5769: 36,-15
-            5770: 36,-16
-            5771: 36,-17
-            5772: 36,-18
-            5773: 36,-19
-            5774: 36,-20
-            5775: 36,-21
-            5776: 36,-22
-            5777: 36,-23
-            5821: 17,-23
+            1471: -35,-34
+            1472: -35,-35
+            1481: -35,-33
+            1498: -31,-27
+            1499: -31,-28
+            1572: -35,-36
+            1573: -35,-37
+            1574: -35,-38
+            1575: -35,-39
+            1576: -35,-40
+            1577: -35,-41
+            1620: -27,-29
+            1621: -27,-28
+            1751: -12,-22
+            1752: -12,-23
+            1753: -12,-24
+            1754: -12,-25
+            2844: 34,-1
+            2845: 34,-2
+            2957: 22,11
+            2958: 22,10
+            5440: 30,-31
+            5441: 30,-30
+            5442: 30,-29
+            5661: 26,-26
+            5686: 12,-20
+            5687: 12,-21
+            5688: 12,-22
+            5689: 12,-23
+            5692: 12,-27
+            5693: 12,-28
+            5694: 12,-29
+            5695: 12,-30
+            5714: 27,-26
+            5760: 36,-15
+            5761: 36,-16
+            5762: 36,-17
+            5763: 36,-18
+            5764: 36,-19
+            5765: 36,-20
+            5766: 36,-21
+            5767: 36,-22
+            5768: 36,-23
+            5812: 17,-23
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -7014,20 +7014,20 @@ entities:
             1073: -44,6
             1074: -44,7
             1177: -43,0
-            2677: -35,11
-            2678: -35,12
-            3147: 32,15
-            3573: 28,16
-            4343: -10,43
-            4833: 3,46
-            5599: 8,-28
+            2668: -35,11
+            2669: -35,12
+            3138: 32,15
+            3564: 28,16
+            4334: -10,43
+            4824: 3,46
+            5590: 8,-28
         - node:
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
             968: -26,10
-            4152: -8,26
-            7078: 16,-40
+            4143: -8,26
+            7069: 16,-40
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -7035,30 +7035,30 @@ entities:
           decals:
             1175: -43,-2
             1176: -38,-1
-            1654: -22,-20
-            3146: 33,20
-            4832: 3,50
-            5598: 6,-22
+            1645: -22,-20
+            3137: 33,20
+            4823: 3,50
+            5589: 6,-22
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            1436: -36,-33
-            4298: -17,36
-            4342: -10,39
-            4560: -28,28
-            7026: 19,-49
-            7027: 18,-49
-            7028: 17,-49
-            7029: 16,-49
+            1427: -36,-33
+            4289: -17,36
+            4333: -10,39
+            4551: -28,28
+            7017: 19,-49
+            7018: 18,-49
+            7019: 17,-49
+            7020: 16,-49
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingAreaGreyscale
           decals:
-            7030: 21,-52
-            7031: 21,-51
+            7021: 21,-52
+            7022: 21,-51
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale
@@ -7070,11 +7070,11 @@ entities:
             308: 5,-10
             309: -1,-10
             312: 11,-4
-            3796: 42,-11
-            3805: 40,-7
-            4840: 0,48
-            4862: 2,49
-            4984: 4,59
+            3787: 42,-11
+            3796: 40,-7
+            4831: 0,48
+            4853: 2,49
+            4975: 4,59
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale
@@ -7085,35 +7085,35 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale
           decals:
-            4977: 1,58
-            4987: 4,59
+            4968: 1,58
+            4978: 4,59
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale
           decals:
-            3389: 40,27
+            3380: 40,27
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale
           decals:
-            5465: 27,-32
-            5875: 26,-25
-            5943: 12,-37
-            5972: 23,-36
-            7242: 40,-39
-            7243: 46,-37
-            7244: 45,-38
-            7303: 6,-14
+            5456: 27,-32
+            5866: 26,-25
+            5934: 12,-37
+            5963: 23,-36
+            7233: 40,-39
+            7234: 46,-37
+            7235: 45,-38
+            7294: 6,-14
         - node:
             color: '#6C6C6C93'
             id: QuarterTileOverlayGreyscale
           decals:
-            2977: 23,9
-            2978: 24,9
-            2979: 25,9
-            2980: 26,9
-            2981: 26,10
-            2982: 26,11
+            2968: 23,9
+            2969: 24,9
+            2970: 25,9
+            2971: 26,9
+            2972: 26,10
+            2973: 26,11
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale
@@ -7123,10 +7123,10 @@ entities:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale
           decals:
-            7393: -47,-23
-            7404: -48,-18
-            7405: -49,-24
-            7406: -48,-24
+            7384: -47,-23
+            7395: -48,-18
+            7396: -49,-24
+            7397: -48,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale
@@ -7134,57 +7134,57 @@ entities:
             544: 9,13
             1296: -37,-25
             1300: -38,-23
-            1376: -39,-29
-            1385: -40,-32
-            2363: -20,-46
-            2364: -20,-48
+            1367: -39,-29
+            1376: -40,-32
+            2354: -20,-46
+            2355: -20,-48
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale
           decals:
             468: -17,2
-            2204: -36,-49
-            2243: -32,-53
-            2259: -34,-53
-            2627: -35,10
-            2629: -36,8
-            2690: -1,-21
-            2691: -1,-27
-            3496: 28,2
-            3548: 28,8
-            3563: 28,15
-            3588: 28,33
-            3614: 42,29
-            3621: 42,36
-            3622: 42,39
-            4025: -1,20
-            4216: -5,29
-            4225: -14,29
-            4226: -17,29
-            4391: -38,37
-            4457: -38,21
-            4522: -25,30
-            4523: -25,36
-            4717: -1,39
-            6942: 30,-64
-            6951: 31,-54
+            2195: -36,-49
+            2234: -32,-53
+            2250: -34,-53
+            2618: -35,10
+            2620: -36,8
+            2681: -1,-21
+            2682: -1,-27
+            3487: 28,2
+            3539: 28,8
+            3554: 28,15
+            3579: 28,33
+            3605: 42,29
+            3612: 42,36
+            3613: 42,39
+            4016: -1,20
+            4207: -5,29
+            4216: -14,29
+            4217: -17,29
+            4382: -38,37
+            4448: -38,21
+            4513: -25,30
+            4514: -25,36
+            4708: -1,39
+            6933: 30,-64
+            6942: 31,-54
         - node:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale
           decals:
-            3919: -17,16
-            3922: -23,14
-            3956: -30,21
-            3958: -26,18
+            3910: -17,16
+            3913: -23,14
+            3947: -30,21
+            3949: -26,18
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale
           decals:
-            1473: -28,-33
-            1635: -25,-32
-            2973: 26,9
-            5167: 14,-17
-            5175: 20,-16
+            1464: -28,-33
+            1626: -25,-32
+            2964: 26,9
+            5158: 14,-17
+            5166: 20,-16
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale180
@@ -7196,9 +7196,9 @@ entities:
             265: 4,-3
             275: -10,-1
             278: 2,11
-            3795: 33,-6
-            3799: 35,-10
-            3822: 38,-12
+            3786: 33,-6
+            3790: 35,-10
+            3813: 38,-12
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale180
@@ -7209,34 +7209,34 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale180
           decals:
-            4720: -12,45
-            4974: 3,61
-            4979: 0,60
-            4980: 2,60
+            4711: -12,45
+            4965: 3,61
+            4970: 0,60
+            4971: 2,60
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale180
           decals:
-            3373: 31,29
+            3364: 31,29
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2726: 23,-7
-            2756: 18,-7
-            2810: 24,-15
-            5971: 23,-35
-            5973: 23,-36
-            6028: 36,-39
-            7240: 47,-41
-            7241: 40,-39
-            7302: 6,-14
+            2717: 23,-7
+            2747: 18,-7
+            2801: 24,-15
+            5962: 23,-35
+            5964: 23,-36
+            6019: 36,-39
+            7231: 47,-41
+            7232: 40,-39
+            7293: 6,-14
         - node:
             color: '#6C6C6C93'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2975: 22,11
-            2976: 22,10
+            2966: 22,11
+            2967: 22,10
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale180
@@ -7247,30 +7247,30 @@ entities:
             id: QuarterTileOverlayGreyscale180
           decals:
             553: 12,12
-            3012: 28,8
-            3217: 43,21
-            3259: 12,20
-            3313: 19,25
-            3314: 23,25
-            5406: 36,-29
-            5896: 27,-25
+            3003: 28,8
+            3208: 43,21
+            3250: 12,20
+            3304: 19,25
+            3305: 23,25
+            5397: 36,-29
+            5887: 27,-25
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale180
           decals:
-            7391: -49,-16
-            7392: -47,-23
-            7401: -43,-16
-            7407: -49,-23
-            7409: -45,-23
-            7410: -45,-20
+            7382: -49,-16
+            7383: -47,-23
+            7392: -43,-16
+            7398: -49,-23
+            7400: -45,-23
+            7401: -45,-20
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale180
           decals:
             1350: -46,-27
-            2440: -30,-52
-            2441: -27,-53
+            2431: -30,-52
+            2432: -27,-53
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale180
@@ -7278,37 +7278,37 @@ entities:
             469: -15,-1
             556: 9,-10
             557: 9,-10
-            2142: -46,-35
-            2205: -38,-46
-            2245: -33,-49
-            2257: -35,-52
-            2630: -33,5
-            2632: -33,9
-            2661: -33,-1
-            2662: -33,-1
-            2665: -29,-1
-            2669: -20,-1
-            2719: 2,17
-            3509: 30,5
-            3525: 31,6
-            3561: 30,15
-            3575: 30,22
-            3597: 30,37
-            3598: 30,34
-            3637: 44,38
-            3643: 44,31
-            3650: 40,27
-            3652: 39,26
-            3660: 30,26
-            4199: -15,27
-            4446: -37,19
-            4477: -36,28
-            4546: -23,27
-            4824: 2,45
-            6108: 2,-27
-            6506: 2,25
-            6932: 24,-62
-            6953: 28,-51
+            2133: -46,-35
+            2196: -38,-46
+            2236: -33,-49
+            2248: -35,-52
+            2621: -33,5
+            2623: -33,9
+            2652: -33,-1
+            2653: -33,-1
+            2656: -29,-1
+            2660: -20,-1
+            2710: 2,17
+            3500: 30,5
+            3516: 31,6
+            3552: 30,15
+            3566: 30,22
+            3588: 30,37
+            3589: 30,34
+            3628: 44,38
+            3634: 44,31
+            3641: 40,27
+            3643: 39,26
+            3651: 30,26
+            4190: -15,27
+            4437: -37,19
+            4468: -36,28
+            4537: -23,27
+            4815: 2,45
+            6099: 2,-27
+            6497: 2,25
+            6923: 24,-62
+            6944: 28,-51
         - node:
             color: '#D4D4D496'
             id: QuarterTileOverlayGreyscale180
@@ -7318,27 +7318,27 @@ entities:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale180
           decals:
-            4249: -9,32
+            4240: -9,32
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2525: -17,-53
-            6212: -2,-46
-            6260: 0,-53
+            2516: -17,-53
+            6203: -2,-46
+            6251: 0,-53
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale180
           decals:
-            5312: 32,-22
-            5313: 33,-22
+            5303: 32,-22
+            5304: 33,-22
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale180
           decals:
-            1636: -27,-27
-            5178: 18,-15
-            5693: 12,-19
+            1627: -27,-27
+            5169: 18,-15
+            5684: 12,-19
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale270
@@ -7350,9 +7350,9 @@ entities:
             276: 11,-1
             306: 11,5
             313: 5,11
-            3797: 42,-6
-            3800: 40,-10
-            3821: 36,-12
+            3788: 42,-6
+            3791: 40,-10
+            3812: 36,-12
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale270
@@ -7363,22 +7363,22 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale270
           decals:
-            4975: -2,61
-            4978: 1,60
-            4981: -1,60
+            4966: -2,61
+            4969: 1,60
+            4972: -1,60
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale270
           decals:
-            3390: 40,29
+            3381: 40,29
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale270
           decals:
             589: 8,-13
-            2774: 22,-12
-            2811: 25,-15
-            5976: 26,-35
+            2765: 22,-12
+            2802: 25,-15
+            5967: 26,-35
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale270
@@ -7388,54 +7388,54 @@ entities:
             color: '#9FED5896'
             id: QuarterTileOverlayGreyscale270
           decals:
-            3020: 30,8
-            5895: 26,-25
+            3011: 30,8
+            5886: 26,-25
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale270
           decals:
-            7408: -45,-24
+            7399: -45,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale270
           decals:
-            2358: -27,-45
-            2463: -27,-56
-            2464: -24,-56
+            2349: -27,-45
+            2454: -27,-56
+            2455: -24,-56
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale270
           decals:
             470: -17,-1
-            2143: -44,-35
-            2203: -36,-46
-            2246: -32,-49
-            2258: -34,-52
-            2664: -31,-1
-            2668: -22,-1
-            2681: -35,6
-            2692: -1,-29
-            2693: -1,-25
-            3510: 28,5
-            3558: 28,13
-            3585: 28,29
-            3619: 42,34
-            3620: 42,37
-            3648: 42,27
-            3653: 37,26
-            4022: -1,18
-            4198: -17,27
-            4478: -38,28
-            4524: -25,34
-            4548: -25,28
-            4716: -1,36
-            6941: 30,-62
-            6952: 31,-51
+            2134: -44,-35
+            2194: -36,-46
+            2237: -32,-49
+            2249: -34,-52
+            2655: -31,-1
+            2659: -22,-1
+            2672: -35,6
+            2683: -1,-29
+            2684: -1,-25
+            3501: 28,5
+            3549: 28,13
+            3576: 28,29
+            3610: 42,34
+            3611: 42,37
+            3639: 42,27
+            3644: 37,26
+            4013: -1,18
+            4189: -17,27
+            4469: -38,28
+            4515: -25,34
+            4539: -25,28
+            4707: -1,36
+            6932: 30,-62
+            6943: 31,-51
         - node:
             color: '#D4D4D496'
             id: QuarterTileOverlayGreyscale270
           decals:
-            5404: 35,-33
+            5395: 35,-33
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale270
@@ -7450,32 +7450,32 @@ entities:
             528: 9,18
             529: 9,17
             530: 10,17
-            2559: -7,-53
+            2550: -7,-53
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale270
           decals:
-            5314: 30,-22
-            5317: 29,-22
-            5318: 28,-22
-            5319: 28,-21
-            5320: 28,-20
-            5321: 28,-19
-            5322: 28,-18
-            5323: 28,-17
-            5324: 28,-16
-            5343: 31,-19
-            5345: 32,-18
-            5347: 33,-17
+            5305: 30,-22
+            5308: 29,-22
+            5309: 28,-22
+            5310: 28,-21
+            5311: 28,-20
+            5312: 28,-19
+            5313: 28,-18
+            5314: 28,-17
+            5315: 28,-16
+            5334: 31,-19
+            5336: 32,-18
+            5338: 33,-17
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale270
           decals:
-            1474: -33,-27
-            2858: 35,1
-            5168: 14,-14
-            5177: 20,-15
-            5694: 14,-19
+            1465: -33,-27
+            2849: 35,1
+            5159: 14,-14
+            5168: 20,-15
+            5685: 14,-19
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale90
@@ -7487,11 +7487,11 @@ entities:
             307: 2,-10
             310: -4,-10
             311: -10,-4
-            3798: 33,-11
-            3806: 35,-7
-            4839: 1,48
-            4861: -1,49
-            4985: -3,59
+            3789: 33,-11
+            3797: 35,-7
+            4830: 1,48
+            4852: -1,49
+            4976: -3,59
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale90
@@ -7502,25 +7502,25 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale90
           decals:
-            4976: 0,58
-            4986: -3,59
+            4967: 0,58
+            4977: -3,59
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale90
           decals:
-            3372: 31,27
+            3363: 31,27
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale90
           decals:
             554: 9,-10
-            5464: 26,-32
-            5876: 27,-25
-            5977: 26,-35
-            6030: 35,-38
-            7222: 6,-37
-            7249: 41,-41
-            7299: 6,-13
+            5455: 26,-32
+            5867: 27,-25
+            5968: 26,-35
+            6021: 35,-38
+            7213: 6,-37
+            7240: 41,-41
+            7290: 6,-13
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale90
@@ -7530,60 +7530,60 @@ entities:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale90
           decals:
-            7411: -41,-24
+            7402: -41,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale90
           decals:
             1295: -39,-24
-            1382: -40,-34
-            2365: -21,-49
-            2422: -21,-51
+            1373: -40,-34
+            2356: -21,-49
+            2413: -21,-51
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale90
           decals:
             467: -15,2
-            2206: -38,-49
-            2244: -33,-53
-            2256: -35,-53
-            2631: -33,7
-            2633: -33,2
-            2695: 2,-24
-            3515: 30,2
-            3545: 20,8
-            3557: 30,8
-            3562: 30,17
-            3576: 30,24
-            3595: 30,39
-            3596: 30,36
-            3602: 30,30
-            3613: 40,29
-            3636: 44,40
-            3642: 44,33
-            4023: 2,19
-            4054: -15,20
-            4223: -12,29
-            4224: -15,29
-            4458: -39,21
-            4535: -23,29
-            4831: 2,47
-            6184: 7,-46
-            6185: 8,-47
-            6504: 2,27
-            6939: 24,-64
-            6954: 28,-54
-            7208: 30,-42
+            2197: -38,-49
+            2235: -33,-53
+            2247: -35,-53
+            2622: -33,7
+            2624: -33,2
+            2686: 2,-24
+            3506: 30,2
+            3536: 20,8
+            3548: 30,8
+            3553: 30,17
+            3567: 30,24
+            3586: 30,39
+            3587: 30,36
+            3593: 30,30
+            3604: 40,29
+            3627: 44,40
+            3633: 44,33
+            4014: 2,19
+            4045: -15,20
+            4214: -12,29
+            4215: -15,29
+            4449: -39,21
+            4526: -23,29
+            4822: 2,47
+            6175: 7,-46
+            6176: 8,-47
+            6495: 2,27
+            6930: 24,-64
+            6945: 28,-54
+            7199: 30,-42
         - node:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale90
           decals:
             905: -20,6
-            3899: 44,-17
-            3916: -19,14
-            3953: -28,25
-            3954: -27,20
-            4248: -9,34
+            3890: 44,-17
+            3907: -19,14
+            3944: -28,25
+            3945: -27,20
+            4239: -9,34
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale90
@@ -7595,46 +7595,46 @@ entities:
             524: 6,18
             525: 6,19
             526: 5,19
-            2579: -5,-45
-            6153: 0,-42
-            6237: 6,-48
+            2570: -5,-45
+            6144: 0,-42
+            6228: 6,-48
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale90
           decals:
-            5325: 28,-16
-            5326: 29,-16
-            5327: 30,-16
-            5328: 31,-16
-            5329: 32,-16
-            5330: 33,-16
-            5331: 34,-16
-            5332: 34,-17
-            5333: 34,-18
-            5334: 34,-19
-            5335: 34,-20
-            5336: 34,-21
-            5338: 30,-21
-            5342: 29,-20
-            5344: 31,-19
-            5346: 32,-18
+            5316: 28,-16
+            5317: 29,-16
+            5318: 30,-16
+            5319: 31,-16
+            5320: 32,-16
+            5321: 33,-16
+            5322: 34,-16
+            5323: 34,-17
+            5324: 34,-18
+            5325: 34,-19
+            5326: 34,-20
+            5327: 34,-21
+            5329: 30,-21
+            5333: 29,-20
+            5335: 31,-19
+            5337: 32,-18
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale90
           decals:
-            2974: 22,9
-            5176: 18,-16
+            2965: 22,9
+            5167: 18,-16
         - node:
             color: '#FFFFFFFF'
             id: Remains
           decals:
-            1955: -8,-43
+            1946: -8,-43
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            3349: 30,16
+            3340: 30,16
         - node:
             color: '#FFFFFFFF'
             id: StandClear
@@ -7642,33 +7642,33 @@ entities:
             535: 4,18
             536: 8,18
             537: 5,13
-            3866: 41,-13
-            3887: 46,-13
-            3888: 46,-7
-            3889: 46,-5
-            3914: 46,-15
-            6537: 11,-66
-            6538: 12,-66
-            6539: 13,-66
-            6576: 4,-70
-            6709: -4,-70
+            3857: 41,-13
+            3878: 46,-13
+            3879: 46,-7
+            3880: 46,-5
+            3905: 46,-15
+            6528: 11,-66
+            6529: 12,-66
+            6530: 13,-66
+            6567: 4,-70
+            6700: -4,-70
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            3441: 46,32
-            3442: 46,39
-            3867: 44,-12
-            3868: 44,-5
+            3432: 46,32
+            3433: 46,39
+            3858: 44,-12
+            3859: 44,-5
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            3809: 39,-7
-            3810: 38,-7
-            3843: 32,-5
-            4860: 2,50
+            3800: 39,-7
+            3801: 38,-7
+            3834: 32,-5
+            4851: 2,50
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale
@@ -7679,18 +7679,18 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            5524: 8,-19
+            5515: 8,-19
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            3019: 30,6
-            3257: 12,17
+            3010: 30,6
+            3248: 12,17
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            7402: -47,-18
+            7393: -47,-18
         - node:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale
@@ -7701,59 +7701,59 @@ entities:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            2628: -36,10
-            3539: 16,10
-            3547: 27,8
-            3725: 33,-6
-            4278: -18,36
-            4315: -21,36
-            4388: -38,39
-            4396: -43,37
-            5349: 40,-15
-            6393: -8,-56
-            7186: 10,-41
+            2619: -36,10
+            3530: 16,10
+            3538: 27,8
+            3716: 33,-6
+            4269: -18,36
+            4306: -21,36
+            4379: -38,39
+            4387: -43,37
+            5340: 40,-15
+            6384: -8,-56
+            7177: 10,-41
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
             907: -22,8
-            2758: 27,-3
-            3897: 43,-15
-            3923: -23,16
-            3955: -28,19
-            4127: -17,23
-            4564: -5,34
-            4587: -7,40
-            5511: 4,-19
-            6226: 2,-49
+            2749: 27,-3
+            3888: 43,-15
+            3914: -23,16
+            3946: -28,19
+            4118: -17,23
+            4555: -5,34
+            4578: -7,40
+            5502: 4,-19
+            6217: 2,-49
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            4933: 3,61
-            6169: 6,-42
-            6214: -1,-47
-            6259: -4,-51
+            4924: 3,61
+            6160: 6,-42
+            6205: -1,-47
+            6250: -4,-51
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            1470: -28,-32
-            1471: -33,-33
-            1638: -25,-29
-            1741: -21,-29
-            2074: -7,-29
-            5708: 14,-29
-            5719: 23,-26
-            5734: 41,-26
-            5766: 38,-18
+            1461: -28,-32
+            1462: -33,-33
+            1629: -25,-29
+            1732: -21,-29
+            2065: -7,-29
+            5699: 14,-29
+            5710: 23,-26
+            5725: 41,-26
+            5757: 38,-18
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3801: 36,-10
-            3802: 37,-10
-            3827: 43,-12
+            3792: 36,-10
+            3793: 37,-10
+            3818: 43,-12
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale180
@@ -7764,48 +7764,48 @@ entities:
             color: '#334E6DC8'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            4723: -4,43
+            4714: -4,43
         - node:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            2809: 22,-15
-            5526: 10,-20
-            6027: 36,-40
+            2800: 22,-15
+            5517: 10,-20
+            6018: 36,-40
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3134: 37,14
-            3315: 21,25
-            5405: 36,-28
+            3125: 37,14
+            3306: 21,25
+            5396: 36,-28
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
             896: -28,4
-            7390: -42,-17
+            7381: -42,-17
         - node:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
             540: 10,11
-            2110: -42,-42
-            2357: -29,-45
+            2101: -42,-42
+            2348: -29,-45
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3508: 31,5
-            3651: 40,26
-            3715: 42,-11
-            4171: -24,23
-            4211: -3,27
-            4276: -15,31
-            4445: -36,19
-            5350: 41,-19
-            6980: 32,-49
-            6995: 32,-65
+            3499: 31,5
+            3642: 40,26
+            3706: 42,-11
+            4162: -24,23
+            4202: -3,27
+            4267: -15,31
+            4436: -36,19
+            5341: 41,-19
+            6971: 32,-49
+            6986: 32,-65
         - node:
             color: '#D4D4D496'
             id: ThreeQuarterTileOverlayGreyscale180
@@ -7816,49 +7816,49 @@ entities:
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
             906: -20,7
-            2760: 30,-5
-            3896: 46,-19
-            3918: -17,14
-            3957: -25,20
-            4128: -15,22
-            4242: -9,31
-            4243: -7,32
-            4563: -3,33
-            4588: -3,36
-            5512: 6,-20
-            6224: 4,-51
+            2751: 30,-5
+            3887: 46,-19
+            3909: -17,14
+            3948: -25,20
+            4119: -15,22
+            4233: -9,31
+            4234: -7,32
+            4554: -3,33
+            4579: -3,36
+            5503: 6,-20
+            6215: 4,-51
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            2526: -16,-54
-            2527: -13,-53
-            2560: -7,-54
-            6205: 5,-46
-            6257: -3,-54
+            2517: -16,-54
+            2518: -13,-53
+            2551: -7,-54
+            6196: 5,-46
+            6248: -3,-54
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            1468: -31,-30
-            1596: -35,-42
-            1637: -27,-30
-            1742: -24,-27
-            1753: -12,-27
-            1754: -18,-27
-            2077: -4,-27
-            5699: 12,-24
-            5736: 36,-24
-            5744: 17,-24
-            5745: 24,-24
-            5746: 30,-24
+            1459: -31,-30
+            1587: -35,-42
+            1628: -27,-30
+            1733: -24,-27
+            1744: -12,-27
+            1745: -18,-27
+            2068: -4,-27
+            5690: 12,-24
+            5727: 36,-24
+            5735: 17,-24
+            5736: 24,-24
+            5737: 30,-24
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3803: 39,-10
-            3804: 38,-10
-            3817: 32,-12
+            3794: 39,-10
+            3795: 38,-10
+            3808: 32,-12
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale270
@@ -7869,12 +7869,12 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            5527: 8,-20
+            5518: 8,-20
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3117: 32,14
+            3108: 32,14
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale270
@@ -7886,70 +7886,70 @@ entities:
           decals:
             538: 8,11
             539: 7,12
-            2109: -44,-42
-            2355: -25,-45
+            2100: -44,-42
+            2346: -25,-45
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3507: 27,5
-            3714: 33,-11
-            4057: -17,18
-            4275: -18,31
-            4314: -21,31
-            5351: 40,-19
-            6135: -1,-43
-            6375: -8,-61
-            7005: 22,-65
+            3498: 27,5
+            3705: 33,-11
+            4048: -17,18
+            4266: -18,31
+            4305: -21,31
+            5342: 40,-19
+            6126: -1,-43
+            6366: -8,-61
+            6996: 22,-65
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
             908: -24,12
-            2757: 27,-5
-            3898: 43,-19
-            3915: -20,14
-            3959: -25,16
-            4129: -17,22
-            4241: -13,31
-            4562: -5,33
-            4586: -7,36
-            5513: 4,-20
-            6223: 2,-51
+            2748: 27,-5
+            3889: 43,-19
+            3906: -20,14
+            3950: -25,16
+            4120: -17,22
+            4232: -13,31
+            4553: -5,33
+            4577: -7,36
+            5504: 4,-20
+            6214: 2,-51
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            2557: -6,-51
-            6145: 1,-41
-            6204: 6,-46
-            6222: 7,-47
-            6258: -1,-53
+            2548: -6,-51
+            6136: 1,-41
+            6195: 6,-46
+            6213: 7,-47
+            6249: -1,-53
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
             1272: -33,-17
-            1469: -29,-30
-            1472: -33,-30
-            1509: -29,-27
-            1743: -22,-27
-            1751: -16,-27
-            1752: -10,-27
-            5737: 38,-24
-            5741: 32,-24
-            5742: 26,-24
-            5743: 19,-24
-            5758: 14,-24
-            5767: 38,-16
+            1460: -29,-30
+            1463: -33,-30
+            1500: -29,-27
+            1734: -22,-27
+            1742: -16,-27
+            1743: -10,-27
+            5728: 38,-24
+            5732: 32,-24
+            5733: 26,-24
+            5734: 19,-24
+            5749: 14,-24
+            5758: 38,-16
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            3807: 36,-7
-            3808: 37,-7
-            3834: 43,-5
-            4859: -1,50
+            3798: 36,-7
+            3799: 37,-7
+            3825: 43,-5
+            4850: -1,50
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale90
@@ -7960,78 +7960,78 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            2773: 22,-13
-            5525: 10,-19
-            6029: 32,-37
+            2764: 22,-13
+            5516: 10,-19
+            6020: 32,-37
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
             552: 12,15
-            2988: 28,6
-            3135: 37,18
-            3216: 42,23
-            3258: 12,22
-            3311: 18,27
+            2979: 28,6
+            3126: 37,18
+            3207: 42,23
+            3249: 12,22
+            3302: 18,27
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            7394: -49,-21
-            7395: -49,-22
+            7385: -49,-21
+            7386: -49,-22
         - node:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
             541: 10,15
-            2368: -20,-49
+            2359: -20,-49
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            3521: 36,2
-            3543: 20,10
-            3546: 21,8
-            3612: 40,30
-            3724: 42,-6
-            4170: -24,25
-            4277: -15,36
-            4389: -37,39
-            5348: 41,-15
-            6385: 0,-56
-            6981: 32,-50
-            7206: 30,-41
-            7207: 32,-42
+            3512: 36,2
+            3534: 20,10
+            3537: 21,8
+            3603: 40,30
+            3715: 42,-6
+            4161: -24,25
+            4268: -15,36
+            4380: -37,39
+            5339: 41,-15
+            6376: 0,-56
+            6972: 32,-50
+            7197: 30,-41
+            7198: 32,-42
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            2759: 30,-3
-            3894: 44,-15
-            3895: 46,-17
-            3995: -33,20
-            4126: -15,23
-            4244: -7,34
-            4246: -9,35
-            4565: -3,34
-            4589: -3,40
-            5510: 6,-19
-            6225: 4,-49
+            2750: 30,-3
+            3885: 44,-15
+            3886: 46,-17
+            3986: -33,20
+            4117: -15,23
+            4235: -7,34
+            4237: -9,35
+            4556: -3,34
+            4580: -3,40
+            5501: 6,-19
+            6216: 4,-49
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            4932: -2,61
-            6168: 5,-42
+            4923: -2,61
+            6159: 5,-42
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            1740: -23,-29
-            2068: -9,-29
-            2852: 34,0
-            5700: 12,-26
-            5735: 39,-26
+            1731: -23,-29
+            2059: -9,-29
+            2843: 34,0
+            5691: 12,-26
+            5726: 39,-26
         - node:
             color: '#FFFFFFFF'
             id: WarnBox
@@ -8040,27 +8040,27 @@ entities:
             1085: -37,9
             1086: -37,10
             1139: -37,-2
-            1424: -33,-26
-            1425: -34,-26
-            1426: -35,-26
-            4142: -14,26
-            4143: -11,26
-            4144: -5,26
-            4877: 1,53
-            4878: 0,53
-            5203: 18,-19
-            5204: 17,-19
-            5398: 47,-32
-            5624: 20,-26
-            5899: 23,-29
-            5904: 11,-31
+            1415: -33,-26
+            1416: -34,-26
+            1417: -35,-26
+            4133: -14,26
+            4134: -11,26
+            4135: -5,26
+            4868: 1,53
+            4869: 0,53
+            5194: 18,-19
+            5195: 17,-19
+            5389: 47,-32
+            5615: 20,-26
+            5890: 23,-29
+            5895: 11,-31
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: WarnBox
           decals:
-            2131: -45,-44
-            2133: -48,-35
+            2122: -45,-44
+            2124: -48,-35
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNE
@@ -8068,76 +8068,76 @@ entities:
             506: 4,17
             855: -29,-7
             1261: -33,16
-            1428: -34,-28
-            1437: -36,-33
-            1659: -21,-21
-            2187: -36,-46
-            2232: -34,-52
-            2236: -32,-49
-            2342: -80,-51
-            2343: -79,-52
-            3161: 35,17
-            3169: 36,13
-            3193: 40,17
-            3438: 44,26
-            4356: -28,32
-            4413: -40,30
-            4663: 5,39
-            4666: 8,39
-            4667: 8,42
-            4668: 5,42
-            5603: 9,-28
-            6197: 0,-48
-            6331: 2,-59
-            6367: -1,-57
-            6644: 8,-69
-            6651: -5,-69
-            6666: -1,-73
-            6674: -1,-74
-            6701: 7,-74
-            6894: 27,-51
-            7073: 36,-47
-            7120: 31,-43
-            7121: 29,-42
-            7134: 14,-43
-            7326: 30,-55
-            7519: -1,-57
+            1419: -34,-28
+            1428: -36,-33
+            1650: -21,-21
+            2178: -36,-46
+            2223: -34,-52
+            2227: -32,-49
+            2333: -80,-51
+            2334: -79,-52
+            3152: 35,17
+            3160: 36,13
+            3184: 40,17
+            3429: 44,26
+            4347: -28,32
+            4404: -40,30
+            4654: 5,39
+            4657: 8,39
+            4658: 8,42
+            4659: 5,42
+            5594: 9,-28
+            6188: 0,-48
+            6322: 2,-59
+            6358: -1,-57
+            6635: 8,-69
+            6642: -5,-69
+            6657: -1,-73
+            6665: -1,-74
+            6692: 7,-74
+            6885: 27,-51
+            7064: 36,-47
+            7111: 31,-43
+            7112: 29,-42
+            7125: 14,-43
+            7317: 30,-55
+            7510: -1,-57
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNW
           decals:
             1191: -45,-10
             1260: -35,16
-            1427: -35,-28
-            1660: -25,-21
-            2231: -35,-52
-            2237: -33,-49
-            2340: -82,-51
-            2341: -83,-52
-            3160: 34,17
-            3164: 38,17
-            3168: 32,13
-            3437: 42,26
-            4664: 7,39
-            4665: 4,39
-            4669: 4,42
-            4670: 7,42
-            5378: 46,-31
-            5604: 5,-28
-            6196: -3,-48
-            6368: -7,-57
-            6371: 0,-59
-            6429: -16,-58
-            6641: 5,-69
-            6650: -8,-69
-            6667: 1,-73
-            6675: 1,-74
-            6681: -7,-74
-            6893: 20,-51
-            6911: 24,-55
-            7142: 12,-43
-            7154: 11,-42
-            7518: -7,-57
+            1418: -35,-28
+            1651: -25,-21
+            2222: -35,-52
+            2228: -33,-49
+            2331: -82,-51
+            2332: -83,-52
+            3151: 34,17
+            3155: 38,17
+            3159: 32,13
+            3428: 42,26
+            4655: 7,39
+            4656: 4,39
+            4660: 4,42
+            4661: 7,42
+            5369: 46,-31
+            5595: 5,-28
+            6187: -3,-48
+            6359: -7,-57
+            6362: 0,-59
+            6420: -16,-58
+            6632: 5,-69
+            6641: -8,-69
+            6658: 1,-73
+            6666: 1,-74
+            6672: -7,-74
+            6884: 20,-51
+            6902: 24,-55
+            7133: 12,-43
+            7145: 11,-42
+            7509: -7,-57
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSE
@@ -8145,38 +8145,38 @@ entities:
             1094: -44,8
             1200: -39,-13
             1259: -33,14
-            1429: -34,-30
-            1658: -21,-25
-            2193: -36,-49
-            2238: -32,-53
-            2253: -34,-53
-            2254: -34,-53
-            2338: -80,-55
-            2339: -79,-54
-            3159: 35,15
-            3173: 32,18
-            3178: 36,19
-            4654: 6,35
-            4662: 5,38
-            4673: 8,41
-            4674: 5,41
-            5049: 5,72
-            5606: 9,-22
-            6190: 4,-45
-            6195: 0,-49
-            6323: 2,-57
-            6330: 2,-61
-            6366: -1,-60
-            6643: 8,-71
-            6652: -5,-71
-            6697: 6,-77
-            6700: 7,-75
-            6908: 27,-54
-            7090: 29,-40
-            7091: 21,-40
-            7115: 31,-48
-            7145: 14,-47
-            7335: 30,-61
+            1420: -34,-30
+            1649: -21,-25
+            2184: -36,-49
+            2229: -32,-53
+            2244: -34,-53
+            2245: -34,-53
+            2329: -80,-55
+            2330: -79,-54
+            3150: 35,15
+            3164: 32,18
+            3169: 36,19
+            4645: 6,35
+            4653: 5,38
+            4664: 8,41
+            4665: 5,41
+            5040: 5,72
+            5597: 9,-22
+            6181: 4,-45
+            6186: 0,-49
+            6314: 2,-57
+            6321: 2,-61
+            6357: -1,-60
+            6634: 8,-71
+            6643: -5,-71
+            6688: 6,-77
+            6691: 7,-75
+            6899: 27,-54
+            7081: 29,-40
+            7082: 21,-40
+            7106: 31,-48
+            7136: 14,-47
+            7326: 30,-61
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSW
@@ -8184,40 +8184,40 @@ entities:
             511: 7,19
             899: -30,8
             1258: -35,14
-            1430: -35,-30
-            1657: -25,-25
-            1811: -21,-32
-            2239: -33,-53
-            2255: -35,-53
-            2336: -82,-55
-            2337: -83,-54
-            3158: 34,15
-            3165: 38,14
-            3176: 34,19
-            3180: 38,19
-            4367: -28,36
-            4661: 7,38
-            4671: 4,41
-            4672: 7,41
-            5048: -3,72
-            5377: 46,-33
-            5605: 5,-22
-            6188: -2,-45
-            6189: 2,-45
-            6194: -3,-49
-            6365: -7,-60
-            6412: -16,-59
-            6431: -16,-56
-            6642: 5,-71
-            6653: -8,-71
-            6682: -7,-75
-            6685: -6,-77
-            6892: 20,-52
-            6904: 22,-54
-            6916: 24,-61
-            7079: 17,-40
-            7133: 12,-47
-            7155: 11,-48
+            1421: -35,-30
+            1648: -25,-25
+            1802: -21,-32
+            2230: -33,-53
+            2246: -35,-53
+            2327: -82,-55
+            2328: -83,-54
+            3149: 34,15
+            3156: 38,14
+            3167: 34,19
+            3171: 38,19
+            4358: -28,36
+            4652: 7,38
+            4662: 4,41
+            4663: 7,41
+            5039: -3,72
+            5368: 46,-33
+            5596: 5,-22
+            6179: -2,-45
+            6180: 2,-45
+            6185: -3,-49
+            6356: -7,-60
+            6403: -16,-59
+            6422: -16,-56
+            6633: 5,-71
+            6644: -8,-71
+            6673: -7,-75
+            6676: -6,-77
+            6883: 20,-52
+            6895: 22,-54
+            6907: 24,-61
+            7070: 17,-40
+            7124: 12,-47
+            7146: 11,-48
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNE
@@ -8225,97 +8225,97 @@ entities:
             854: -31,-7
             1245: -33,-15
             1289: -32,-21
-            1420: -36,-27
-            1546: -33,-42
-            1858: -7,-25
-            2347: -79,-53
-            2348: -80,-52
-            6424: -12,-58
-            6661: -5,-73
-            7032: 32,-53
-            7123: 29,-43
+            1411: -36,-27
+            1537: -33,-42
+            1849: -7,-25
+            2338: -79,-53
+            2339: -80,-52
+            6415: -12,-58
+            6652: -5,-73
+            7023: 32,-53
+            7114: 29,-43
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNW
           decals:
             1152: -40,3
             1197: -42,-9
-            1419: -29,-21
-            1865: -1,-25
-            2349: -82,-52
-            6369: -7,-58
-            6427: -14,-58
-            6640: 5,-70
-            6671: 5,-73
-            7524: -7,-58
+            1410: -29,-21
+            1856: -1,-25
+            2340: -82,-52
+            6360: -7,-58
+            6418: -14,-58
+            6631: 5,-70
+            6662: 5,-73
+            7515: -7,-58
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSE
           decals:
             1090: -44,12
             1244: -33,-11
-            1545: -33,-37
-            1857: -7,-21
-            2159: -42,-35
-            2345: -80,-54
-            2346: -79,-53
-            4659: 4,38
-            6329: 2,-53
-            6420: -10,-59
-            6619: -5,-65
-            6699: 6,-75
-            7216: 32,-48
+            1536: -33,-37
+            1848: -7,-21
+            2150: -42,-35
+            2336: -80,-54
+            2337: -79,-53
+            4650: 4,38
+            6320: 2,-53
+            6411: -10,-59
+            6610: -5,-65
+            6690: 6,-75
+            7207: 32,-48
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSW
           decals:
             1174: -40,-5
-            1866: -1,-21
-            2128: -43,-43
-            2344: -82,-54
-            4660: 8,38
-            6370: -7,-59
-            6416: -12,-59
-            6629: 5,-65
-            6639: 5,-70
-            6683: -6,-75
-            6902: 22,-52
-            7523: -7,-59
+            1857: -1,-21
+            2119: -43,-43
+            2335: -82,-54
+            4651: 8,38
+            6361: -7,-59
+            6407: -12,-59
+            6620: 5,-65
+            6630: 5,-70
+            6674: -6,-75
+            6893: 22,-52
+            7514: -7,-59
         - node:
             color: '#FFFFFFFF'
             id: WarnEndE
           decals:
-            1656: -23,-19
-            2335: -77,-53
-            5906: 6,-29
-            6853: 22,-50
-            7531: -2,-70
+            1647: -23,-19
+            2326: -77,-53
+            5897: 6,-29
+            6844: 22,-50
+            7522: -2,-70
         - node:
             color: '#FFFFFFFF'
             id: WarnEndN
           decals:
             1136: -37,-3
             1140: -37,3
-            5120: -5,77
+            5111: -5,77
         - node:
             color: '#FFFFFFFF'
             id: WarnEndS
           decals:
             1135: -37,-5
             1141: -37,-1
-            2087: -3,-27
-            4657: 4,37
-            4658: 8,37
-            5121: -5,76
+            2078: -3,-27
+            4648: 4,37
+            4649: 8,37
+            5112: -5,76
         - node:
             color: '#FFFFFFFF'
             id: WarnEndW
           decals:
-            1439: -29,-28
-            1655: -24,-19
-            2270: -44,-53
-            5905: 5,-29
-            6854: 20,-50
+            1430: -29,-28
+            1646: -24,-19
+            2261: -44,-53
+            5896: 5,-29
+            6845: 20,-50
         - node:
             color: '#FFFFFFFF'
             id: WarnFull
@@ -8327,19 +8327,19 @@ entities:
             1280: -32,-13
             1281: -31,-20
             1282: -30,-20
-            1551: -32,-40
-            1552: -32,-39
-            1553: -32,-38
-            1859: -2,-23
-            1860: -2,-22
-            1861: -2,-24
-            2160: -41,-37
-            2161: -41,-36
-            7033: 33,-49
-            7034: 33,-50
-            7035: 33,-51
-            7036: 33,-52
-            7553: -48,-27
+            1542: -32,-40
+            1543: -32,-39
+            1544: -32,-38
+            1850: -2,-23
+            1851: -2,-22
+            1852: -2,-24
+            2151: -41,-37
+            2152: -41,-36
+            7024: 33,-49
+            7025: 33,-50
+            7026: 33,-51
+            7027: 33,-52
+            7544: -48,-27
         - node:
             color: '#FFFFFFFF'
             id: WarnLineE
@@ -8376,127 +8376,127 @@ entities:
             1243: -33,-12
             1263: -33,15
             1269: -35,15
-            1431: -34,-29
-            1438: -36,-34
-            1547: -33,-41
-            1548: -33,-40
-            1549: -33,-39
-            1550: -33,-38
-            1661: -21,-22
-            1662: -21,-23
-            1663: -21,-24
-            1813: -23,-34
-            1814: -23,-32
-            1815: -23,-33
-            1816: -23,-31
-            1817: -21,-34
-            1818: -21,-33
-            1820: -20,-33
-            1850: -7,-24
-            1851: -7,-23
-            1852: -7,-22
-            2153: -43,-30
-            2154: -43,-31
-            2157: -42,-37
-            2158: -42,-36
-            2188: -36,-47
-            2194: -36,-48
-            2240: -32,-52
-            2241: -32,-51
-            2242: -32,-50
-            2276: -27,-49
-            2277: -27,-48
-            2278: -27,-47
-            3162: 35,16
-            3174: 32,19
-            3175: 32,20
-            3181: 30,16
-            3439: 46,32
-            3444: 46,39
-            3569: 30,15
-            3570: 30,14
-            3571: 30,17
-            3572: 30,13
-            4311: -13,38
-            4312: -13,39
-            4313: -13,40
-            4414: -40,29
-            4415: -40,28
-            4675: 8,38
-            4784: 13,46
-            4785: 13,47
-            4786: 11,46
-            4787: 11,47
-            5087: 6,80
-            5088: 6,79
-            5089: 6,78
-            5090: 6,77
-            5091: 6,76
-            5092: 6,75
-            5093: 6,74
-            5129: -5,74
-            5130: -5,75
-            5131: -5,78
-            5132: -5,79
-            5133: -5,80
-            5134: -8,79
-            5179: 14,-17
-            5180: 14,-16
-            5181: 14,-15
-            5182: 14,-14
-            5610: 11,-24
-            5611: 11,-25
-            5612: 11,-25
-            5613: 11,-26
-            6324: 2,-56
-            6325: 2,-55
-            6326: 2,-54
-            6332: 2,-60
-            6357: -1,-59
-            6358: -1,-58
-            6421: -10,-60
-            6425: -12,-57
-            6616: -5,-68
-            6617: -5,-67
-            6618: -5,-66
-            6649: 8,-70
-            6658: -5,-70
-            6660: -5,-72
-            6698: 6,-76
-            6909: 27,-53
-            6910: 27,-52
-            6919: 30,-60
-            6920: 30,-59
-            6921: 30,-58
-            6922: 30,-57
-            6923: 30,-56
-            7037: 32,-49
-            7038: 32,-50
-            7039: 32,-51
-            7040: 32,-52
-            7116: 31,-47
-            7117: 31,-46
-            7118: 31,-45
-            7119: 31,-44
-            7156: 14,-46
-            7157: 14,-45
-            7159: 14,-44
-            7520: -1,-58
-            7521: -1,-59
+            1422: -34,-29
+            1429: -36,-34
+            1538: -33,-41
+            1539: -33,-40
+            1540: -33,-39
+            1541: -33,-38
+            1652: -21,-22
+            1653: -21,-23
+            1654: -21,-24
+            1804: -23,-34
+            1805: -23,-32
+            1806: -23,-33
+            1807: -23,-31
+            1808: -21,-34
+            1809: -21,-33
+            1811: -20,-33
+            1841: -7,-24
+            1842: -7,-23
+            1843: -7,-22
+            2144: -43,-30
+            2145: -43,-31
+            2148: -42,-37
+            2149: -42,-36
+            2179: -36,-47
+            2185: -36,-48
+            2231: -32,-52
+            2232: -32,-51
+            2233: -32,-50
+            2267: -27,-49
+            2268: -27,-48
+            2269: -27,-47
+            3153: 35,16
+            3165: 32,19
+            3166: 32,20
+            3172: 30,16
+            3430: 46,32
+            3435: 46,39
+            3560: 30,15
+            3561: 30,14
+            3562: 30,17
+            3563: 30,13
+            4302: -13,38
+            4303: -13,39
+            4304: -13,40
+            4405: -40,29
+            4406: -40,28
+            4666: 8,38
+            4775: 13,46
+            4776: 13,47
+            4777: 11,46
+            4778: 11,47
+            5078: 6,80
+            5079: 6,79
+            5080: 6,78
+            5081: 6,77
+            5082: 6,76
+            5083: 6,75
+            5084: 6,74
+            5120: -5,74
+            5121: -5,75
+            5122: -5,78
+            5123: -5,79
+            5124: -5,80
+            5125: -8,79
+            5170: 14,-17
+            5171: 14,-16
+            5172: 14,-15
+            5173: 14,-14
+            5601: 11,-24
+            5602: 11,-25
+            5603: 11,-25
+            5604: 11,-26
+            6315: 2,-56
+            6316: 2,-55
+            6317: 2,-54
+            6323: 2,-60
+            6348: -1,-59
+            6349: -1,-58
+            6412: -10,-60
+            6416: -12,-57
+            6607: -5,-68
+            6608: -5,-67
+            6609: -5,-66
+            6640: 8,-70
+            6649: -5,-70
+            6651: -5,-72
+            6689: 6,-76
+            6900: 27,-53
+            6901: 27,-52
+            6910: 30,-60
+            6911: 30,-59
+            6912: 30,-58
+            6913: 30,-57
+            6914: 30,-56
+            7028: 32,-49
+            7029: 32,-50
+            7030: 32,-51
+            7031: 32,-52
+            7107: 31,-47
+            7108: 31,-46
+            7109: 31,-45
+            7110: 31,-44
+            7147: 14,-46
+            7148: 14,-45
+            7150: 14,-44
+            7511: -1,-58
+            7512: -1,-59
         - node:
             color: '#FFFFFFFF'
             id: WarnLineGreyscaleE
           decals:
-            4347: -27,40
-            4348: -27,39
-            4349: -27,38
+            4338: -27,40
+            4339: -27,39
+            4340: -27,38
         - node:
             color: '#FFFFFFFF'
             id: WarnLineGreyscaleW
           decals:
-            4344: -21,38
-            4345: -21,39
-            4346: -21,40
+            4335: -21,38
+            4336: -21,39
+            4337: -21,40
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
@@ -8521,187 +8521,187 @@ entities:
             1209: -45,-13
             1262: -34,14
             1268: -34,16
-            1664: -22,-25
-            1665: -23,-25
-            1666: -24,-25
-            1679: -22,-17
-            1680: -23,-17
-            1681: -24,-17
-            1682: -25,-17
-            1853: -6,-21
-            1854: -5,-21
-            1855: -4,-21
-            1856: -3,-21
-            2195: -37,-49
-            2196: -38,-49
-            2271: -43,-53
-            2272: -42,-53
-            2351: -81,-55
-            2354: -78,-53
-            3177: 35,19
-            3869: 40,-10
-            3870: 39,-10
-            3871: 38,-10
-            3872: 37,-10
-            3873: 36,-10
-            3874: 35,-10
-            3884: 46,-13
-            3885: 46,-7
-            3886: 46,-5
-            3913: 46,-15
-            4104: -13,22
-            4105: -12,22
-            4106: -10,22
-            4107: -9,22
-            4108: -8,22
-            4109: -7,22
-            4110: -6,22
-            4111: -4,22
-            4112: -3,22
-            4363: -31,36
-            4364: -30,36
-            4365: -29,36
-            4366: -27,36
-            4467: -40,24
-            4468: -41,24
-            4469: -42,24
-            4470: -43,24
-            4655: 5,35
-            4656: 4,35
-            4677: 4,44
-            4678: 5,44
-            4679: 6,44
-            4680: 7,44
-            4681: 8,44
-            5026: 2,52
-            5027: 1,52
-            5028: 0,52
-            5029: -1,52
-            5034: 2,58
-            5035: -1,58
-            5038: 3,72
-            5039: 2,72
-            5040: 1,72
-            5041: 0,72
-            5042: -1,72
-            5304: 34,-15
-            5305: 33,-15
-            5306: 32,-15
-            5307: 31,-15
-            5308: 30,-15
-            5309: 29,-15
-            5310: 28,-15
-            5381: 47,-33
-            5607: 8,-22
-            5608: 7,-22
-            5609: 6,-22
-            6191: 3,-45
-            6192: 0,-45
-            6193: -1,-45
-            6198: -1,-49
-            6199: -2,-49
-            6327: 4,-53
-            6328: 3,-53
-            6351: -8,-59
-            6352: -6,-60
-            6353: -5,-60
-            6354: -4,-60
-            6355: -3,-60
-            6356: -2,-60
-            6413: -15,-59
-            6414: -14,-59
-            6415: -13,-59
-            6418: -9,-59
-            6432: -15,-56
-            6433: -14,-56
-            6434: -13,-56
-            6435: -12,-56
-            6436: -11,-56
-            6437: -10,-56
-            6438: -21,-60
-            6439: -20,-60
-            6440: -19,-60
-            6441: -18,-60
-            6540: 14,-67
-            6541: 13,-67
-            6542: 12,-67
-            6543: 11,-67
-            6544: 10,-67
-            6620: -4,-65
-            6621: -3,-65
-            6622: -2,-65
-            6623: -1,-65
-            6624: 0,-65
-            6625: 1,-65
-            6626: 2,-65
-            6627: 3,-65
-            6628: 4,-65
-            6636: 4,-70
-            6637: 3,-70
-            6638: 2,-70
-            6647: 6,-71
-            6648: 7,-71
-            6654: -7,-71
-            6655: -6,-71
-            6673: 0,-74
-            6686: -5,-77
-            6687: -4,-77
-            6688: -3,-77
-            6689: -2,-77
-            6690: -1,-77
-            6691: 0,-77
-            6692: 1,-77
-            6693: 2,-77
-            6694: 3,-77
-            6695: 4,-77
-            6696: 5,-77
-            6855: 21,-50
-            6901: 21,-52
-            6905: 23,-54
-            6906: 25,-54
-            6907: 26,-54
-            6917: 27,-61
-            6918: 29,-61
-            7070: 34,-42
-            7071: 35,-42
-            7072: 36,-42
-            7080: 18,-40
-            7081: 19,-40
-            7082: 20,-40
-            7083: 22,-40
-            7084: 23,-40
-            7085: 24,-40
-            7086: 25,-40
-            7087: 26,-40
-            7088: 27,-40
-            7089: 28,-40
-            7097: 12,-48
-            7098: 14,-48
-            7099: 15,-48
-            7100: 16,-48
-            7101: 17,-48
-            7102: 18,-48
-            7103: 19,-48
-            7104: 20,-48
-            7105: 21,-48
-            7106: 22,-48
-            7107: 23,-48
-            7108: 24,-48
-            7109: 25,-48
-            7110: 26,-48
-            7111: 27,-48
-            7112: 28,-48
-            7113: 29,-48
-            7114: 30,-48
-            7158: 13,-48
-            7168: 13,-47
-            7329: 24,-54
-            7332: 25,-61
-            7333: 26,-61
-            7334: 28,-61
-            7522: -4,-60
-            7532: -3,-70
-            7533: -4,-70
+            1655: -22,-25
+            1656: -23,-25
+            1657: -24,-25
+            1670: -22,-17
+            1671: -23,-17
+            1672: -24,-17
+            1673: -25,-17
+            1844: -6,-21
+            1845: -5,-21
+            1846: -4,-21
+            1847: -3,-21
+            2186: -37,-49
+            2187: -38,-49
+            2262: -43,-53
+            2263: -42,-53
+            2342: -81,-55
+            2345: -78,-53
+            3168: 35,19
+            3860: 40,-10
+            3861: 39,-10
+            3862: 38,-10
+            3863: 37,-10
+            3864: 36,-10
+            3865: 35,-10
+            3875: 46,-13
+            3876: 46,-7
+            3877: 46,-5
+            3904: 46,-15
+            4095: -13,22
+            4096: -12,22
+            4097: -10,22
+            4098: -9,22
+            4099: -8,22
+            4100: -7,22
+            4101: -6,22
+            4102: -4,22
+            4103: -3,22
+            4354: -31,36
+            4355: -30,36
+            4356: -29,36
+            4357: -27,36
+            4458: -40,24
+            4459: -41,24
+            4460: -42,24
+            4461: -43,24
+            4646: 5,35
+            4647: 4,35
+            4668: 4,44
+            4669: 5,44
+            4670: 6,44
+            4671: 7,44
+            4672: 8,44
+            5017: 2,52
+            5018: 1,52
+            5019: 0,52
+            5020: -1,52
+            5025: 2,58
+            5026: -1,58
+            5029: 3,72
+            5030: 2,72
+            5031: 1,72
+            5032: 0,72
+            5033: -1,72
+            5295: 34,-15
+            5296: 33,-15
+            5297: 32,-15
+            5298: 31,-15
+            5299: 30,-15
+            5300: 29,-15
+            5301: 28,-15
+            5372: 47,-33
+            5598: 8,-22
+            5599: 7,-22
+            5600: 6,-22
+            6182: 3,-45
+            6183: 0,-45
+            6184: -1,-45
+            6189: -1,-49
+            6190: -2,-49
+            6318: 4,-53
+            6319: 3,-53
+            6342: -8,-59
+            6343: -6,-60
+            6344: -5,-60
+            6345: -4,-60
+            6346: -3,-60
+            6347: -2,-60
+            6404: -15,-59
+            6405: -14,-59
+            6406: -13,-59
+            6409: -9,-59
+            6423: -15,-56
+            6424: -14,-56
+            6425: -13,-56
+            6426: -12,-56
+            6427: -11,-56
+            6428: -10,-56
+            6429: -21,-60
+            6430: -20,-60
+            6431: -19,-60
+            6432: -18,-60
+            6531: 14,-67
+            6532: 13,-67
+            6533: 12,-67
+            6534: 11,-67
+            6535: 10,-67
+            6611: -4,-65
+            6612: -3,-65
+            6613: -2,-65
+            6614: -1,-65
+            6615: 0,-65
+            6616: 1,-65
+            6617: 2,-65
+            6618: 3,-65
+            6619: 4,-65
+            6627: 4,-70
+            6628: 3,-70
+            6629: 2,-70
+            6638: 6,-71
+            6639: 7,-71
+            6645: -7,-71
+            6646: -6,-71
+            6664: 0,-74
+            6677: -5,-77
+            6678: -4,-77
+            6679: -3,-77
+            6680: -2,-77
+            6681: -1,-77
+            6682: 0,-77
+            6683: 1,-77
+            6684: 2,-77
+            6685: 3,-77
+            6686: 4,-77
+            6687: 5,-77
+            6846: 21,-50
+            6892: 21,-52
+            6896: 23,-54
+            6897: 25,-54
+            6898: 26,-54
+            6908: 27,-61
+            6909: 29,-61
+            7061: 34,-42
+            7062: 35,-42
+            7063: 36,-42
+            7071: 18,-40
+            7072: 19,-40
+            7073: 20,-40
+            7074: 22,-40
+            7075: 23,-40
+            7076: 24,-40
+            7077: 25,-40
+            7078: 26,-40
+            7079: 27,-40
+            7080: 28,-40
+            7088: 12,-48
+            7089: 14,-48
+            7090: 15,-48
+            7091: 16,-48
+            7092: 17,-48
+            7093: 18,-48
+            7094: 19,-48
+            7095: 20,-48
+            7096: 21,-48
+            7097: 22,-48
+            7098: 23,-48
+            7099: 24,-48
+            7100: 25,-48
+            7101: 26,-48
+            7102: 27,-48
+            7103: 28,-48
+            7104: 29,-48
+            7105: 30,-48
+            7149: 13,-48
+            7159: 13,-47
+            7320: 24,-54
+            7323: 25,-61
+            7324: 26,-61
+            7325: 28,-61
+            7513: -4,-60
+            7523: -3,-70
+            7524: -4,-70
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
@@ -8721,97 +8721,97 @@ entities:
             1170: -40,-6
             1265: -35,15
             1266: -33,15
-            1432: -35,-29
-            1667: -25,-24
-            1668: -25,-23
-            1669: -25,-22
-            1812: -21,-31
-            1821: -20,-33
-            1822: -19,-34
-            1823: -19,-33
-            1824: -19,-32
-            1825: -19,-31
-            1862: -1,-22
-            1863: -1,-23
-            1864: -1,-24
-            2127: -43,-44
-            2155: -45,-30
-            2156: -45,-31
-            2233: -33,-52
-            2234: -33,-51
-            2235: -33,-50
-            2352: -83,-53
-            3163: 34,16
-            3166: 38,15
-            3167: 38,16
-            3179: 34,20
-            3440: 46,32
-            3443: 46,39
-            4308: -18,38
-            4309: -18,39
-            4310: -18,40
-            4368: -29,37
-            4369: -29,38
-            4370: -29,39
-            4652: 8,35
-            4653: 8,34
-            4676: 4,38
-            4782: 13,46
-            4783: 13,47
-            5080: 7,74
-            5081: 7,75
-            5082: 7,76
-            5083: 7,77
-            5084: 7,78
-            5085: 7,79
-            5086: 7,80
-            5122: -4,74
-            5123: -4,75
-            5124: -4,76
-            5125: -4,78
-            5126: -4,79
-            5127: -4,80
-            5128: -4,77
-            5183: 18,-17
-            5184: 18,-16
-            5185: 18,-15
-            5186: 18,-14
-            5379: 46,-32
-            5614: 11,-26
-            5615: 11,-25
-            5616: 11,-24
-            6372: 0,-60
-            6373: 0,-61
-            6409: -16,-62
-            6410: -16,-61
-            6411: -16,-60
-            6417: -12,-60
-            6426: -14,-57
-            6430: -16,-57
-            6630: 5,-66
-            6631: 5,-67
-            6632: 5,-68
-            6659: -8,-70
-            6672: 5,-72
-            6684: -6,-76
-            6903: 22,-53
-            6912: 24,-56
-            6913: 24,-57
-            6914: 24,-58
-            6915: 24,-60
-            7160: 11,-47
-            7161: 11,-46
-            7162: 11,-45
-            7163: 11,-44
-            7164: 11,-43
-            7165: 12,-44
-            7166: 12,-45
-            7167: 12,-46
-            7322: 24,-59
-            7548: 5,-70
-            7550: -47,-28
-            7551: -47,-27
-            7552: -47,-26
+            1423: -35,-29
+            1658: -25,-24
+            1659: -25,-23
+            1660: -25,-22
+            1803: -21,-31
+            1812: -20,-33
+            1813: -19,-34
+            1814: -19,-33
+            1815: -19,-32
+            1816: -19,-31
+            1853: -1,-22
+            1854: -1,-23
+            1855: -1,-24
+            2118: -43,-44
+            2146: -45,-30
+            2147: -45,-31
+            2224: -33,-52
+            2225: -33,-51
+            2226: -33,-50
+            2343: -83,-53
+            3154: 34,16
+            3157: 38,15
+            3158: 38,16
+            3170: 34,20
+            3431: 46,32
+            3434: 46,39
+            4299: -18,38
+            4300: -18,39
+            4301: -18,40
+            4359: -29,37
+            4360: -29,38
+            4361: -29,39
+            4643: 8,35
+            4644: 8,34
+            4667: 4,38
+            4773: 13,46
+            4774: 13,47
+            5071: 7,74
+            5072: 7,75
+            5073: 7,76
+            5074: 7,77
+            5075: 7,78
+            5076: 7,79
+            5077: 7,80
+            5113: -4,74
+            5114: -4,75
+            5115: -4,76
+            5116: -4,78
+            5117: -4,79
+            5118: -4,80
+            5119: -4,77
+            5174: 18,-17
+            5175: 18,-16
+            5176: 18,-15
+            5177: 18,-14
+            5370: 46,-32
+            5605: 11,-26
+            5606: 11,-25
+            5607: 11,-24
+            6363: 0,-60
+            6364: 0,-61
+            6400: -16,-62
+            6401: -16,-61
+            6402: -16,-60
+            6408: -12,-60
+            6417: -14,-57
+            6421: -16,-57
+            6621: 5,-66
+            6622: 5,-67
+            6623: 5,-68
+            6650: -8,-70
+            6663: 5,-72
+            6675: -6,-76
+            6894: 22,-53
+            6903: 24,-56
+            6904: 24,-57
+            6905: 24,-58
+            6906: 24,-60
+            7151: 11,-47
+            7152: 11,-46
+            7153: 11,-45
+            7154: 11,-44
+            7155: 11,-43
+            7156: 12,-44
+            7157: 12,-45
+            7158: 12,-46
+            7313: 24,-59
+            7539: 5,-70
+            7541: -47,-28
+            7542: -47,-27
+            7543: -47,-26
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
@@ -8839,392 +8839,392 @@ entities:
             1267: -34,14
             1287: -31,-21
             1288: -30,-21
-            1421: -35,-27
-            1422: -34,-27
-            1423: -33,-27
-            1670: -24,-21
-            1671: -23,-21
-            1672: -22,-21
-            1846: -3,-25
-            1847: -4,-25
-            1848: -5,-25
-            1849: -6,-25
-            2189: -37,-46
-            2190: -38,-46
-            2273: -43,-53
-            2274: -42,-53
-            2350: -81,-51
-            2353: -78,-53
-            3170: 35,13
-            3171: 34,13
-            3172: 33,13
-            3433: 28,41
-            3434: 29,41
-            3435: 30,41
-            3436: 43,26
-            3875: 35,-7
-            3876: 36,-7
-            3877: 37,-7
-            3878: 38,-7
-            3879: 39,-7
-            3880: 40,-7
-            3881: 46,-5
-            3882: 46,-7
-            3883: 46,-13
-            3912: 46,-15
-            4073: -3,20
-            4074: -4,20
-            4075: -5,20
-            4076: -6,20
-            4077: -7,20
-            4078: -8,20
-            4079: -9,20
-            4080: -10,20
-            4081: -11,20
-            4082: -12,20
-            4083: -13,20
-            4084: -14,20
-            4145: -13,26
-            4146: -12,26
-            4147: -10,26
-            4148: -9,26
-            4149: -6,26
-            4150: -4,26
-            4151: -3,26
-            4153: -8,26
-            4154: -7,26
-            4168: -20,26
-            4169: -21,26
-            4357: -29,32
-            4358: -30,32
-            4359: -31,32
-            4360: -31,36
-            4361: -30,36
-            4362: -29,36
-            4416: -41,30
-            4417: -42,30
-            4418: -43,30
-            5024: -1,53
-            5025: 2,53
-            5043: -1,69
-            5044: 0,69
-            5045: 1,69
-            5046: 2,69
-            5047: 3,69
-            5094: -1,82
-            5095: 0,82
-            5096: 1,82
-            5097: 2,82
-            5098: 3,82
-            5380: 47,-31
-            5600: 6,-28
-            5601: 7,-28
-            5602: 8,-28
-            6200: -2,-48
-            6201: -1,-48
-            6359: -2,-57
-            6360: -3,-57
-            6361: -4,-57
-            6362: -5,-57
-            6363: -6,-57
-            6364: -8,-58
-            6419: -9,-58
-            6422: -10,-58
-            6423: -11,-58
-            6428: -15,-58
-            6442: -18,-62
-            6443: -19,-62
-            6444: -20,-62
-            6445: -21,-62
-            6545: 14,-66
-            6546: 13,-66
-            6547: 12,-66
-            6548: 11,-66
-            6549: 10,-66
-            6633: 4,-70
-            6634: 3,-70
-            6635: 2,-70
-            6645: 7,-69
-            6646: 6,-69
-            6656: -6,-69
-            6657: -7,-69
-            6662: -4,-73
-            6663: -3,-73
-            6664: -2,-73
-            6665: 0,-73
-            6668: 2,-73
-            6669: 3,-73
-            6670: 4,-73
-            6676: -2,-74
-            6677: -3,-74
-            6678: -4,-74
-            6679: -5,-74
-            6680: -6,-74
-            6702: 6,-74
-            6703: 5,-74
-            6704: 4,-74
-            6705: 3,-74
-            6706: 2,-74
-            6856: 21,-50
-            6895: 21,-51
-            6896: 22,-51
-            6897: 24,-51
-            6898: 23,-51
-            6899: 25,-51
-            6900: 26,-51
-            6924: 27,-55
-            6925: 26,-55
-            6926: 25,-55
-            7074: 35,-47
-            7075: 34,-47
-            7122: 30,-43
-            7135: 28,-42
-            7136: 27,-42
-            7137: 26,-42
-            7138: 25,-42
-            7139: 24,-42
-            7140: 23,-42
-            7141: 22,-42
-            7143: 20,-42
-            7144: 21,-42
-            7146: 19,-42
-            7147: 18,-42
-            7148: 17,-42
-            7149: 16,-42
-            7150: 15,-42
-            7151: 14,-42
-            7152: 13,-42
-            7153: 12,-42
-            7169: 13,-43
-            7175: 14,-49
-            7176: 13,-49
-            7177: 12,-49
-            7178: 12,-49
-            7179: 10,-49
-            7323: 28,-55
-            7324: 29,-55
-            7512: -7,-57
-            7513: -6,-57
-            7514: -5,-57
-            7515: -4,-57
-            7516: -3,-57
-            7517: -2,-57
-            7529: -4,-70
-            7530: -3,-70
+            1412: -35,-27
+            1413: -34,-27
+            1414: -33,-27
+            1661: -24,-21
+            1662: -23,-21
+            1663: -22,-21
+            1837: -3,-25
+            1838: -4,-25
+            1839: -5,-25
+            1840: -6,-25
+            2180: -37,-46
+            2181: -38,-46
+            2264: -43,-53
+            2265: -42,-53
+            2341: -81,-51
+            2344: -78,-53
+            3161: 35,13
+            3162: 34,13
+            3163: 33,13
+            3424: 28,41
+            3425: 29,41
+            3426: 30,41
+            3427: 43,26
+            3866: 35,-7
+            3867: 36,-7
+            3868: 37,-7
+            3869: 38,-7
+            3870: 39,-7
+            3871: 40,-7
+            3872: 46,-5
+            3873: 46,-7
+            3874: 46,-13
+            3903: 46,-15
+            4064: -3,20
+            4065: -4,20
+            4066: -5,20
+            4067: -6,20
+            4068: -7,20
+            4069: -8,20
+            4070: -9,20
+            4071: -10,20
+            4072: -11,20
+            4073: -12,20
+            4074: -13,20
+            4075: -14,20
+            4136: -13,26
+            4137: -12,26
+            4138: -10,26
+            4139: -9,26
+            4140: -6,26
+            4141: -4,26
+            4142: -3,26
+            4144: -8,26
+            4145: -7,26
+            4159: -20,26
+            4160: -21,26
+            4348: -29,32
+            4349: -30,32
+            4350: -31,32
+            4351: -31,36
+            4352: -30,36
+            4353: -29,36
+            4407: -41,30
+            4408: -42,30
+            4409: -43,30
+            5015: -1,53
+            5016: 2,53
+            5034: -1,69
+            5035: 0,69
+            5036: 1,69
+            5037: 2,69
+            5038: 3,69
+            5085: -1,82
+            5086: 0,82
+            5087: 1,82
+            5088: 2,82
+            5089: 3,82
+            5371: 47,-31
+            5591: 6,-28
+            5592: 7,-28
+            5593: 8,-28
+            6191: -2,-48
+            6192: -1,-48
+            6350: -2,-57
+            6351: -3,-57
+            6352: -4,-57
+            6353: -5,-57
+            6354: -6,-57
+            6355: -8,-58
+            6410: -9,-58
+            6413: -10,-58
+            6414: -11,-58
+            6419: -15,-58
+            6433: -18,-62
+            6434: -19,-62
+            6435: -20,-62
+            6436: -21,-62
+            6536: 14,-66
+            6537: 13,-66
+            6538: 12,-66
+            6539: 11,-66
+            6540: 10,-66
+            6624: 4,-70
+            6625: 3,-70
+            6626: 2,-70
+            6636: 7,-69
+            6637: 6,-69
+            6647: -6,-69
+            6648: -7,-69
+            6653: -4,-73
+            6654: -3,-73
+            6655: -2,-73
+            6656: 0,-73
+            6659: 2,-73
+            6660: 3,-73
+            6661: 4,-73
+            6667: -2,-74
+            6668: -3,-74
+            6669: -4,-74
+            6670: -5,-74
+            6671: -6,-74
+            6693: 6,-74
+            6694: 5,-74
+            6695: 4,-74
+            6696: 3,-74
+            6697: 2,-74
+            6847: 21,-50
+            6886: 21,-51
+            6887: 22,-51
+            6888: 24,-51
+            6889: 23,-51
+            6890: 25,-51
+            6891: 26,-51
+            6915: 27,-55
+            6916: 26,-55
+            6917: 25,-55
+            7065: 35,-47
+            7066: 34,-47
+            7113: 30,-43
+            7126: 28,-42
+            7127: 27,-42
+            7128: 26,-42
+            7129: 25,-42
+            7130: 24,-42
+            7131: 23,-42
+            7132: 22,-42
+            7134: 20,-42
+            7135: 21,-42
+            7137: 19,-42
+            7138: 18,-42
+            7139: 17,-42
+            7140: 16,-42
+            7141: 15,-42
+            7142: 14,-42
+            7143: 13,-42
+            7144: 12,-42
+            7160: 13,-43
+            7166: 14,-49
+            7167: 13,-49
+            7168: 12,-49
+            7169: 12,-49
+            7170: 10,-49
+            7314: 28,-55
+            7315: 29,-55
+            7503: -7,-57
+            7504: -6,-57
+            7505: -5,-57
+            7506: -4,-57
+            7507: -3,-57
+            7508: -2,-57
+            7520: -4,-70
+            7521: -3,-70
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
           decals:
-            3196: 39,5
-            3199: 38,4
-            3200: 37,5
+            3187: 39,5
+            3190: 38,4
+            3191: 37,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNw
           decals:
-            3206: 41,5
-            3431: 25,35
+            3197: 41,5
+            3422: 25,35
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerSw
           decals:
-            2885: 33,9
+            2876: 33,9
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndS
           decals:
-            2884: 31,9
-            3195: 39,4
+            2875: 31,9
+            3186: 39,4
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndW
           decals:
-            3194: 38,5
+            3185: 38,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerNe
           decals:
-            3201: 37,4
-            3202: 38,2
-            4781: 6,46
+            3192: 37,4
+            3193: 38,2
+            4772: 6,46
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerNw
           decals:
-            3205: 41,2
-            3207: 43,5
-            4780: 9,46
+            3196: 41,2
+            3198: 43,5
+            4771: 9,46
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerSw
           decals:
-            3197: 39,5
+            3188: 39,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineE
           decals:
-            3198: 38,3
-            4776: 6,47
-            4777: 6,48
-            4778: 6,49
-            4779: 6,50
+            3189: 38,3
+            4767: 6,47
+            4768: 6,48
+            4769: 6,49
+            4770: 6,50
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineN
           decals:
-            3203: 39,2
-            3204: 40,2
-            3208: 42,5
-            3432: 26,35
-            4774: 8,46
-            4775: 7,46
+            3194: 39,2
+            3195: 40,2
+            3199: 42,5
+            3423: 26,35
+            4765: 8,46
+            4766: 7,46
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineS
           decals:
-            2886: 34,9
-            2887: 35,9
-            4763: -3,54
-            4764: -4,54
-            4765: -5,54
-            4766: -6,54
-            4767: -7,54
-            4768: -8,54
-            4769: -9,54
-            5358: 44,-22
-            5359: 43.996502,-21.948832
-            5360: 43.996502,-21.99856
-            5361: 43.996502,-21.973696
+            2877: 34,9
+            2878: 35,9
+            4754: -3,54
+            4755: -4,54
+            4756: -5,54
+            4757: -6,54
+            4758: -7,54
+            4759: -8,54
+            4760: -9,54
+            5349: 44,-22
+            5350: 43.996502,-21.948832
+            5351: 43.996502,-21.99856
+            5352: 43.996502,-21.973696
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineW
           decals:
-            2882: 31,11
-            2883: 31,10
-            3209: 41,3
-            3210: 41,4
-            3211: 43,6
-            3212: 43,7
-            3213: 43,8
-            3214: 43,9
-            4770: 9,50
-            4771: 9,49
-            4772: 9,48
-            4773: 9,47
+            2873: 31,11
+            2874: 31,10
+            3200: 41,3
+            3201: 41,4
+            3202: 43,6
+            3203: 43,7
+            3204: 43,8
+            3205: 43,9
+            4761: 9,50
+            4762: 9,49
+            4763: 9,48
+            4764: 9,47
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: clown
           decals:
-            7351: 4.776539,-35.340748
+            7342: 4.776539,-35.340748
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF00005A'
             id: footprint
           decals:
-            5139: 12.790892,-10.743357
+            5130: 12.790892,-10.743357
         - node:
             cleanable: True
             angle: -3.141592653589793 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5927: 36.792473,-23.683962
-            5928: 37.137463,-23.28303
-            5929: 36.792473,-22.95669
-            5930: 37.146786,-22.70494
-            5931: 36.78315,-22.359953
-            5932: 37.165436,-22.07091
-            5933: 36.820446,-21.753893
+            5918: 36.792473,-23.683962
+            5919: 37.137463,-23.28303
+            5920: 36.792473,-22.95669
+            5921: 37.146786,-22.70494
+            5922: 36.78315,-22.359953
+            5923: 37.165436,-22.07091
+            5924: 36.820446,-21.753893
         - node:
             cleanable: True
             angle: -1.5707963267948966 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5916: 11.844839,-26.264587
-            5917: 11.6490345,-25.956896
-            5923: 3.9564643,-24.88426
-            5924: 4.4226646,-25.247896
-            5925: 4.8702173,-24.88426
-            5926: 5.205881,-25.25722
+            5907: 11.844839,-26.264587
+            5908: 11.6490345,-25.956896
+            5914: 3.9564643,-24.88426
+            5915: 4.4226646,-25.247896
+            5916: 4.8702173,-24.88426
+            5917: 5.205881,-25.25722
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5918: 12.857773,-20.710676
-            5919: 13.156141,-21.074314
-            5920: 12.8204775,-21.465921
-            5921: 13.128169,-21.801586
-            5922: 12.8204775,-22.239815
+            5909: 12.857773,-20.710676
+            5910: 13.156141,-21.074314
+            5911: 12.8204775,-21.465921
+            5912: 13.128169,-21.801586
+            5913: 12.8204775,-22.239815
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000FF'
             id: footprint
           decals:
-            5142: 12.800216,-9.782984
-            5143: 13.201148,-10.081352
-            5144: 12.800216,-10.333101
+            5133: 12.800216,-9.782984
+            5134: 13.201148,-10.081352
+            5135: 12.800216,-10.333101
         - node:
             color: '#FFFFFFFF'
             id: rune1
           decals:
             458: -16,6
-            2805: 28,-7
+            2796: 28,-7
         - node:
             color: '#FFFFFFFF'
             id: rune2
           decals:
-            2806: 29,-7
+            2797: 29,-7
         - node:
             color: '#FFFFFFFF'
             id: rune3
           decals:
-            2807: 28,-8
+            2798: 28,-8
         - node:
             color: '#FFFFFFFF'
             id: rune4
           decals:
-            2808: 29,-8
+            2799: 29,-8
         - node:
             cleanable: True
             angle: -4.71238898038469 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5936: 9.984598,-26.331085
+            5927: 9.984598,-26.331085
         - node:
             cleanable: True
             angle: -3.141592653589793 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5934: 37.17476,-21.101212
-            5935: 36.811123,-21.063915
+            5925: 37.17476,-21.101212
+            5926: 36.811123,-21.063915
         - node:
             cleanable: True
             angle: -1.5707963267948966 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5937: 10.031219,-25.930153
+            5928: 10.031219,-25.930153
         - node:
             cleanable: True
             color: '#FF0000FF'
             id: thinline
           decals:
-            5141: 13.210472,-9.009092
+            5132: 13.210472,-9.009092
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000FF'
             id: thinline
           decals:
-            5140: 12.781568,-8.962471
+            5131: 12.781568,-8.962471
     - type: GridAtmosphere
       version: 2
       data:
@@ -15129,7 +15129,7 @@ entities:
       pos: 34.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -53943.504
+      secondsUntilStateChange: -55045.918
       state: Opening
   - uid: 383
     components:
@@ -16993,6 +16993,13 @@ entities:
     - type: Transform
       pos: 23.497353,-9.44327
       parent: 2
+- proto: AsimovCircuitBoard
+  entities:
+  - uid: 24105
+    components:
+    - type: Transform
+      pos: 2.4947147,69.516464
+      parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 263
@@ -17071,30 +17078,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,77.5
-      parent: 2
-  - uid: 704
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,77.5
-      parent: 2
-  - uid: 705
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,78.5
-      parent: 2
-  - uid: 706
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,77.5
-      parent: 2
-  - uid: 707
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,76.5
       parent: 2
   - uid: 708
     components:
@@ -17368,6 +17351,21 @@ entities:
       parent: 2
 - proto: AtmosFixFreezerMarker
   entities:
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -0.5,79.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -1.5,79.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -1.5,80.5
+      parent: 2
   - uid: 758
     components:
     - type: Transform
@@ -17475,6 +17473,191 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,21.5
+      parent: 2
+  - uid: 19940
+    components:
+    - type: Transform
+      pos: 0.5,79.5
+      parent: 2
+  - uid: 23932
+    components:
+    - type: Transform
+      pos: 0.5,80.5
+      parent: 2
+  - uid: 23944
+    components:
+    - type: Transform
+      pos: 1.5,80.5
+      parent: 2
+  - uid: 23945
+    components:
+    - type: Transform
+      pos: 1.5,79.5
+      parent: 2
+  - uid: 23946
+    components:
+    - type: Transform
+      pos: 2.5,79.5
+      parent: 2
+  - uid: 23947
+    components:
+    - type: Transform
+      pos: 2.5,80.5
+      parent: 2
+  - uid: 23948
+    components:
+    - type: Transform
+      pos: 3.5,79.5
+      parent: 2
+  - uid: 23949
+    components:
+    - type: Transform
+      pos: 3.5,78.5
+      parent: 2
+  - uid: 23950
+    components:
+    - type: Transform
+      pos: 4.5,78.5
+      parent: 2
+  - uid: 23951
+    components:
+    - type: Transform
+      pos: 4.5,79.5
+      parent: 2
+  - uid: 23952
+    components:
+    - type: Transform
+      pos: 4.5,80.5
+      parent: 2
+  - uid: 23956
+    components:
+    - type: Transform
+      pos: -0.5,78.5
+      parent: 2
+  - uid: 23957
+    components:
+    - type: Transform
+      pos: -1.5,78.5
+      parent: 2
+  - uid: 23958
+    components:
+    - type: Transform
+      pos: -1.5,77.5
+      parent: 2
+  - uid: 23959
+    components:
+    - type: Transform
+      pos: -0.5,77.5
+      parent: 2
+  - uid: 23964
+    components:
+    - type: Transform
+      pos: 0.5,75.5
+      parent: 2
+  - uid: 23965
+    components:
+    - type: Transform
+      pos: 0.5,74.5
+      parent: 2
+  - uid: 23966
+    components:
+    - type: Transform
+      pos: 1.5,74.5
+      parent: 2
+  - uid: 23967
+    components:
+    - type: Transform
+      pos: 1.5,75.5
+      parent: 2
+  - uid: 23968
+    components:
+    - type: Transform
+      pos: 2.5,75.5
+      parent: 2
+  - uid: 23969
+    components:
+    - type: Transform
+      pos: 2.5,74.5
+      parent: 2
+  - uid: 23972
+    components:
+    - type: Transform
+      pos: 3.5,77.5
+      parent: 2
+  - uid: 23973
+    components:
+    - type: Transform
+      pos: 4.5,77.5
+      parent: 2
+  - uid: 23974
+    components:
+    - type: Transform
+      pos: 4.5,76.5
+      parent: 2
+  - uid: 24025
+    components:
+    - type: Transform
+      pos: 3.5,76.5
+      parent: 2
+  - uid: 24026
+    components:
+    - type: Transform
+      pos: 3.5,75.5
+      parent: 2
+  - uid: 24030
+    components:
+    - type: Transform
+      pos: 4.5,75.5
+      parent: 2
+  - uid: 24031
+    components:
+    - type: Transform
+      pos: 4.5,74.5
+      parent: 2
+  - uid: 24032
+    components:
+    - type: Transform
+      pos: -1.5,74.5
+      parent: 2
+  - uid: 24069
+    components:
+    - type: Transform
+      pos: -1.5,75.5
+      parent: 2
+  - uid: 24070
+    components:
+    - type: Transform
+      pos: -0.5,75.5
+      parent: 2
+  - uid: 24071
+    components:
+    - type: Transform
+      pos: -0.5,76.5
+      parent: 2
+  - uid: 24072
+    components:
+    - type: Transform
+      pos: -1.5,76.5
+      parent: 2
+  - uid: 24124
+    components:
+    - type: Transform
+      pos: 0.5,77.5
+      parent: 2
+  - uid: 24125
+    components:
+    - type: Transform
+      pos: 1.5,77.5
+      parent: 2
+  - uid: 24126
+    components:
+    - type: Transform
+      pos: 1.5,76.5
+      parent: 2
+  - uid: 24127
+    components:
+    - type: Transform
+      pos: 2.5,77.5
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
@@ -19297,6 +19480,51 @@ entities:
     - type: DeviceLinkSink
       links:
       - 18291
+  - uid: 24096
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,73.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 24104
+  - uid: 24099
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,73.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 24104
+  - uid: 24100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,73.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 24104
+  - uid: 24101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,81.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 24104
+  - uid: 24102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,81.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 24104
 - proto: Bloodpack
   entities:
   - uid: 1033
@@ -19477,13 +19705,6 @@ entities:
         Enquanto a Maldição do Peso Eterno é implacável em suas imposições de tarefas, ela concede à pessoa afetada um mínimo de livre-arbítrio. A vítima pode escolher a ordem em que realiza as tarefas e até mesmo o tipo de atividade que deseja empreender, dentro dos limites impostos pela maldição. Essa capacidade de escolha paradoxalmente intensifica o sofrimento da pessoa, pois ela deve decidir constantemente qual tarefa realizar, sabendo que nunca haverá um fim para essa demanda interminável.
     - type: Physics
       canCollide: False
-- proto: BookChefGaming
-  entities:
-  - uid: 1056
-    components:
-    - type: Transform
-      pos: 19.417454,16.533361
-      parent: 2
 - proto: BookChemicalCompendium
   entities:
   - uid: 1057
@@ -19514,6 +19735,13 @@ entities:
     components:
     - type: Transform
       pos: 20.433872,-13.290758
+      parent: 2
+- proto: BookHowToCookForFortySpaceman
+  entities:
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 19.417454,16.533361
       parent: 2
 - proto: BookHowToSurvive
   entities:
@@ -20606,6 +20834,14 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 24094
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,76.5
+      parent: 2
 - proto: CableApcExtension
   entities:
   - uid: 1231
@@ -37152,6 +37388,71 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-64.5
+      parent: 2
+  - uid: 24078
+    components:
+    - type: Transform
+      pos: -7.5,71.5
+      parent: 2
+  - uid: 24079
+    components:
+    - type: Transform
+      pos: -7.5,70.5
+      parent: 2
+  - uid: 24080
+    components:
+    - type: Transform
+      pos: 3.5,85.5
+      parent: 2
+  - uid: 24081
+    components:
+    - type: Transform
+      pos: 3.5,86.5
+      parent: 2
+  - uid: 24082
+    components:
+    - type: Transform
+      pos: 8.5,79.5
+      parent: 2
+  - uid: 24083
+    components:
+    - type: Transform
+      pos: 10.5,79.5
+      parent: 2
+  - uid: 24084
+    components:
+    - type: Transform
+      pos: 10.5,80.5
+      parent: 2
+  - uid: 24085
+    components:
+    - type: Transform
+      pos: 8.5,79.5
+      parent: 2
+  - uid: 24086
+    components:
+    - type: Transform
+      pos: 9.5,79.5
+      parent: 2
+  - uid: 24087
+    components:
+    - type: Transform
+      pos: 9.5,72.5
+      parent: 2
+  - uid: 24088
+    components:
+    - type: Transform
+      pos: 10.5,72.5
+      parent: 2
+  - uid: 24089
+    components:
+    - type: Transform
+      pos: 10.5,73.5
+      parent: 2
+  - uid: 24110
+    components:
+    - type: Transform
+      pos: 4.5,68.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -58773,69 +59074,6 @@ entities:
     - type: Transform
       pos: 23.488644,-36.37967
       parent: 2
-- proto: chem_master
-  entities:
-  - uid: 8612
-    components:
-    - type: Transform
-      pos: -3.5,-30.5
-      parent: 2
-  - uid: 8613
-    components:
-    - type: Transform
-      pos: 38.5,12.5
-      parent: 2
-  - uid: 8614
-    components:
-    - type: Transform
-      pos: 38.5,-32.5
-      parent: 2
-  - uid: 8615
-    components:
-    - type: Transform
-      pos: 9.5,-29.5
-      parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 8616
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-  - uid: 8617
-    components:
-    - type: Transform
-      pos: 4.5,-30.5
-      parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 8618
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
 - proto: ChemDispenser
   entities:
   - uid: 8619
@@ -58976,6 +59214,69 @@ entities:
     - type: Transform
       pos: 4.5,-29.5
       parent: 2
+- proto: ChemMaster
+  entities:
+  - uid: 8612
+    components:
+    - type: Transform
+      pos: -3.5,-30.5
+      parent: 2
+  - uid: 8613
+    components:
+    - type: Transform
+      pos: 38.5,12.5
+      parent: 2
+  - uid: 8614
+    components:
+    - type: Transform
+      pos: 38.5,-32.5
+      parent: 2
+  - uid: 8615
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        beakerSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 8616
+        outputSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+  - uid: 8617
+    components:
+    - type: Transform
+      pos: 4.5,-30.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        beakerSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 8618
+        outputSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
 - proto: ChemMasterMachineCircuitboard
   entities:
   - uid: 8646
@@ -61949,11 +62250,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,69.5
       parent: 2
-  - uid: 9022
-    components:
-    - type: Transform
-      pos: 1.5,72.5
-      parent: 2
   - uid: 9023
     components:
     - type: Transform
@@ -62914,6 +63210,13 @@ entities:
     - type: DeviceLinkSink
       links:
       - 19984
+- proto: CorporateCircuitBoard
+  entities:
+  - uid: 24106
+    components:
+    - type: Transform
+      pos: 2.4947147,69.68834
+      parent: 2
 - proto: CrateArtifactContainer
   entities:
   - uid: 9160
@@ -108329,7 +108632,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,74.5
       parent: 2
-- proto: IntercomAssesmbly
+  - uid: 24095
+    components:
+    - type: Transform
+      pos: 1.5,78.5
+      parent: 2
+- proto: IntercomAssembly
   entities:
   - uid: 15643
     components:
@@ -111947,6 +112255,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 27.5,15.5
       parent: 2
+- proto: NTDefaultCircuitBoard
+  entities:
+  - uid: 24107
+    components:
+    - type: Transform
+      pos: 2.4947147,69.37584
+      parent: 2
 - proto: NuclearBomb
   entities:
   - uid: 16126
@@ -113152,6 +113467,13 @@ entities:
     components:
     - type: Transform
       pos: -27.5,26.5
+      parent: 2
+- proto: PlayerStationAi
+  entities:
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 1.5,77.5
       parent: 2
 - proto: Plunger
   entities:
@@ -125718,6 +126040,27 @@ entities:
       linkedPorts:
         1016:
         - Pressed: Toggle
+  - uid: 24104
+    components:
+    - type: MetaData
+      desc: For securing the core
+      name: AI Core blast doors
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,76.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        24096:
+        - Pressed: Toggle
+        24099:
+        - Pressed: Toggle
+        24100:
+        - Pressed: Toggle
+        24101:
+        - Pressed: Toggle
+        24102:
+        - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 18268
@@ -128104,7 +128447,7 @@ entities:
     - type: Transform
       pos: 13.5,-1.5
       parent: 2
-- proto: SignChemistry1
+- proto: SignChem
   entities:
   - uid: 18448
     components:
@@ -128248,7 +128591,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 24.5,-22.5
       parent: 2
-- proto: SignHydro2
+- proto: SignHydro1
   entities:
   - uid: 18470
     components:
@@ -129058,7 +129401,7 @@ entities:
     - type: Transform
       pos: 40.506535,21.44361
       parent: 2
-- proto: soda_dispenser
+- proto: SodaDispenser
   entities:
   - uid: 18609
     components:
@@ -130652,6 +130995,16 @@ entities:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
+  - uid: 24097
+    components:
+    - type: Transform
+      pos: 2.5,85.5
+      parent: 2
+  - uid: 24098
+    components:
+    - type: Transform
+      pos: 0.5,85.5
+      parent: 2
 - proto: SpawnPointBotanist
   entities:
   - uid: 18864
@@ -131831,6 +132184,13 @@ entities:
     - type: Transform
       pos: 23.5,-27.5
       parent: 2
+- proto: StationAiUploadComputer
+  entities:
+  - uid: 9022
+    components:
+    - type: Transform
+      pos: 1.5,72.5
+      parent: 2
 - proto: StationMap
   entities:
   - uid: 19049
@@ -132918,6 +133278,64 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Representative Office
+  - uid: 23954
+    components:
+    - type: Transform
+      pos: 1.5,79.5
+      parent: 2
+  - uid: 23955
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,75.5
+      parent: 2
+  - uid: 24073
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,83.5
+      parent: 2
+  - uid: 24074
+    components:
+    - type: Transform
+      pos: 4.5,87.5
+      parent: 2
+  - uid: 24075
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,80.5
+      parent: 2
+  - uid: 24076
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,73.5
+      parent: 2
+  - uid: 24077
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,69.5
+      parent: 2
+  - uid: 24103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,75.5
+      parent: 2
+  - uid: 24108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,84.5
+      parent: 2
+  - uid: 24109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,67.5
+      parent: 2
 - proto: SurveillanceCameraEngineering
   entities:
   - uid: 19212
@@ -133204,6 +133622,42 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: East Supermatter
+  - uid: 24115
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-72.5
+      parent: 2
+  - uid: 24116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 28.5,-69.5
+      parent: 2
+  - uid: 24117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-62.5
+      parent: 2
+  - uid: 24118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-58.5
+      parent: 2
+  - uid: 24119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-54.5
+      parent: 2
+  - uid: 24120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-66.5
+      parent: 2
 - proto: SurveillanceCameraGeneral
   entities:
   - uid: 19238
@@ -134022,6 +134476,24 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Robotics 1
+  - uid: 24112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-26.5
+      parent: 2
+  - uid: 24113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-38.5
+      parent: 2
+  - uid: 24114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,-45.5
+      parent: 2
 - proto: SurveillanceCameraSecurity
   entities:
   - uid: 19316
@@ -134303,6 +134775,16 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Chief Justice room
+  - uid: 24111
+    components:
+    - type: Transform
+      pos: 17.5,20.5
+      parent: 2
+  - uid: 24123
+    components:
+    - type: Transform
+      pos: -39.5,39.5
+      parent: 2
 - proto: SurveillanceCameraService
   entities:
   - uid: 19341
@@ -134555,6 +135037,18 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Magnet
+  - uid: 24121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -48.5,-17.5
+      parent: 2
+  - uid: 24122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,-7.5
+      parent: 2
 - proto: SurveillanceCameraWirelessRouterBase
   entities:
   - uid: 19364
@@ -138006,13 +138500,6 @@ entities:
     components:
     - type: Transform
       pos: 28.511677,-14.453636
-      parent: 2
-- proto: ToyAi
-  entities:
-  - uid: 19940
-    components:
-    - type: Transform
-      pos: 1.4992511,77.624275
       parent: 2
 - proto: ToyAmongPequeno
   entities:
@@ -150134,6 +150621,36 @@ entities:
     - type: Transform
       pos: -7.5,17.5
       parent: 2
+  - uid: 23960
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,76.5
+      parent: 2
+  - uid: 23961
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,76.5
+      parent: 2
+  - uid: 23962
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,78.5
+      parent: 2
+  - uid: 23963
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,78.5
+      parent: 2
+  - uid: 23970
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,78.5
+      parent: 2
   - uid: 24027
     components:
     - type: Transform
@@ -157351,7 +157868,7 @@ entities:
       links:
       - 19976
     - type: Door
-      secondsUntilStateChange: -190235.81
+      secondsUntilStateChange: -191338.22
       state: Opening
   - uid: 23356
     components:
@@ -157577,6 +158094,41 @@ entities:
     components:
     - type: Transform
       pos: 8.5,25.5
+      parent: 2
+  - uid: 23953
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,77.5
+      parent: 2
+  - uid: 23971
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,77.5
+      parent: 2
+  - uid: 24090
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,77.5
+      parent: 2
+  - uid: 24091
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,77.5
+      parent: 2
+  - uid: 24092
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,76.5
+      parent: 2
+  - uid: 24093
+    components:
+    - type: Transform
+      pos: 1.5,76.5
       parent: 2
 - proto: WindoorSecureEngineeringLocked
   entities:

--- a/Resources/Prototypes/Maps/radstation.yml
+++ b/Resources/Prototypes/Maps/radstation.yml
@@ -45,7 +45,6 @@
             Scientist: [ 5, 5 ]
             ForensicMantis: [ 1, 1 ]
             ResearchAssistant: [ 2, 2 ]
-            Borg: [ 1, 1 ]
             Chaplain: [ 1, 1 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
@@ -73,3 +72,6 @@
             Clerk: [ 1, 1 ]
             Lawyer: [ 1, 1 ]
             Prosecutor: [ 1, 1]
+            #silicon
+            StationAi: [ 1, 1 ]
+            Borg: [ 3, 3 ]


### PR DESCRIPTION
# Description

This PR adds a Station AI to Radstation! Also cleans up some of the camera coverage. Since it's a mid to highpop map, this core is a bit better protected with the addition of blast doors to the windows that the AI can shut with a button. Also two cyborg spawners in the AI room, because I know for a fact we'll want them for any future malf/traitor AI implementation. :)

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/8a530f9a-c8d4-4469-81e9-a2d1be15bba1)

</p>
</details>

# Changelog

:cl:
- add: Station AI has been added to Radstation
