### PR TITLE
Martial Artist Rework + Fix MeleeWeapon Wizmerge Bugs

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             if (Interaction.CombatModeCanHandInteract(entity, target))
                 return;
 
-            if (target == null && weapon.HeavyOnLightMiss)
+            if (weapon.HeavyOnLightMiss && !CanDoLightAttack(entity, target, weapon, out _))
             {
                 ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
                 return;

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -151,6 +151,9 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             if (mousePos.MapId != attackerPos.MapId ||
                 (attackerPos.Position - mousePos.Position).Length() > weapon.Range)
             {
+                if (weapon.HeavyOnLightMiss)
+                    ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
+
                 return;
             }
 
@@ -164,6 +167,12 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             // Don't light-attack if interaction will be handling this instead
             if (Interaction.CombatModeCanHandInteract(entity, target))
                 return;
+
+            if (target == null && weapon.HeavyOnLightMiss)
+            {
+                ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
+                return;
+            }
 
             RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));
         }

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
@@ -11,21 +11,12 @@ public sealed partial class BoxerComponent : Component
     [DataField("modifiers", required: true)]
     public DamageModifierSet UnarmedModifiers = default!;
 
-    /// <summary>
-    ///   What to multiply the melee weapon range by.
-    /// </summary>
-    [DataField]
-    public float RangeModifier = 1f;
+    [DataField("rangeBonus")]
+    public float RangeBonus = 1.0f;
 
     /// <summary>
     /// Damage modifier with boxing glove stam damage.
     /// </summary>
-    [DataField]
+    [DataField("boxingGlovesModifier")]
     public float BoxingGlovesModifier = 1.75f;
-
-    /// <summary>
-    ///   Turns the left click into a power attack when the light attack misses.
-    /// </summary>
-    [DataField]
-    public bool HeavyOnLightMiss = true;
 }

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
@@ -19,4 +19,10 @@ public sealed partial class BoxerComponent : Component
     /// </summary>
     [DataField("boxingGlovesModifier")]
     public float BoxingGlovesModifier = 1.75f;
+
+    /// <summary>
+    ///   Turns the left click into a power attack when the light attack misses.
+    /// </summary>
+    [DataField]
+    public bool HeavyOnLightMiss = true;
 }

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
@@ -11,13 +11,16 @@ public sealed partial class BoxerComponent : Component
     [DataField("modifiers", required: true)]
     public DamageModifierSet UnarmedModifiers = default!;
 
-    [DataField("rangeBonus")]
-    public float RangeBonus = 1.5f;
+    /// <summary>
+    ///   What to multiply the melee weapon range by.
+    /// </summary>
+    [DataField]
+    public float RangeModifier = 1f;
 
     /// <summary>
     /// Damage modifier with boxing glove stam damage.
     /// </summary>
-    [DataField("boxingGlovesModifier")]
+    [DataField]
     public float BoxingGlovesModifier = 1.75f;
 
     /// <summary>

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
@@ -22,7 +22,7 @@ public sealed partial class BoxingSystem : EntitySystem
         if (!TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
             return;
 
-        meleeComp.Range *= component.RangeBonus;
+        meleeComp.Range *= component.RangeModifier;
         meleeComp.HeavyOnLightMiss = component.HeavyOnLightMiss;
 
         if (component.HeavyOnLightMiss)

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
@@ -19,9 +19,16 @@ public sealed partial class BoxingSystem : EntitySystem
 
     private void OnInit(EntityUid uid, BoxerComponent component, ComponentInit args)
     {
-        if (TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
-            meleeComp.Range *= component.RangeBonus;
+        if (!TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
+            return;
+
+        meleeComp.Range *= component.RangeBonus;
+        meleeComp.HeavyOnLightMiss = component.HeavyOnLightMiss;
+
+        if (component.HeavyOnLightMiss)
+            meleeComp.WideAnimation = meleeComp.Animation;
     }
+
     private void OnMeleeHit(EntityUid uid, BoxerComponent component, MeleeHitEvent args)
     {
         args.ModifiersList.Add(component.UnarmedModifiers);

--- a/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Boxer/BoxingSystem.cs
@@ -19,16 +19,9 @@ public sealed partial class BoxingSystem : EntitySystem
 
     private void OnInit(EntityUid uid, BoxerComponent component, ComponentInit args)
     {
-        if (!TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
-            return;
-
-        meleeComp.Range *= component.RangeModifier;
-        meleeComp.HeavyOnLightMiss = component.HeavyOnLightMiss;
-
-        if (component.HeavyOnLightMiss)
-            meleeComp.WideAnimation = meleeComp.Animation;
+        if (TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
+            meleeComp.Range *= component.RangeBonus;
     }
-
     private void OnMeleeHit(EntityUid uid, BoxerComponent component, MeleeHitEvent args)
     {
         args.ModifiersList.Add(component.UnarmedModifiers);

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -607,6 +607,12 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
     public EntProtoId? Animation;
 
     // <summary>
+    //     Whether to set the power attack animation to be the same as the light attack.
+    // </summary>
+    [DataField, AlwaysPushInheritance]
+    public bool HeavyAnimationFromLight = true;
+
+    // <summary>
     //     The damage values of unarmed damage.
     // </summary>
     [DataField, AlwaysPushInheritance]
@@ -617,6 +623,24 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
     // </summary>
     [DataField, AlwaysPushInheritance]
     public DamageSpecifier? FlatDamageIncrease;
+
+    /// <summary>
+    ///   Turns the left click into a power attack when the light attack misses.
+    /// </summary>
+    [DataField]
+    public bool? HeavyOnLightMiss;
+
+    // <summary>
+    //     What to multiply the melee weapon range by.
+    // </summary>
+    [DataField, AlwaysPushInheritance]
+    public float? RangeModifier;
+
+    // <summary>
+    //     What to multiply the attack rate by.
+    // </summary>
+    [DataField, AlwaysPushInheritance]
+    public float? AttackRateModifier;
 
     public override void OnPlayerSpawn(EntityUid uid,
         IComponentFactory factory,
@@ -630,15 +654,24 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
             melee.SoundHit = SoundHit;
 
         if (Animation != null)
-        {
             melee.Animation = Animation.Value;
-            melee.WideAnimation = Animation.Value; // Special case for Martial Artist
-        }
+
+        if (HeavyAnimationFromLight)
+            melee.WideAnimation = melee.Animation;
 
         if (Damage != null)
             melee.Damage = Damage;
 
         if (FlatDamageIncrease != null)
             melee.Damage += FlatDamageIncrease;
+
+        if (HeavyOnLightMiss != null)
+            melee.HeavyOnLightMiss = HeavyOnLightMiss.Value;
+
+        if (RangeModifier != null)
+            melee.Range *= RangeModifier.Value;
+
+        if (AttackRateModifier != null)
+            melee.AttackRate *= AttackRateModifier.Value;
     }
 }

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -61,6 +61,12 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField]
     public bool DisableClick = false;
 
+    /// <summary>
+    ///   If true, when a light attack misses, the weapon will perform a power attack instead.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool HeavyOnLightMiss = false;
+
     /*
      * Melee combat works based around 2 types of attacks:
      * 1. Click attacks with left-click. This attacks whatever is under your mnouse

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -180,8 +180,9 @@ trait-description-Feeble =
 trait-name-MartialArtist = Martial Artist
 trait-description-MartialArtist =
     You have received formal training in unarmed combat, whether with Fists, Feet, or Claws.
-    Your unarmed melee attacks have a small range increase, and deal 50% more damage.
-    This does not apply to any form of armed melee, only the weapons you were naturally born with.
+    Your unarmed melee attacks deal [color=yellow]50%[/color] more damage, have a small range increase, and are now
+    considered a [color=yellow]Power Attack[/color], requiring less accuracy than regular unarmed melee attacks.
+    This has no effect on damage dealt with any form of armed melee.
 
 trait-name-Vigor = Vigor
 trait-description-Vigor =

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -181,7 +181,7 @@ trait-name-MartialArtist = Martial Artist
 trait-description-MartialArtist =
     You have received formal training in unarmed combat, whether with Fists, Feet, or Claws.
     Your unarmed melee attacks deal [color=yellow]50%[/color] more damage, have a small range increase, and are now
-    considered a [color=yellow]Power Attack[/color], requiring less accuracy than regular unarmed melee attacks.
+    considered a [color=red]Power Attack[/color], requiring less precision than regular unarmed melee attacks.
     This has no effect on damage dealt with any form of armed melee.
 
 trait-name-Vigor = Vigor

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -179,7 +179,7 @@ trait-description-Feeble =
 
 trait-name-MartialArtist = Martial Artist
 trait-description-MartialArtist =
-    You have received formal training in unarmed combat, whether with fists, feet, or claws.
+    You have received formal training in unarmed combat, whether with fists, claws, feet, or teeth.
     Your unarmed melee attack is now considered a single-target [color=orange]Power Attack[/color], requiring less precision.
     Additionally, your unarmed melee attacks deal [color=yellow]20%[/color] more damage, attack [color=yellow]25%[/color] faster, and have [color=yellow]10%[/color] increased range.
     This has no effect on damage dealt with any form of armed melee.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -179,10 +179,11 @@ trait-description-Feeble =
 
 trait-name-MartialArtist = Martial Artist
 trait-description-MartialArtist =
-    You have received formal training in unarmed combat, whether with Fists, Feet, or Claws.
-    Your unarmed melee attacks deal [color=yellow]50%[/color] more damage, have a small range increase, and are now
-    considered a [color=red]Power Attack[/color], requiring less precision than regular unarmed melee attacks.
+    You have received formal training in unarmed combat, whether with fists, feet, or claws.
+    Your unarmed melee attack is now considered a single-target [color=orange]Power Attack[/color], requiring less precision.
+    Additionally, your unarmed melee attacks deal [color=yellow]20%[/color] more damage, attack [color=yellow]25%[/color] faster, and have [color=yellow]10%[/color] increased range.
     This has no effect on damage dealt with any form of armed melee.
+    The [color=#9FED58]Boxer[/color], [color=#9FED58]Martial Artist[/color], and [color=#9FED58]Gladiator[/color] jobs start with this trait by default.
 
 trait-name-Vigor = Vigor
 trait-description-Vigor =

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -256,6 +256,11 @@
       damage:
         types:
           Blunt: 6 # It's tough.
+      heavyRateModifier: 1
+      heavyDamageBaseModifier: 1
+      heavyPartDamageMultiplier: 1
+      heavyStaminaCost: 0
+      maxTargets: 1
     - type: MobPrice
       price: 1500 # Kidnapping a living person and selling them for cred is a good move.
       deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -179,6 +179,11 @@
     damage:
       types:
         Blunt: 5
+    heavyRateModifier: 1
+    heavyDamageBaseModifier: 1
+    heavyPartDamageMultiplier: 1
+    heavyStaminaCost: 0
+    maxTargets: 1
   - type: SleepEmitSound
   - type: SSDIndicator
   - type: StandingState

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
@@ -15,14 +15,9 @@
       department: Security
       min: 21600
   special:
-  - !type:AddComponentSpecial
-    components:
-    - type: Boxer
-      modifiers:
-        coefficients: # These only apply to unarmed
-          Blunt: 1.5
-          Slash: 1.5
-          Piercing: 1.5
+  - !type:AddTraitSpecial
+    traits:
+    - MartialArtist
 
 - type: startingGear
   id: NyanoGladiatorGear

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
@@ -16,14 +16,9 @@
   - Theatre # DeltaV - Add Theatre access
   - Boxer # DeltaV - Add Boxer access
   special:
-  - !type:AddComponentSpecial
-    components:
-    - type: Boxer
-      modifiers:
-        coefficients: # These only apply to unarmed
-          Blunt: 1.5
-          Slash: 1.5
-          Piercing: 1.5
+  - !type:AddTraitSpecial
+    traits:
+    - MartialArtist
 
 - type: startingGear
   id: MartialArtistGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -14,15 +14,9 @@
   - Theatre # DeltaV - Add Theatre access
   - Boxer # DeltaV - Add Boxer access
   special: # Nyanotrasen - BoxerComponent, see Content.Server/Nyanotrasen/Abilities/Boxer/Boxer/BoxerComponent.cs
-  - !type:AddComponentSpecial
-    components:
-    - type: Boxer
-      rangeModifier: 1.1
-      modifiers:
-        coefficients: # These only apply to unarmed
-          Blunt: 1.5
-          Slash: 1.5
-          Piercing: 1.5
+  - !type:AddTraitSpecial
+    traits:
+    - MartialArtist
 
 - type: startingGear
   id: BoxerGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -17,7 +17,7 @@
   - !type:AddComponentSpecial
     components:
     - type: Boxer
-      rangeModifier: 1.066666
+      rangeModifier: 1.1
       modifiers:
         coefficients: # These only apply to unarmed
           Blunt: 1.5

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -17,6 +17,7 @@
   - !type:AddComponentSpecial
     components:
     - type: Boxer
+      rangeModifier: 1.066666
       modifiers:
         coefficients: # These only apply to unarmed
           Blunt: 1.5

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -296,6 +296,7 @@
     - !type:TraitReplaceComponent
       components:
         - type: Boxer
+          rangeModifier: 1.066666
           modifiers:
             coefficients:
               Blunt: 1.5

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -307,6 +307,8 @@
               Blunt: 1.2
               Slash: 1.2
               Piercing: 1.2
+              Poison: 1.2
+              Asphyxiation: 1.2
       # An attack rate of 1.25 hits per second (1 / 0.8 = 1.25) multiplied by 20% extra damage
       # effectively means 50% more overall DPS, same DPS bonus as before (1 * 1.25 * 1.2 = 1.5)
       # but the extra attack rate makes it visually apparent that it's Martial Artist.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -415,6 +415,11 @@
         - Human
         - Oni
         - SlimePerson
+        - Diona
+        - Dwarf
+        - Arachne
+        - IPC # Other species could justify getting this trait for Blunt stamina damage,
+              # but 6 blunt -> 5 blunt is a straight up downgrade.
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -296,7 +296,7 @@
     - !type:TraitReplaceComponent
       components:
         - type: Boxer
-          rangeModifier: 1.066666
+          rangeModifier: 1.1
           modifiers:
             coefficients:
               Blunt: 1.5

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -292,16 +292,24 @@
       - Borg
       - MedicalBorg
       - Boxer
+      - MartialArtist
+      - Gladiator
   functions:
+    - !type:TraitModifyUnarmed
+      heavyOnLightMiss: true
+      attackRateModifier: 1.25
+      rangeModifier: 1.1
     - !type:TraitReplaceComponent
-      components:
-        - type: Boxer
-          rangeModifier: 1.1
+      components:     # Keep BoxerComponent for now until we have After/Before on traits prototypes
+        - type: Boxer # for potential conflicts with other traits that replace unarmed damage
           modifiers:
             coefficients:
-              Blunt: 1.5
-              Slash: 1.5
-              Piercing: 1.5
+              Blunt: 1.2
+              Slash: 1.2
+              Piercing: 1.2
+      # An attack rate of 1.25 hits per second multiplied by 20% extra damage
+      # effectively means 50% more overall DPS, same DPS bonus as before (1 * 1.25 * 1.2 = 1.5)
+      # but the extra attack rate makes it visually apparent that it's Martial Artist.
 
 - type: trait
   id: Small
@@ -414,7 +422,6 @@
     - !type:TraitModifyUnarmed
       soundHit:
         collection: Punch
-      angle: 30
       animation: WeaponArcFist
       damage:
         types:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -358,16 +358,14 @@
       traits:
         - Claws
   functions:
-    - !type:TraitReplaceComponent
-      components:
-        - type: MeleeWeapon
-          soundHit:
-            collection: AlienClaw
-          animation: WeaponArcClaw
-          damage:
-            types:
-              Piercing: 5 # No, this isn't "OP", this is literally the worst brute damage type in the game.
-                          # Same deal as Slash, except that a majority of all armor provides Piercing resistance.
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: AlienClaw
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Piercing: 5 # No, this isn't "OP", this is literally the worst brute damage type in the game.
+                      # Same deal as Slash, except that a majority of all armor provides Piercing resistance.
 
 - type: trait
   id: Claws
@@ -386,17 +384,14 @@
       traits:
         - Talons
   functions:
-    - !type:TraitReplaceComponent
-      components:
-        - type: MeleeWeapon
-          soundHit:
-            collection: AlienClaw
-          angle: 30
-          animation: WeaponArcClaw
-          damage:
-            types:
-              Slash: 5 # Trade stamina damage on hit for a very minor amount of extra bleed.
-                      # Blunt also deals bleed damage, so this is more of a sidegrade.
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: AlienClaw
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Slash: 5 # Trade stamina damage on hit for a very minor amount of extra bleed.
+                  # Blunt also deals bleed damage, so this is more of a sidegrade.
 
 - type: trait
   id: NaturalWeaponRemoval
@@ -415,16 +410,14 @@
         - Talons
         - Claws
   functions:
-    - !type:TraitReplaceComponent
-      components:
-        - type: MeleeWeapon
-          soundHit:
-            collection: Punch
-          angle: 30
-          animation: WeaponArcFist
-          damage:
-            types:
-              Blunt: 5
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: Punch
+      angle: 30
+      animation: WeaponArcFist
+      damage:
+        types:
+          Blunt: 5
 
 - type: trait
   id: StrikingCalluses
@@ -453,16 +446,10 @@
           jobs:
             - Boxer
   functions:
-    - !type:TraitReplaceComponent
-      components:
-        - type: MeleeWeapon
-          soundHit:
-            collection: Punch
-          angle: 30
-          animation: WeaponArcFist
-          damage:
-            types:
-              Blunt: 6
+    - !type:TraitModifyUnarmed
+      flatDamageIncrease:
+        types:
+          Blunt: 1
 
 - type: trait
   id: Spinarette

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -297,7 +297,7 @@
   functions:
     - !type:TraitModifyUnarmed
       heavyOnLightMiss: true
-      attackRateModifier: 1.25
+      attackRateModifier: 0.8
       rangeModifier: 1.1
     - !type:TraitReplaceComponent
       components:     # Keep BoxerComponent for now until we have After/Before on traits prototypes
@@ -307,7 +307,7 @@
               Blunt: 1.2
               Slash: 1.2
               Piercing: 1.2
-      # An attack rate of 1.25 hits per second multiplied by 20% extra damage
+      # An attack rate of 1.25 hits per second (1 / 0.8 = 1.25) multiplied by 20% extra damage
       # effectively means 50% more overall DPS, same DPS bonus as before (1 * 1.25 * 1.2 = 1.5)
       # but the extra attack rate makes it visually apparent that it's Martial Artist.
 

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -432,7 +432,7 @@
 - type: trait
   id: StrikingCalluses
   category: Physical
-  points: -4
+  points: -3
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -284,7 +284,7 @@
 - type: trait
   id: MartialArtist
   category: Physical
-  points: -3
+  points: -5
   requirements:
   - !type:CharacterJobRequirement
     inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -453,6 +453,8 @@
         - !type:CharacterJobRequirement
           jobs:
             - Boxer
+            - MartialArtist
+            - Gladiator
   functions:
     - !type:TraitModifyUnarmed
       flatDamageIncrease:


### PR DESCRIPTION
# Description

Reworks the Martial Artist trait, making it a more impactful and visually distinct trait.
- Left-clicks are now single-target power attacks, requiring less aim than before.
- **50%** damage bonus reduced to **20%** damage bonus (same overall DPS with next change).
- Gain **25%** attack rate bonus.
  - The attack rate bonus helps make the trait feel and look distinct from non-Martial Artist melee attacks.
- **50%** range bonus reduced to **10%** range bonus.
- The damage bonus is now also applied to Asphyxiation and Poison damage, which Lamia unarmed attacks deal.
- Trait cost increased from **-3** points to **-5** points.
- Striking Calluses (which requires Martial Artist) cost reduced from **-4** points to **-3** points to prevent the Martial Artist/Striking Calluses combo from being too expensive. The combo used to cost **-7** points, now it is **-8** points.

The reworked Martial Artist trait is also given to the Boxers, Martial Artists and Gladiators.

Also reverted some wizmerge messery that messed up the melee attack rate **again**, and messed up pistol whipping by making the cooldowns of gunshots and melee attacks intertwined.

Also while we're at it, Natural Weapons Removal has been disabled for all species whose damage is pure Blunt, including Diona, Dwarf, Arachne and IPC. (IPC have 6 blunt so the trait would literally be a 0-point negative trait for them)  

## Technical Details

A new trait function has been added for Martial Artist: `TraitModifyUnarmed`, which modifies the player entity's `MeleeWeaponComponent`.

The Claws, Talons, Natural Weapon Removal, and Striking Calluses traits have also been refactored under the hood to use `TraitModifyUnarmed`, instead of replacing `MeleeWeaponComponent` which would wipe out all the changes made by the Martial Artist trait.

## Media

### New Description
![martialartist](https://github.com/user-attachments/assets/de51530f-5f2a-41a8-b686-c12f746b5e4a)

### Martial Artist In Action
https://github.com/user-attachments/assets/7890aac2-2c74-4abd-be9f-b28c2922c865

### Striking Calluses New Description
![strikingcalluses](https://github.com/user-attachments/assets/bc15425e-3460-49f2-88f5-840c686e0053)

### Natural Weapons Removal New Description
![naturalweaponsremoval](https://github.com/user-attachments/assets/583adaa4-48c0-46e3-882b-1bb0f470018c)

# Changelog

:cl: Skubman
- add: Martial Artist Rework: Martial Artist now costs 5 points, but it turns all unarmed melee attacks into single-target power attacks, with 20% bonus damage, 25% bonus attack rate and 10% bonus attack range.
- tweak: The reworked Martial Artist trait is now given for free to Boxers, Martial Artists, and Gladiators.
- tweak: Martial Artists (the job) and Gladiators can now select the Striking Calluses trait.
- tweak: The Martial Artist trait now applies bonus damage to the Lamiae's unarmed Asphyxiation and Poison damage.
- tweak: The cost of Striking Calluses has been reduced from 4 points to 3 points.
- fix: Fixed a bug where slow weapons were fast and fast weapons were slow.
- fix: You can pistol whip (right-click melee) immediately after firing a gun again, and the cooldown on firing the gun after pistol whipping is always 0.528 seconds again.
- fix: Prevented Dionas, Arachnae and IPCs, who all have pure Blunt damage from selecting the redundant Natural Weapons Removal trait.