### PR TITLE
Maybe Fix Antag Related Crash

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -478,14 +478,17 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
 
         var antags = AntagPreferences
             .Where(id => prototypeManager.TryIndex<AntagPrototype>(id, out var antag) && antag.SetPreference)
+            .Distinct()
             .ToList();
 
         var traits = TraitPreferences
             .Where(prototypeManager.HasIndex<TraitPrototype>)
+            .Distinct()
             .ToList();
 
         var loadouts = LoadoutPreferences
             .Where(l => prototypeManager.HasIndex<LoadoutPrototype>(l.LoadoutName))
+            .Distinct()
             .ToList();
 
         Name = name;


### PR DESCRIPTION
# Description

I'm trying to fix a crash caused by character profiles saving the same antag preference twice. I have no clue why or how it's happening, but this should probably prevent it from happening by making the profile sanitizer remove duplicate keys before saving them to the database.

The relevant crash log: 
[goobcrash.txt](https://github.com/user-attachments/files/18391763/goobcrash.txt)

# Changelog

:cl:
- fix: Attempted to fix a crash related to antag preferences saving multiple times.
