### PR TITLE
Add Pockets and Tail-Drag to Admin Ghosts

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -27,6 +27,7 @@
   - type: Hands
   - type: ComplexInteraction
   - type: Puller
+    needsHands: false # Tail Drag
     pushAcceleration: 1000000 # Will still be capped in max speed
     maxPushRange: 20
   - type: CombatMode

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -19,6 +19,48 @@
       strippingWindowPos: 2,3
       displayName: ID
 
+    # For Pockets to hold stuffs.
+    - name: pocket1
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 0,3
+      strippingWindowPos: 0,4
+      displayName: Pocket 1
+      stripHidden: true
+    - name: pocket2
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 2,3
+      strippingWindowPos: 1,4
+      displayName: Pocket 2
+      stripHidden: true
+    - name: pocket3
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 4,3
+      strippingWindowPos: 2,4
+      displayName: Pocket 3
+      stripHidden: true
+    - name: pocket4
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 6,3
+      strippingWindowPos: 3,4
+      displayName: Pocket 4
+      stripHidden: true
+
     # For drip reasons.
     - name: head
       slotTexture: head


### PR DESCRIPTION
# Description
Adds 4 pockets to the Admin Ghosts and the ability to Tail-Drag (no hands needed).

---

# Media
https://github.com/user-attachments/assets/701b66bd-c42c-429f-a33a-f8e465ef068d

---

# Changelog
:cl:
ADMIN:
- add: Added pockets to Admin Ghosts.
- add: Added tail-drag (no-hands) to Admin Ghosts.
