### PR TITLE
Fixes Weather Soundspam(And Crash)

### DIFF
--- a/Content.Client/Weather/WeatherSystem.cs
+++ b/Content.Client/Weather/WeatherSystem.cs
@@ -44,7 +44,8 @@ public sealed class WeatherSystem : SharedWeatherSystem
             return;
         }
 
-        if (!Timing.IsFirstTimePredicted || weatherProto.Sound == null)
+        if (!Timing.IsFirstTimePredicted || weatherProto.Sound == null
+            || weather.Stream is not null) // Don't ever generate more than one weather sound.
             return;
 
         var playStream = _audio.PlayGlobal(weatherProto.Sound, Filter.Local(), true);


### PR DESCRIPTION
# Description

Pretty simple fix, just tell the weather system "If there's already a weather sound playing, stop.". I have infact tested this, and verified that this fix does work.

Fixes https://github.com/Simple-Station/Einstein-Engines/issues/1285

# Changelog

:cl:
- fix: Fixed a crash caused by Weather System creating millions of sounds.
