### PR TITLE
AddTraitSpecial

### DIFF
--- a/Content.Server/Jobs/AddTraitSpecial.cs
+++ b/Content.Server/Jobs/AddTraitSpecial.cs
@@ -4,35 +4,27 @@ using Content.Shared.Traits;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Jobs
+namespace Content.Server.Jobs;
+
+
+[UsedImplicitly]
+public sealed partial class AddTraitSpecial : JobSpecial
 {
-    [UsedImplicitly]
-    public sealed partial class AddTraitSpecial : JobSpecial
+    // Datafield for storing multiple trait prototype IDs as strings
+    [DataField(required: true)]
+    public HashSet<string> Traits { get; private set; } = new();
+
+    public override void AfterEquip(EntityUid mob)
     {
-        // Datafield for storing multiple trait prototype IDs as strings
-        [DataField("traits")]
-        public HashSet<string> Traits { get; private set; } = new();
+        // Resolve the necessary systems
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+        var traitSystem = entityManager.System<TraitSystem>();
 
-        public override void AfterEquip(EntityUid mob)
-        {
-            if (Traits == null || Traits.Count == 0)
-                throw new InvalidOperationException("No traits are set.");
-
-            // Resolve the necessary systems
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            var traitSystem = entityManager.System<TraitSystem>();
-
-            // Iterate through each trait and add it to the entity
-            foreach (var traitId in Traits)
-            {
-                if (!prototypeManager.TryIndex(traitId, out TraitPrototype? traitPrototype))
-                {
-                    throw new InvalidOperationException($"Trait prototype '{traitId}' could not be found.");
-                }
+        // Iterate through each trait and add it to the entity
+        foreach (var traitId in Traits)
+            if (prototypeManager.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
 
                 traitSystem.AddTrait(mob, traitPrototype);
-            }
-        }
     }
 }

--- a/Content.Server/Jobs/AddTraitSpecial.cs
+++ b/Content.Server/Jobs/AddTraitSpecial.cs
@@ -1,0 +1,38 @@
+using Content.Server.Traits;
+using Content.Shared.Roles;
+using Content.Shared.Traits;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Jobs
+{
+    [UsedImplicitly]
+    public sealed partial class AddTraitSpecial : JobSpecial
+    {
+        // Datafield for storing multiple trait prototype IDs as strings
+        [DataField("traits")]
+        public HashSet<string> Traits { get; private set; } = new();
+
+        public override void AfterEquip(EntityUid mob)
+        {
+            if (Traits == null || Traits.Count == 0)
+                throw new InvalidOperationException("No traits are set.");
+
+            // Resolve the necessary systems
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+            var traitSystem = entityManager.System<TraitSystem>();
+
+            // Iterate through each trait and add it to the entity
+            foreach (var traitId in Traits)
+            {
+                if (!prototypeManager.TryIndex(traitId, out TraitPrototype? traitPrototype))
+                {
+                    throw new InvalidOperationException($"Trait prototype '{traitId}' could not be found.");
+                }
+
+                traitSystem.AddTrait(mob, traitPrototype);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a way to specify traits in the jobs special area.

Hashset so you can specify multiple traits. Tested on Nuclear14 to give the tribals a specific language in a friendly way.
```
  special:
  - !type:AddTraitSpecial
    traits: [ LanguageTribal, LanguageChinese ]
```