### PR TITLE
Fix Big Security Glasses Not Having HUD

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -302,7 +302,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingEyesGlassesCheapSunglasses
+  parent: ClothingEyesGlassesSecurity
   id: ClothingEyesGlassesSecurityBig
   name: big security glasses
   description: Upgraded big sunglasses that provide flash immunity and a security HUD.


### PR DESCRIPTION
# Description

Fixed big security glasses not having flash protection and security HUD by inheriting from `ClothingEyesGlassesSecurity` instead of `ClothingEyesGlassesCheapSunglasses`.

## Changelog

:cl: Skubman
- fix: Big security glasses now provide flash immunity and a security HUD.