### PR TITLE
Fix Energy Swords

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -21,6 +21,7 @@
   - type: ItemToggleHot
   - type: ItemToggleSize
     activatedSize: Huge
+  - type: ItemTogglePointLight
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
       path: /Audio/Weapons/eblade1.ogg
@@ -69,7 +70,7 @@
   - type: EmbedPassiveDamage
   - type: Item
     size: Small
-    sprite: DeltaV/Objects/Weapons/Melee/e_sword.rsi # Delta-V
+    sprite: Objects/Weapons/Melee/e_sword-inhands.rsi
   - type: UseDelay
     delay: 1.0
   - type: PointLight
@@ -183,8 +184,6 @@
     damage:
       types:
         Blunt: 0
-  - type: ThrowingAngle
-    angle: 315
   - type: Item
     size: Tiny
     sprite: Objects/Weapons/Melee/e_dagger.rsi


### PR DESCRIPTION
# Description

Energy swords were missing a component. Also E-Daggers were causing a debug assert so I've fixed that too.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/7bc4076d-7eea-4a75-96f8-b3e23d1c31f3)

![image](https://github.com/user-attachments/assets/80e22650-3435-455c-bb87-ce77dcf02fc0)

</p>
</details>

# Changelog

:cl:
- fix: Fixed Energy Swords not displaying their blade when ignited.
