### PR TITLE
Make Loadout Firearms Comply With Space Law

### DIFF
--- a/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
@@ -25,8 +25,8 @@ public sealed partial class CharacterAgeRequirement : CharacterRequirement
     [DataField(required: true)]
     public int Min;
 
-    [DataField(required: true)]
-    public int Max;
+    [DataField]
+    public int Max = 2147483647;
 
     public override bool IsValid(
         JobPrototype job,

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -166,6 +166,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Captain
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponAntiqueLaser
 
@@ -180,6 +182,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Captain
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPulsePistolCaptain
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -20,6 +20,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPulsePistolHoS
 
@@ -34,6 +36,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponSubMachineGunWt550HoS
 
@@ -62,6 +66,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponSubMachineGunC20rHoS
 
@@ -76,6 +82,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponShotgunBulldogHoS
 
@@ -104,6 +112,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - HeadOfSecurity
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponEnergyGunMultiphase
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
@@ -130,6 +130,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazinePistol
 
@@ -146,6 +148,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazinePistol
 
@@ -159,6 +163,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazinePistolRubber
 
@@ -172,6 +178,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazinePistolRubber
 
@@ -189,6 +197,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderMagnum
 
@@ -206,6 +216,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderMagnum
 
@@ -220,6 +232,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderMagnumRubber
 
@@ -234,6 +248,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderMagnumRubber
 
@@ -251,6 +267,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineMagnum
 
@@ -268,6 +286,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineMagnumRubber
 
@@ -285,6 +305,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineMagnum
 
@@ -302,6 +324,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineMagnumRubber
 
@@ -319,6 +343,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderRifleHeavy
 
@@ -336,6 +362,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderRifleHeavy
 
@@ -350,6 +378,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderRifleHeavyRubber
 
@@ -364,6 +394,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - SpeedLoaderRifleHeavyRubber
 
@@ -401,6 +433,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolMk58Security
 
@@ -416,6 +450,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolMk58SecurityNonlethal
 
@@ -434,6 +470,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverInspectorSecurity
 
@@ -449,6 +487,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverInspectorNonLethalSecurity
 
@@ -467,6 +507,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverDeckardSecurity
 
@@ -482,6 +524,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverDeckardNonLethalSecurity
 
@@ -500,6 +544,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolN1984Security
 
@@ -515,6 +561,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolN1984SecurityNonLethal
 
@@ -533,6 +581,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolViperSecurity
 
@@ -548,6 +598,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolViperSecurityNonLethal
 
@@ -566,6 +618,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolViperWoodSecurity
 
@@ -605,6 +659,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponLaserSvalinn
 
@@ -623,6 +679,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponEnergyGunMiniSecurity
 
@@ -641,6 +699,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponEnergyGunPistolSecurity
 
@@ -659,6 +719,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolPollockSecurity
 
@@ -674,6 +736,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponPistolPollockNonlethalSecurity
 
@@ -692,6 +756,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverSnubSecurity
 
@@ -707,6 +773,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverSnubNonlethalSecurity
 
@@ -725,6 +793,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverK38MasterSecurity
 
@@ -740,6 +810,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverK38MasterNonlethalSecurity
 
@@ -758,6 +830,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverFitzSecurity
 
@@ -773,6 +847,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverFitzNonlethalSecurity
 
@@ -791,6 +867,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverPythonSecurity
 
@@ -806,6 +884,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverPythonNonlethalSecurity
 
@@ -824,6 +904,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverArgentiSecurity
 
@@ -839,6 +921,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverArgentiNonLethalSecurity
 

--- a/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
@@ -17,6 +17,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - BoxBeanbag
 
@@ -31,6 +33,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineBoxLightRifleRubber
 
@@ -45,6 +49,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponShotgunDoubleBarreledRubber
 
@@ -59,6 +65,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponSniperMosinRubber
 


### PR DESCRIPTION
# Description

Just because I can. I've added requirements to every firearm available in Loadouts, and added a minimum character age requirement to them in order to make them consistent with Space Law(Biesel Republic Law). 

# Changelog

:cl:
- add: In order to comply with Biesel Republic laws governing firearm ownership, all firearms now require that a person be 21 years of age or older to purchase.