### PR TITLE
Add Security Officer Playtime Requirement

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,6 +6,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
+      min: 36000 # 10 hours
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
# Description
Bro, it is absolutely wild that they don't have a requirement. This must've been looked over or something, so I added a Security Officer playtime requirement to the already-existing department requirement that was missing an actual minute listing.

---

# Changelog
:cl:
- fix: Fixed the missing playtime requirement on Security Officer. It is now set to 10 hours of Security Department.