### PR TITLE
Shadowkin Nerf....

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -361,16 +361,16 @@
 - type: damageModifierSet
   id: Shadowkin
   coefficients:
-    Blunt: 0.95
-    Slash: 1.2
-    Piercing: 1.1
+    Blunt: 1.2
+    Slash: 1.3
+    Piercing: 1.2
     Asphyxiation: 0
-    Cold: 0.75
+    Cold: 0.8
     Heat: 1.2
-    Cellular: 0.25
+    Cellular: 0.50
     Bloodloss: 1.35
-    Shock: 1.25
-    Radiation: 1.3
+    Shock: 1.35
+    Radiation: 1.45
 
 - type: damageModifierSet
   id: DermalArmor


### PR DESCRIPTION
# Description

Honestly... much needed until they can get a proper rework from TCJ or someone else. This PR nerfs them a shit ton (no more teleporting away when you're in danger, smh) to make them more in line with the other species so they aren't powergamer central. Additionally, brings them more in-line with the traditional SS13 shadowkin. Shadowkins should no longer get darkswap and such, in fact I've commented out the entire ability until it too can get a rework. 

---

# TODO

- [x] Commented out DarkSwap for shadowkin & for everynoe else
- [x] Made shadowkins much more easy to damage
- [x]  Brought shadowkin much more in line with their SS13 counterparts
- [ ] Fixed shadowkin lore, making the guidebook entry more interesting
- [x] Shadowkin can be chosen as a player species roundstart
- [ ] Make DarkSwap unable to interact with the world as a whole
- [ ] Give DarkSwap a longer cooldown
- [ ] Make DarkSwap unable to be used if stunned
- [ ] Adjust DarkSwap glimmer production
- [ ] Shadowkin do not have black eyes by default
- [ ] Shadowkin have the black eyes trait listed (Waveform Misalignment equivalent)
- [ ] Shadowkin are affected by glimmer (all negative affects from high glimmer are doubled)

---

# Changelog

:cl:
- add: Shadowkins can now be roundstart species again
- tweak: Shadowkins are now more easy to damage
- tweak Shadowkins are much more like their SS13 counterparters
- remove: Removed DarkSwap as an ability as a whole.