### PR TITLE
Update SharedStationAiSystem.cs

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -144,6 +144,9 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiBuiCheck(Entity<StationAiWhitelistComponent> ent, ref BoundUserInterfaceCheckRangeEvent args)
     {
+        if (!HasComp<StationAiHeldComponent>(args.Actor))
+            return;
+
         args.Result = BoundUserInterfaceRangeResult.Fail;
 
         // Similar to the inrange check but more optimised so server doesn't die.


### PR DESCRIPTION
Found it. Had to trace everything calling the Ai Whitelist component, and found this system was closing all UIs if you weren't an AI and were trying to interact with a computer with said whitelist component.