### PR TITLE
Default Disable Traits Anticheat 

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -445,7 +445,7 @@ namespace Content.Shared.CCVar
         ///     If you are intending to decrease the trait points availability, or modify the costs of traits, consider temporarily disabling this.
         /// </summary>
         public static readonly CVarDef<bool> TraitsPunishCheaters =
-            CVarDef.Create("game.traits_punish_cheaters", true, CVar.REPLICATED);
+            CVarDef.Create("game.traits_punish_cheaters", false, CVar.REPLICATED);
 
         /// <summary>
         ///     Whether to allow characters to select loadout items.


### PR DESCRIPTION
# Description

The Traitsystem anticheat is apparently really good at yeeting players who join as a different job than the one they selected for their traits menu. A better solution would be to rework the latejoin system so that it simply prevents you from joining as any job that would have an invalid trait total(Trait points after all *valid* traits are applied being a negative number is the key here). However since doing that would require me spend 10 hours thoroughly reading a >1000 line function which has so many indentations that parts of it don't even fit on my 17" monitor, I'm electing to disable the system pending a rework.

# Changelog

No changelog because we shouldn't be openly telling the players they can just cheat the traits menu lmao.
