### PR TITLE
Nerf Salvage

### DIFF
--- a/Resources/Locale/en-US/weapons/extenddescriptions/descriptions.ftl
+++ b/Resources/Locale/en-US/weapons/extenddescriptions/descriptions.ftl
@@ -1,0 +1,1 @@
+gun-legality-salvage = This weapon is licensed for use in planetary expeditions. It is unlawful to brandish this weapon aboard NanoTrasen stations, and may be confiscated by Security if removed from the station's Salvage Department.

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -15,8 +15,6 @@
       - id: RadioHandheld
       - id: FlashlightSeclite
       - id: Pickaxe
-      - id: SeismicCharge
-        amount: 2
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag
@@ -45,8 +43,6 @@
       - id: RadioHandheld
       - id: FlashlightSeclite
       - id: Pickaxe
-      - id: SeismicCharge
-        amount: 2
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -11,7 +11,7 @@
   - id: Soap
     cost: 200
   - id: SeismicCharge
-    cost: 250
+    cost: 1500
   - id: WeaponGrapplingGun
     cost: 300
   # TODO: laser pointer 300, toy facehugger 300
@@ -40,17 +40,17 @@
     cost: 1000
   # TODO: lazarus injector for 1k
   - id: WeaponSniperMosinEmpty
-    cost: 750 # Literally the worst gun in the game.
+    cost: 1500
   - id: WeaponRevolverArgentiEmpty
-    cost: 1100
+    cost: 4400
   - id: WeaponRifleNovaliteC1Empty
-    cost: 1300
+    cost: 5200
   - id: ClothingBackpackDuffelSalvageConscription
     cost: 1500
   - id: WeaponRifleGestioEmpty
-    cost: 1600
+    cost: 6400
   - id: WeaponRifleSVTEmpty
-    cost: 1600
+    cost: 6400
   - id: SpaceCash1000
     cost: 2000
   # TODO: super resonator for 2500

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -11,5 +11,11 @@
     - state: animation-icon
       visible: false
       map: [ "empty-icon" ]
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false
   # todo: add itemcomponent with inhandVisuals states using unused texture and animation assets in kinetic_accelerator.rsi
   # todo: add clothingcomponent with clothingVisuals states using unused texture and animations assets in kinetic_accelerator.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -119,6 +119,12 @@
   components:
   - type: BallisticAmmoProvider
     proto: null
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false
 
 - type: entity
   name: Hristov

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -38,8 +38,15 @@
 - type: entity
   parent: WeaponRevolverArgenti
   id: WeaponRevolverArgentiEmpty
+  suffix: Empty
   components:
   - type: RevolverAmmoProvider
     capacity: 8
     chambers: [ False, False, False, False, False, False, False, False ]
     ammoSlots: [ null, null, null, null, null, null, null, null ]
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -15,7 +15,7 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/gestio.rsi
   - type: Gun
-    fireRate: 3.75
+    fireRate: 1.5
     projectileSpeed: 30
     angleDecay: 4 #in testing 3 was more balanced
     angleIncrease: 6
@@ -93,6 +93,7 @@
     slots:
       gun_magazine:
         name: Magazine
+        startingItem: null
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -101,6 +102,7 @@
             - MagazineLightRifle
       gun_chamber:
         name: Chamber
+        startingItem: null
         priority: 1
         whitelist:
           tags:
@@ -122,7 +124,7 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/novalitec1.rsi
   - type: Gun
-    fireRate: 4
+    fireRate: 2
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
@@ -189,6 +191,7 @@
     slots:
       gun_magazine:
         name: Magazine
+        startingItem: null
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -197,6 +200,7 @@
             - MagazineNovaliteC1
       gun_chamber:
         name: Chamber
+        startingItem: null
         priority: 1
         whitelist:
           tags:
@@ -223,7 +227,7 @@
     - Back
     - suitStorage
   - type: Gun
-    fireRate: 4
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
@@ -267,6 +271,7 @@
     slots:
       gun_magazine:
         name: Magazine
+        startingItem: null
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -275,6 +280,7 @@
             - MagazineLightRifle
       gun_chamber:
         name: Chamber
+        startingItem: null
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -88,6 +88,7 @@
 - type: entity
   parent: WeaponRifleGestio
   id: WeaponRifleGestioEmpty
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:
@@ -107,6 +108,12 @@
         whitelist:
           tags:
             - CartridgeLightRifle
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false
 
 - type: entity
   parent: BaseWeaponRifle
@@ -186,6 +193,7 @@
 - type: entity
   parent: WeaponRifleNovaliteC1
   id: WeaponRifleNovaliteC1Empty
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:
@@ -205,6 +213,12 @@
         whitelist:
           tags:
             - CartridgeRifle
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false
 
 - type: entity
   id: WeaponRifleSVT
@@ -266,6 +280,7 @@
 - type: entity
   parent: WeaponRifleSVT
   id: WeaponRifleSVTEmpty
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:
@@ -285,3 +300,9 @@
         whitelist:
           tags:
             - CartridgeLightRifle
+  - type: ExtendDescription
+    descriptionList:
+      - description: "gun-legality-salvage"
+        fontSize: 12
+        color: "#ff4f00"
+        requireDetailRange: false


### PR DESCRIPTION
# Description

I may have been a little *too* generous with Salvage players. This update fixes the salvage guns spawning with a magazine or lethal ammo. There was also an issue that they were perhaps "Too easy to obtain". In actual practice, it turns out that a single "Mining Expedition" earns salvage enough mining points to buy like 4 rifles. Which led to situations where Salvage functionally became station security after they then broke into the armory to print ammo. 

Another issue I discovered is that Salvage can also use their breaching charges to blow open security crates(And also blow open the armory......). So now they don't spawn with bombs in their lockers, and need to pay for them with said mining points. 


<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/a5d3fba3-33b3-4f65-ab69-ee6d0f617633)

</p>
</details>


# Changelog


:cl:
- add: Added a legality notice to the description of salvage's firearms. 
- tweak: The mining points cost of all salvage firearms have been increased by 4x
- remove: Salvage no longer starts with bombs in their lockers. Buy them with your mining points.
