### PR TITLE
Assay Power Hotfix

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/AssayPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/AssayPowerSystem.cs
@@ -40,16 +40,19 @@ public sealed class AssayPowerSystem : EntitySystem
             return;
 
         var ev = new AssayDoAfterEvent(_gameTiming.CurTime, args.FontSize, args.FontColor);
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.Performer, args.UseDelay - TimeSpan.FromSeconds(psionic.CurrentAmplification), ev, args.Performer, args.Target, args.Performer)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.Performer, args.UseDelay - TimeSpan.FromSeconds(psionic.CurrentAmplification), ev, args.Performer, args.Target, args.Performer)
         {
             BlockDuplicate = true,
             BreakOnMove = true,
             BreakOnDamage = true,
-        }, out var doAfterId);
+        };
+
+        if (!_doAfterSystem.TryStartDoAfter(doAfterArgs, out var doAfterId))
+            return;
+
         psionic.DoAfter = doAfterId;
 
         _popups.PopupEntity(Loc.GetString(args.PopupTarget, ("entity", args.Target)), args.Performer, PopupType.Medium);
-
         _audioSystem.PlayPvs(args.SoundUse, args.Performer, AudioParams.Default.WithVolume(8f).WithMaxDistance(1.5f).WithRolloffFactor(3.5f));
         _psionics.LogPowerUsed(args.Performer, args.PowerName, args.MinGlimmer, args.MaxGlimmer);
         args.Handled = true;


### PR DESCRIPTION
# Description

Assay featured the return of a bug that was present with the "Heal Other Powers", which made it so that failing to cast the Assay power (due to attempting to use it while moving for instance), caused the player to permanently lose the ability to cast any psi powers. The reason for this and the fix for it are pretty much exactly the same as it was for HealOtherPowerSystem.

Goddamn I **desperately** need to generalize these powers so I never have to go through this again.

# Changelog

:cl:
- fix: Fixed a bug where failing to cast the Assay power meant one lost the ability to ever use psionic powers again.
