### PR TITLE
Fix Announcement Spam

### DIFF
--- a/Content.Server/StationEvents/Events/RandomSentienceRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSentienceRule.cs
@@ -1,8 +1,6 @@
-using Content.Server.Announcements.Systems;
 using System.Linq;
 using Content.Shared.Dataset;
 using Content.Server.Ghost.Roles.Components;
-using Content.Server.Station.Components;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
@@ -13,27 +11,25 @@ namespace Content.Server.StationEvents.Events;
 
 public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRuleComponent>
 {
-    [Dependency] private readonly AnnouncerSystem _announcer = default!;
-
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     protected override void Started(EntityUid uid, RandomSentienceRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
-        if (!TryGetRandomStation(out var randomStation))
+        if (!TryGetRandomStation(out var station))
             return;
 
         var targetList = new List<Entity<SentienceTargetComponent>>();
         var query = EntityQueryEnumerator<SentienceTargetComponent, TransformComponent>();
         while (query.MoveNext(out var targetUid, out var target, out var xform))
         {
-            if (StationSystem.GetOwningStation(targetUid, xform) != randomStation)
+            if (StationSystem.GetOwningStation(targetUid, xform) != station)
                 continue;
 
             targetList.Add((targetUid, target));
         }
 
         var toMakeSentient = _random.Next(component.MinSentiences, component.MaxSentiences);
-        var stationsToNotify = new List<EntityUid>();
+
         var groups = new HashSet<string>();
 
         for (var i = 0; i < toMakeSentient && targetList.Count > 0; i++)
@@ -72,27 +68,12 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
         var kind2 = groupList.Count > 1 ? groupList[1] : "???";
         var kind3 = groupList.Count > 2 ? groupList[2] : "???";
 
-        foreach (var target in targetList)
-        {
-            var targetStation = StationSystem.GetOwningStation(target);
-            if(targetStation == null)
-                continue;
-            stationsToNotify.Add((EntityUid) targetStation);
-        }
-        foreach (var station in stationsToNotify)
-        {
-            _announcer.SendAnnouncement(
-                _announcer.GetAnnouncementId(args.RuleId),
-                StationSystem.GetInStation(EntityManager.GetComponent<StationDataComponent>(station)),
-                "station-event-random-sentience-announcement",
-                null,
-                Color.Gold,
-                null,
-                null,
+        ChatSystem.DispatchStationAnnouncement(
+            station.Value,
+            _announcer.GetAnnouncementId(args.RuleId),
                 ("kind1", kind1), ("kind2", kind2), ("kind3", kind3), ("amount", groupList.Count),
-                    ("data", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventData"))),
-                    ("strength", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventStrength")))
-            );
-        }
+                ("data", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventData"))),
+                ("strength", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventStrength")))
+        );
     }
 }

--- a/Content.Server/StationEvents/Events/RandomSentienceRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSentienceRule.cs
@@ -70,10 +70,14 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
 
         ChatSystem.DispatchStationAnnouncement(
             station.Value,
-            _announcer.GetAnnouncementId(args.RuleId),
-                ("kind1", kind1), ("kind2", kind2), ("kind3", kind3), ("amount", groupList.Count),
+            Loc.GetString(
+                "station-event-random-sentience-announcement",
+                ("kind1", kind1),
+                ("kind2", kind2),
+                ("kind3", kind3),
+                ("amount", groupList.Count),
                 ("data", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventData"))),
-                ("strength", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventStrength")))
+                ("strength", _random.Pick(_prototype.Index<LocalizedDatasetPrototype>("RandomSentienceEventStrength"))))
         );
     }
 }


### PR DESCRIPTION
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed announcement spam caused by my silly blunder.
