### PR TITLE
Space Wind Version 3

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -19,7 +19,6 @@ namespace Content.Server.Atmos.EntitySystems
         public bool MonstermosDepressurization { get; private set; }
         public bool MonstermosRipTiles { get; private set; }
         public float MonstermosRipTilesMinimumPressure { get; private set; }
-        public float MonstermosRipTilesPressureOffset { get; private set; }
         public bool GridImpulse { get; private set; }
         public float SpacingEscapeRatio { get; private set; }
         public float SpacingMinGas { get; private set; }
@@ -54,7 +53,6 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.MonstermosDepressurization, value => MonstermosDepressurization = value, true);
             Subs.CVar(_cfg, CCVars.MonstermosRipTiles, value => MonstermosRipTiles = value, true);
             Subs.CVar(_cfg, CCVars.MonstermosRipTilesMinimumPressure, value => MonstermosRipTilesMinimumPressure = value, true);
-            Subs.CVar(_cfg, CCVars.MonstermosRipTilesPressureOffset, value => MonstermosRipTilesPressureOffset = value, true);
             Subs.CVar(_cfg, CCVars.AtmosGridImpulse, value => GridImpulse = value, true);
             Subs.CVar(_cfg, CCVars.AtmosSpacingEscapeRatio, value => SpacingEscapeRatio = value, true);
             Subs.CVar(_cfg, CCVars.AtmosSpacingMinGas, value => SpacingMinGas = value, true);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -1,233 +1,188 @@
 using Content.Server.Atmos.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
+using Content.Shared.CCVar;
 using Content.Shared.Humanoid;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
-using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using System.Numerics;
 
-namespace Content.Server.Atmos.EntitySystems
+namespace Content.Server.Atmos.EntitySystems;
+
+public sealed partial class AtmosphereSystem
 {
-    public sealed partial class AtmosphereSystem
+    private const int SpaceWindSoundCooldownCycles = 75;
+
+    private int _spaceWindSoundCooldown = 0;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public string? SpaceWindSound { get; private set; } = "/Audio/Effects/space_wind.ogg";
+
+    private readonly HashSet<Entity<MovedByPressureComponent>> _activePressures = new(8);
+
+    private void UpdateHighPressure(float frameTime)
     {
-        private const int SpaceWindSoundCooldownCycles = 75;
+        var toRemove = new RemQueue<Entity<MovedByPressureComponent>>();
 
-        private int _spaceWindSoundCooldown = 0;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public string? SpaceWindSound { get; private set; } = "/Audio/Effects/space_wind.ogg";
-
-        private readonly HashSet<Entity<MovedByPressureComponent>> _activePressures = new(8);
-
-        private void UpdateHighPressure(float frameTime)
+        foreach (var ent in _activePressures)
         {
-            var toRemove = new RemQueue<Entity<MovedByPressureComponent>>();
+            var (uid, comp) = ent;
+            MetaDataComponent? metadata = null;
 
-            foreach (var ent in _activePressures)
+            if (Deleted(uid, metadata))
             {
-                var (uid, comp) = ent;
-                MetaDataComponent? metadata = null;
-
-                if (Deleted(uid, metadata))
-                {
-                    toRemove.Add((uid, comp));
-                    continue;
-                }
-
-                if (Paused(uid, metadata))
-                    continue;
-
-                comp.Accumulator += frameTime;
-
-                if (comp.Accumulator < 2f)
-                    continue;
-
-                // Reset it just for VV reasons even though it doesn't matter
-                comp.Accumulator = 0f;
-                toRemove.Add(ent);
-
-                if (TryComp<PhysicsComponent>(uid, out var body))
-                {
-                    _physics.SetBodyStatus(uid, body, BodyStatus.OnGround);
-                }
-
-                if (TryComp<FixturesComponent>(uid, out var fixtures))
-                {
-                    foreach (var (id, fixture) in fixtures.Fixtures)
-                    {
-                        _physics.AddCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, manager: fixtures);
-                    }
-                }
+                toRemove.Add((uid, comp));
+                continue;
             }
 
-            foreach (var comp in toRemove)
+            if (Paused(uid, metadata))
+                continue;
+
+            comp.Accumulator += frameTime;
+
+            if (comp.Accumulator < 2f)
+                continue;
+
+            // Reset it just for VV reasons even though it doesn't matter
+            comp.Accumulator = 0f;
+            toRemove.Add(ent);
+
+            if (TryComp<PhysicsComponent>(uid, out var body))
             {
-                _activePressures.Remove(comp);
+                _physics.SetBodyStatus(uid, body, BodyStatus.OnGround);
             }
-        }
 
-        private void HighPressureMovements(Entity<GridAtmosphereComponent> gridAtmosphere, TileAtmosphere tile, EntityQuery<PhysicsComponent> bodies, EntityQuery<TransformComponent> xforms, EntityQuery<MovedByPressureComponent> pressureQuery, EntityQuery<MetaDataComponent> metas)
-        {
-            if (tile.PressureDifference < SpaceWindMinimumCalculatedMass * SpaceWindMinimumCalculatedMass)
-                return;
-            // TODO ATMOS finish this
-
-            // Don't play the space wind sound on tiles that are on fire...
-            if (tile.PressureDifference > 15 && !tile.Hotspot.Valid)
+            if (TryComp<FixturesComponent>(uid, out var fixtures))
             {
-                if (_spaceWindSoundCooldown == 0 && !string.IsNullOrEmpty(SpaceWindSound))
+                foreach (var (id, fixture) in fixtures.Fixtures)
                 {
-                    var coordinates = _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.GridIndices);
-                    _audio.PlayPvs(SpaceWindSound, coordinates, AudioParams.Default.WithVariation(0.125f).WithVolume(MathHelper.Clamp(tile.PressureDifference / 10, 10, 100)));
-                }
-            }
-
-
-            if (tile.PressureDifference > 100)
-            {
-                // TODO ATMOS Do space wind graphics here!
-            }
-
-            if (_spaceWindSoundCooldown++ > SpaceWindSoundCooldownCycles)
-                _spaceWindSoundCooldown = 0;
-
-            // No atmos yeets, return early.
-            if (!SpaceWind)
-                return;
-
-            // Used by ExperiencePressureDifference to correct push/throw directions from tile-relative to physics world.
-            var gridWorldRotation = xforms.GetComponent(gridAtmosphere).WorldRotation;
-
-            // If we're using monstermos, smooth out the yeet direction to follow the flow
-            //TODO This is bad, don't run this. It just makes the throws worse by somehow rounding them to orthogonal
-            if (!MonstermosEqualization)
-            {
-                // We step through tiles according to the pressure direction on the current tile.
-                // The goal is to get a general direction of the airflow in the area.
-                // 3 is the magic number - enough to go around corners, but not U-turns.
-                var curTile = tile;
-                for (var i = 0; i < 3; i++)
-                {
-                    if (curTile.PressureDirection == AtmosDirection.Invalid
-                        || !curTile.AdjacentBits.IsFlagSet(curTile.PressureDirection))
-                        break;
-                    curTile = curTile.AdjacentTiles[curTile.PressureDirection.ToIndex()]!;
-                }
-
-                if (curTile != tile)
-                    tile.PressureSpecificTarget = curTile;
-            }
-
-            _entSet.Clear();
-            _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f);
-
-            foreach (var entity in _entSet)
-            {
-                // Ideally containers would have their own EntityQuery internally or something given recursively it may need to slam GetComp<T> anyway.
-                // Also, don't care about static bodies (but also due to collisionwakestate can't query dynamic directly atm).
-                if (!bodies.TryGetComponent(entity, out var body) ||
-                    !pressureQuery.TryGetComponent(entity, out var pressure) ||
-                    !pressure.Enabled)
-                    continue;
-
-                if (_containers.IsEntityInContainer(entity, metas.GetComponent(entity))) continue;
-
-                var pressureMovements = EnsureComp<MovedByPressureComponent>(entity);
-                if (pressure.LastHighPressureMovementAirCycle < gridAtmosphere.Comp.UpdateCounter)
-                {
-                    // tl;dr YEET
-                    ExperiencePressureDifference(
-                        (entity, pressureMovements),
-                        gridAtmosphere.Comp.UpdateCounter,
-                        tile.PressureDifference,
-                        tile.PressureDirection,
-                        tile.PressureSpecificTarget != null ? _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.PressureSpecificTarget.GridIndices) : EntityCoordinates.Invalid,
-                        gridWorldRotation,
-                        xforms.GetComponent(entity),
-                        body);
+                    _physics.AddCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, manager: fixtures);
                 }
             }
         }
 
-        // Called from AtmosphereSystem.LINDA.cs with SpaceWind CVar check handled there.
-        private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection differenceDirection, float difference)
+        foreach (var comp in toRemove)
         {
-            gridAtmosphere.HighPressureDelta.Add(tile);
-
-            if (difference <= tile.PressureDifference)
-                return;
-
-            tile.PressureDifference = difference;
-            tile.PressureDirection = differenceDirection;
+            _activePressures.Remove(comp);
         }
+    }
 
-        //INFO The EE version of this function drops pressureResistanceProbDelta, since it's not needed. If you are for whatever reason calling this function
-        //INFO And if it isn't working, you've probably still got the pressureResistanceProbDelta line included.
-        /// <notes>
-        /// EXPLANATION:
-        /// pressureDifference = Force of Air Flow on a given tile
-        /// physics.Mass = Mass of the object potentially being thrown
-        /// physics.InvMass = 1 divided by said Mass. More CPU efficient way to do division.
-        ///
-        /// Objects can only be thrown if the force of air flow is greater than the SQUARE of their mass or {SpaceWindMinimumCalculatedMass}, whichever is heavier
-        /// This means that the heavier an object is, the exponentially more force is required to move it
-        /// The force of a throw is equal to the force of air pressure, divided by an object's mass. So not only are heavier objects
-        /// less likely to be thrown, they are also harder to throw,
-        /// while lighter objects are yeeted easily, and from great distance.
-        ///
-        /// For a human sized entity with a standard weight of 80kg and a spacing between a hard vacuum and a room pressurized at 101kpa,
-        /// The human shall only be moved if he is either very close to the hole, or is standing in a region of high airflow
-        /// </notes>
+    private void HighPressureMovements(Entity<GridAtmosphereComponent> gridAtmosphere, TileAtmosphere tile, EntityQuery<PhysicsComponent> bodies, EntityQuery<TransformComponent> xforms, EntityQuery<MovedByPressureComponent> pressureQuery, EntityQuery<MetaDataComponent> metas, float frameTime)
+    {
+        // No atmos yeets, return early.
+        if (!SpaceWind)
+            return;
 
-        public void ExperiencePressureDifference(
-            Entity<MovedByPressureComponent> ent,
-            int cycle,
-            float pressureDifference,
-            AtmosDirection direction,
-            EntityCoordinates throwTarget,
-            Angle gridWorldRotation,
-            TransformComponent? xform = null,
-            PhysicsComponent? physics = null)
+        // Previously, we were comparing against the square of the target mass. Now we are comparing smaller values over a variable length of time. TLDR: Smoother space wind
+        var differentiatedPressure = 2 * tile.PressureDifference * frameTime * _cfg.GetCVar(CCVars.SpaceWindStrengthMultiplier);
+        if (differentiatedPressure < SpaceWindMinimumCalculatedMass)
+            return;
+        // TODO ATMOS finish this
+
+        // Don't play the space wind sound on tiles that are on fire...
+        if (tile.PressureDifference > 15 && !tile.Hotspot.Valid)
         {
-            var (uid, component) = ent;
-            if (!Resolve(uid, ref physics, false))
-                return;
-
-            if (!Resolve(uid, ref xform))
-                return;
-
-
-            if (physics.BodyType != BodyType.Static
-                && !float.IsPositiveInfinity(component.MoveResist))
+            if (_spaceWindSoundCooldown == 0 && !string.IsNullOrEmpty(SpaceWindSound))
             {
-                var moveForce = pressureDifference * MathF.Max(physics.InvMass, SpaceWindMaximumCalculatedInverseMass);
-                if (HasComp<HumanoidAppearanceComponent>(ent))
-                    moveForce *= HumanoidThrowMultiplier;
-                if (moveForce > physics.Mass)
-                {
-                    // Grid-rotation adjusted direction
-                    var dirVec = (direction.ToAngle() + gridWorldRotation).ToWorldVec();
-                    moveForce *= MathF.Max(physics.InvMass, SpaceWindMaximumCalculatedInverseMass);
-
-                    //TODO Consider replacing throw target with proper trigonometry angles.
-                    if (throwTarget != EntityCoordinates.Invalid)
-                    {
-                        var pos = throwTarget.ToMap(EntityManager, _transformSystem).Position - xform.WorldPosition + dirVec;
-                        _throwing.TryThrow(uid, pos.Normalized() * MathF.Min(moveForce, SpaceWindMaxVelocity), moveForce);
-                    }
-                    else
-                    {
-                        _throwing.TryThrow(uid, dirVec.Normalized() * MathF.Min(moveForce, SpaceWindMaxVelocity), moveForce);
-                    }
-
-                    component.LastHighPressureMovementAirCycle = cycle;
-                }
+                var coordinates = _mapSystem.ToCenterCoordinates(tile.GridIndex, tile.GridIndices);
+                _audio.PlayPvs(SpaceWindSound, coordinates, AudioParams.Default.WithVariation(0.125f).WithVolume(MathHelper.Clamp(tile.PressureDifference / 10, 10, 100)));
             }
         }
+
+
+        if (tile.PressureDifference > 100)
+        {
+            // TODO ATMOS Do space wind graphics here!
+        }
+
+        if (_spaceWindSoundCooldown++ > SpaceWindSoundCooldownCycles)
+            _spaceWindSoundCooldown = 0;
+
+        // Used by ExperiencePressureDifference to correct push/throw directions from tile-relative to physics world.
+        var gridWorldRotation = _transformSystem.GetWorldRotation(gridAtmosphere);
+
+        var throwDirection = tile.PressureDirection.ToAngle().ToVec();
+        // If we're using monstermos, smooth out the yeet direction to follow the flow
+        if (MonstermosEqualization
+            && tile.PressureDirection != AtmosDirection.Invalid
+            && tile.AdjacentBits.IsFlagSet(tile.PressureDirection))
+        {
+            var nextTileDirection = tile.AdjacentTiles[tile.PressureDirection.ToIndex()]!.PressureDirection;
+            if (nextTileDirection != AtmosDirection.Invalid
+                && nextTileDirection != tile.PressureDirection)
+            {
+                throwDirection = (throwDirection + nextTileDirection.ToAngle().ToVec()) / 2;
+                differentiatedPressure += tile.AdjacentTiles[tile.PressureDirection.ToIndex()]!.PressureDifference * frameTime;
+            }
+        }
+
+        _entSet.Clear();
+        _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f);
+
+        foreach (var entity in _entSet)
+        {
+            // Ideally containers would have their own EntityQuery internally or something given recursively it may need to slam GetComp<T> anyway.
+            // Also, don't care about static bodies (but also due to collisionwakestate can't query dynamic directly atm).
+            if (!bodies.TryGetComponent(entity, out var body)
+                || !pressureQuery.TryGetComponent(entity, out var pressure)
+                || !pressure.Enabled
+                || _containers.IsEntityInContainer(entity, metas.GetComponent(entity))
+                || pressure.LastHighPressureMovementAirCycle >= gridAtmosphere.Comp.UpdateCounter)
+                continue;
+
+            // tl;dr YEET
+            ExperiencePressureDifference(
+                (entity, EnsureComp<MovedByPressureComponent>(entity)),
+                gridAtmosphere.Comp.UpdateCounter,
+                differentiatedPressure,
+                throwDirection,
+                gridWorldRotation,
+                xforms.GetComponent(entity),
+                body);
+        }
+    }
+
+    // Called from AtmosphereSystem.LINDA.cs with SpaceWind CVar check handled there.
+    private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection differenceDirection, float difference)
+    {
+        gridAtmosphere.HighPressureDelta.Add(tile);
+
+        if (difference <= tile.PressureDifference)
+            return;
+
+        tile.PressureDifference = difference;
+        tile.PressureDirection = differenceDirection;
+    }
+
+    public void ExperiencePressureDifference(
+        Entity<MovedByPressureComponent> ent,
+        int cycle,
+        float pressureDifference,
+        Vector2 direction,
+        Angle gridWorldRotation,
+        TransformComponent? xform = null,
+        PhysicsComponent? physics = null)
+    {
+        var (uid, component) = ent;
+        if (!Resolve(uid, ref physics, false)
+            || !Resolve(uid, ref xform)
+            || physics.BodyType == BodyType.Static
+            || float.IsPositiveInfinity(component.MoveResist))
+            return;
+
+        if (HasComp<HumanoidAppearanceComponent>(ent))
+            pressureDifference *= HumanoidThrowMultiplier;
+        if (pressureDifference < physics.Mass)
+            return;
+
+        // Grid-rotation adjusted direction
+        var dirVec = (direction.ToAngle() + gridWorldRotation).ToWorldVec();
+        pressureDifference *= MathF.Max(physics.InvMass, SpaceWindMaximumCalculatedInverseMass);
+
+        _throwing.TryThrow(uid, dirVec.Normalized() * MathF.Min(pressureDifference, SpaceWindMaxVelocity), pressureDifference);
+        component.LastHighPressureMovementAirCycle = cycle;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -114,7 +114,7 @@ public sealed partial class AtmosphereSystem
             if (nextTileDirection != AtmosDirection.Invalid
                 && nextTileDirection != tile.PressureDirection)
             {
-                throwDirection = (throwDirection + nextTileDirection.ToAngle().ToVec()) / 2;
+                throwDirection = throwDirection + nextTileDirection.ToAngle().ToVec();
                 differentiatedPressure += tile.AdjacentTiles[tile.PressureDirection.ToIndex()]!.PressureDifference * frameTime;
             }
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -685,14 +685,14 @@ namespace Content.Server.Atmos.EntitySystems
             adj.MonstermosInfo[idx.ToOppositeDir()] -= amount;
         }
 
-        private void HandleDecompressionFloorRip(MapGridComponent mapGrid, TileAtmosphere tile, float delta)
+        private void HandleDecompressionFloorRip(MapGridComponent mapGrid, TileAtmosphere tile, float sum)
         {
-            if (!mapGrid.TryGetTileRef(tile.GridIndices, out var tileRef))
+            if (!MonstermosRipTiles)
                 return;
-            var tileref = tileRef.Tile;
 
-            var tileDef = (ContentTileDefinition) _tileDefinitionManager[tileref.TypeId];
-            if (!tileDef.Reinforced && tileDef.TileRipResistance < delta * MonstermosRipTilesPressureOffset)
+            var chance = MathHelper.Clamp(0.01f + sum / SpacingMaxWind * 0.3f, 0.003f, 0.3f);
+
+            if (sum > 20 && _robustRandom.Prob(chance))
                 PryTile(mapGrid, tile.GridIndices);
         }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -381,7 +381,7 @@ namespace Content.Server.Atmos.EntitySystems
             return true;
         }
 
-        private bool ProcessHighPressureDelta(Entity<GridAtmosphereComponent> ent)
+        private bool ProcessHighPressureDelta(Entity<GridAtmosphereComponent> ent, float frameTime)
         {
             var atmosphere = ent.Comp;
             if (!atmosphere.ProcessingPaused)
@@ -397,7 +397,7 @@ namespace Content.Server.Atmos.EntitySystems
 
             while (atmosphere.CurrentRunTiles.TryDequeue(out var tile))
             {
-                HighPressureMovements(ent, tile, bodies, xforms, pressureQuery, metas);
+                HighPressureMovements(ent, tile, bodies, xforms, pressureQuery, metas, frameTime);
                 tile.PressureDifference = 0f;
                 tile.LastPressureDirection = tile.PressureDirection;
                 tile.PressureDirection = AtmosDirection.Invalid;
@@ -647,7 +647,7 @@ namespace Content.Server.Atmos.EntitySystems
                         atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
                         continue;
                     case AtmosphereProcessingState.HighPressureDelta:
-                        if (!ProcessHighPressureDelta((ent, ent)))
+                        if (!ProcessHighPressureDelta((ent, ent), frameTime))
                         {
                             atmosphere.ProcessingPaused = true;
                             return;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1361,6 +1361,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> SpaceWind =
             CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
 
+        public static readonly CVarDef<float> SpaceWindStrengthMultiplier =
+            CVarDef.Create("atmos.space_wind_strength_multiplier", 1f, CVar.SERVERONLY);
+
         /// <summary>
         ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
         /// </summary>
@@ -1396,7 +1399,7 @@ namespace Content.Shared.CCVar
         ///     And maybe do your part to fix that? :)
         /// </remarks>
         public static readonly CVarDef<float> SpaceWindMinimumCalculatedMass =
-            CVarDef.Create("atmos.space_wind_minimum_calculated_mass", 10f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.space_wind_minimum_calculated_mass", 5f, CVar.SERVERONLY);
 
         /// <summary>
         /// 	Calculated as 1/Mass, where Mass is the physics.Mass of the desired threshold.
@@ -1433,14 +1436,7 @@ namespace Content.Shared.CCVar
         ///     This should be set by default to the cube of the game's lowest mass tile as defined in their prototypes, but can be increased for server performance reasons
         /// </summary>
         public static readonly CVarDef<float> MonstermosRipTilesMinimumPressure =
-            CVarDef.Create("atmos.monstermos_rip_tiles_min_pressure", 7500f, CVar.SERVERONLY);
-
-        /// <summary>
-        ///     Taken after the minimum pressure is checked, the effective pressure is multiplied by this amount.
-        ///		This allows server hosts to finely tune how likely floor tiles are to be ripped apart by air pressure
-        /// </summary>
-        public static readonly CVarDef<float> MonstermosRipTilesPressureOffset =
-            CVarDef.Create("atmos.monstermos_rip_tiles_pressure_offset", 0.44f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.monstermos_rip_tiles_min_pressure", 20f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Whether explosive depressurization will cause the grid to gain an impulse.
@@ -1476,7 +1472,7 @@ namespace Content.Shared.CCVar
         /// This solves the problem of objects being trapped in an infinite loop of slamming into a wall repeatedly.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosUseExpensiveAirflow =
-            CVarDef.Create("atmos.mmos_expensive_airflow", true, CVar.SERVERONLY);
+            CVarDef.Create("atmos.mmos_expensive_airflow", false, CVar.SERVERONLY);
 
         /// <summary>
         ///     Whether atmos superconduction is enabled.

--- a/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
@@ -90,7 +90,8 @@ namespace Content.Shared.Damage.Systems
 
         private void OnDoHit(EntityUid uid, DamageOtherOnHitComponent component, ThrowDoHitEvent args)
         {
-            if (component.HitQuantity >= component.MaxHitQuantity)
+            if (TerminatingOrDeleted(args.Target)
+                || component.HitQuantity >= component.MaxHitQuantity)
                 return;
 
             var modifiedDamage = _damageable.TryChangeDamage(args.Target, GetDamage(uid, component, args.Component.Thrower),

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -9,6 +9,7 @@
   - type: Item
     sprite: Objects/Tiles/tile.rsi
     size: Normal
+  - type: EmbeddableProjectile
   - type: DamageOtherOnHit
     damage:
       types:

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -15,7 +15,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelCheckerLight
@@ -34,7 +33,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelCheckerLight
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelCheckerDark
@@ -53,7 +51,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteelCheckerDark
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelMini
@@ -72,7 +69,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelPavement
@@ -91,7 +87,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelDiagonal
@@ -110,7 +105,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelOffset
@@ -123,7 +117,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelMono
@@ -142,7 +135,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelPavementVertical
@@ -161,7 +153,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelHerringbone
@@ -180,7 +171,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorSteelDiagonalMini
@@ -199,7 +189,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorBrassFilled
@@ -212,7 +201,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBrassFilled
   heatCapacity: 10000
-  tileRipResistance: 220
 
 - type: tile
   id: FloorBrassReebe
@@ -225,7 +213,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBrassReebe
   heatCapacity: 10000
-  tileRipResistance: 220
 
 - type: tile
   id: FloorPlastic
@@ -244,7 +231,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWood
@@ -265,7 +251,6 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWood
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhite
@@ -284,7 +269,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteMini
@@ -303,7 +287,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePavement
@@ -322,7 +305,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteDiagonal
@@ -341,7 +323,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteOffset
@@ -354,7 +335,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteMono
@@ -373,7 +353,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePavementVertical
@@ -392,7 +371,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteHerringbone
@@ -411,7 +389,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhiteDiagonalMini
@@ -430,7 +407,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorWhitePlastic
@@ -449,7 +425,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorDark
@@ -468,7 +443,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkMini
@@ -487,7 +461,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPavement
@@ -506,7 +479,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkDiagonal
@@ -525,7 +497,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkOffset
@@ -538,7 +509,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkMono
@@ -557,7 +527,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPavementVertical
@@ -576,7 +545,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkHerringbone
@@ -595,7 +563,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkDiagonalMini
@@ -614,7 +581,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorDarkPlastic
@@ -633,7 +599,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemDark
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorTechMaint
@@ -646,7 +611,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemTechmaint
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorReinforced
@@ -672,7 +636,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMono
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorLino
@@ -685,7 +648,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemLino
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorSteelDirty
@@ -698,7 +660,6 @@
     collection: FootstepPlating
   itemDrop: FloorTileItemDirty
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorElevatorShaft
@@ -711,7 +672,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemElevatorShaft
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorMetalDiamond
@@ -724,7 +684,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemMetalDiamond
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorRockVault
@@ -737,7 +696,6 @@
     collection: FootstepAsteroid
   itemDrop: FloorTileItemRockVault
   heatCapacity: 10000
-  tileRipResistance:  400
 
 - type: tile
   id: FloorBlue
@@ -750,7 +708,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemBlue
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorSteelLime
@@ -769,7 +726,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemLime
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorMining
@@ -782,7 +738,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMining
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorMiningDark
@@ -795,7 +750,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMiningDark
   heatCapacity: 10000
-  tileRipResistance: 250
 
 - type: tile
   id: FloorMiningLight
@@ -808,7 +762,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemMiningLight
   heatCapacity: 10000
-  tileRipResistance: 250
 
 # Departamental
 - type: tile
@@ -822,7 +775,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemFreezer
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorShowroom
@@ -835,7 +787,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShowroom
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorHydro
@@ -848,7 +799,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemHydro
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorBar
@@ -867,7 +817,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemBar
   heatCapacity: 10000
-  tileRipResistance: 100
 
 - type: tile
   id: FloorClown
@@ -880,7 +829,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemClown
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorMime
@@ -893,7 +841,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemMime
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorKitchen
@@ -906,7 +853,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemKitchen
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorLaundry
@@ -919,7 +865,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemLaundry
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorSteelDamaged
@@ -939,7 +884,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel #This should probably be made null when it becomes possible to make it such, in SS13 prying destroyed tiles wouldn't give you anything.
   heatCapacity: 10000
-  tileRipResistance: 175
 
 - type: tile
   id: FloorSteelBurnt
@@ -956,8 +900,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemSteel #Same case as FloorSteelDamaged, make it null when possible
   heatCapacity: 10000
-  tileRipResistance: 175
-
 
 # Concrete
 - type: tile
@@ -978,7 +920,6 @@
   itemDrop: FloorTileItemConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorConcreteMono
@@ -998,7 +939,6 @@
   itemDrop: FloorTileItemConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorConcreteSmooth
@@ -1018,7 +958,6 @@
   itemDrop: FloorTileItemConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcrete
@@ -1038,7 +977,6 @@
   itemDrop: FloorTileItemGrayConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcreteMono
@@ -1058,7 +996,6 @@
   itemDrop: FloorTileItemGrayConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorGrayConcreteSmooth
@@ -1078,7 +1015,6 @@
   itemDrop: FloorTileItemGrayConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcrete
@@ -1098,7 +1034,6 @@
   itemDrop: FloorTileItemOldConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcreteMono
@@ -1118,7 +1053,6 @@
   itemDrop: FloorTileItemOldConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 - type: tile
   id: FloorOldConcreteSmooth
@@ -1138,7 +1072,6 @@
   itemDrop: FloorTileItemOldConcrete
   heatCapacity: 10000
   weather: true
-  tileRipResistance: 300
 
 # Carpets (non smoothing)
 - type: tile
@@ -1155,7 +1088,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeBlue
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorArcadeBlue2
@@ -1171,7 +1103,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeBlue2
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorArcadeRed
@@ -1187,7 +1118,6 @@
   friction: 0.25
   itemDrop: FloorTileItemArcadeRed
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorEighties
@@ -1203,7 +1133,6 @@
   friction: 0.25
   itemDrop: FloorTileItemEighties
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorCarpetClown
@@ -1219,7 +1148,6 @@
   friction: 0.25
   itemDrop: FloorTileItemCarpetClown
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorCarpetOffice
@@ -1235,7 +1163,6 @@
   friction: 0.25
   itemDrop: FloorTileItemCarpetOffice
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorBoxing
@@ -1255,7 +1182,6 @@
   friction: 0.25
   itemDrop: FloorTileItemBoxing
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorGym
@@ -1275,7 +1201,6 @@
   friction: 0.25
   itemDrop: FloorTileItemGym
   heatCapacity: 10000
-  tileRipResistance: 50
 
 # Shuttle
 - type: tile
@@ -1289,7 +1214,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleWhite
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleGrey
@@ -1302,7 +1226,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleGrey
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleBlack
@@ -1315,7 +1238,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleBlack
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleBlue
@@ -1328,7 +1250,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleBlue
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleOrange
@@ -1341,7 +1262,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleOrange
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttlePurple
@@ -1354,7 +1274,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttlePurple
   heatCapacity: 10000
-  tileRipResistance: 4500
 
 - type: tile
   id: FloorShuttleRed
@@ -1367,8 +1286,6 @@
     collection: FootstepFloor
   itemDrop: FloorTileItemShuttleRed
   heatCapacity: 10000
-  tileRipResistance: 4500
-
 
 # Materials
 - type: tile
@@ -1382,7 +1299,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemGold
   heatCapacity: 10000
-  tileRipResistance: 600
 
 - type: tile
   id: FloorSilver
@@ -1395,7 +1311,6 @@
     collection: FootstepTile
   itemDrop: FloorTileItemSilver
   heatCapacity: 10000
-  tileRipResistance: 500
 
 - type: tile
   id: FloorGlass
@@ -1414,7 +1329,6 @@
     collection: FootstepTile
   itemDrop: SheetGlass1
   heatCapacity: 10000
-  tileRipResistance: 150
 
 - type: tile
   id: FloorRGlass
@@ -1433,7 +1347,6 @@
     collection: FootstepTile
   itemDrop: SheetRGlass1
   heatCapacity: 10000
-  tileRipResistance: 175
 
 # Circuits
 - type: tile
@@ -1447,7 +1360,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemGCircuit
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorBlueCircuit
@@ -1460,7 +1372,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemBCircuit
   heatCapacity: 10000
-  tileRipResistance: 225
 
 # Terrain
 - type: tile
@@ -1754,7 +1665,6 @@
   itemDrop: FloorTileItemFlesh
   friction: 0.05 #slippy
   heatCapacity: 10000
-  tileRipResistance: 80
 
 - type: tile
   id: FloorTechMaint2
@@ -1767,7 +1677,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemSteelMaint
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorTechMaint3
@@ -1786,7 +1695,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemGratingMaint
   heatCapacity: 10000
-  tileRipResistance: 225
 
 - type: tile
   id: FloorWoodTile
@@ -1807,7 +1715,6 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWoodPattern
   heatCapacity: 10000
-  tileRipResistance: 75
 
 - type: tile
   id: FloorBrokenWood
@@ -1831,7 +1738,6 @@
     collection: BarestepWood
   itemDrop: MaterialWoodPlank1
   heatCapacity: 10000
-  tileRipResistance: 60
 
 - type: tile
   id: FloorWebTile
@@ -1846,7 +1752,6 @@
     collection: BarestepCarpet
   itemDrop: FloorTileItemWeb
   heatCapacity: 10000
-  tileRipResistance: 30
 
 - type: tile
   id: FloorChromite
@@ -1878,7 +1783,6 @@
     collection: FootstepHull
   itemDrop: FloorTileItemSteel #probably should not be normally obtainable, but the game shits itself and dies when you try to put null here
   heatCapacity: 10000
-  tileRipResistance: 500
 
 - type: tile
   id: FloorHullReinforced
@@ -1934,7 +1838,6 @@
     collection: FootstepGrass
   itemDrop: FloorTileItemAstroGrass
   heatCapacity: 10000
-  tileRipResistance: 50
 
 - type: tile
   id: FloorMowedAstroGrass
@@ -1944,7 +1847,6 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
-  tileRipResistance: 50
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -1954,7 +1856,6 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
-  tileRipResistance: 50
 
 # Ice
 - type: tile
@@ -1970,7 +1871,6 @@
   mobFrictionNoInput: 0.05
   mobAcceleration: 2
   itemDrop: FloorTileItemAstroIce
-  tileRipResistance: 50
 
 - type: tile
   id: FloorAstroSnow
@@ -1980,7 +1880,6 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
-  tileRipResistance: 50
 
 - type: tile
   id: FloorWoodLarge
@@ -2001,4 +1900,3 @@
     collection: BarestepWood
   itemDrop: FloorTileItemWoodLarge
   heatCapacity: 10000
-  tileRipResistance: 100


### PR DESCRIPTION
# Description

I promised I would return to this code when I had gotten down the basics of Calculus, and so I have. This PR reworks Space Wind to be even more efficient, while also making it run significantly smoother. Previously, my last optimization to this system involved replacing the need to take the square root of a large float a few thousand times per tick by adding an early exit, cleverly rearranging the math so that it multiplies a few times instead of square rooting, and changing it to use the throwing system. 

That is no longer necessary, it now operates on the Derivative of said function with respect to time. It's no longer necessary to square anything. This new space wind is significantly smoother than before.

<details><summary><h1>Media</h1></summary>
<p>

Final refinements of V3 courtesy of review by Mu Alpha Theta. 

https://github.com/user-attachments/assets/a48d43ae-7b79-4d83-81d5-028dd4e8c6c3

</p>
</details>

# Changelog

:cl:
- add: Added Space Wind Version 3. Smoother motion, better performance.
- add: Monstermos rip tiles has returned as a default CVar. 
- tweak: Floor Tiles once again are embeddable projectiles.
