### PR TITLE
[Shitmed] Increase Brain Eating Time & Show Brain Eating Popup

### DIFF
--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -70,6 +70,12 @@ public sealed partial class FoodComponent : Component
     public float ForceFeedDelay = 3;
 
     /// <summary>
+    /// Shitmed Change: Whether to show a popup to everyone in range when attempting to eat this food.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool PopupOnEatAttempt = false;
+
+    /// <summary>
     /// For mobs that are food, requires killing them before eating.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -70,10 +70,10 @@ public sealed partial class FoodComponent : Component
     public float ForceFeedDelay = 3;
 
     /// <summary>
-    /// Shitmed Change: Whether to show a popup to everyone in range when attempting to eat this food.
+    /// Shitmed Change: Whether to show a popup to everyone in range when attempting to eat this food, and upon successful eating.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool PopupOnEatAttempt = false;
+    public bool PopupOnEat = false;
 
     /// <summary>
     /// For mobs that are food, requires killing them before eating.

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -72,8 +72,8 @@ public sealed partial class FoodComponent : Component
     /// <summary>
     /// Shitmed Change: Whether to show a popup to everyone in range when attempting to eat this food, and upon successful eating.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool PopupOnEat = false;
+    [DataField]
+    public bool PopupOnEat;
 
     /// <summary>
     /// For mobs that are food, requires killing them before eating.

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -301,7 +301,7 @@ public sealed class FoodSystem : EntitySystem
         {
             var targetName = Identity.Entity(args.Target.Value, EntityManager);
             var userName = Identity.Entity(args.User, EntityManager);
-            _popup.PopupEntity(Loc.GetString("food-system-force-feed-success", ("user", userName), ("flavors", flavors)), entity.Owner, entity.Owner);
+            _popup.PopupEntity(Loc.GetString("food-system-force-feed-success", ("user", userName), ("flavors", flavors)), args.Target.Value, args.Target.Value);
 
             _popup.PopupEntity(Loc.GetString("food-system-force-feed-success-user", ("target", targetName)), args.User, args.User);
 

--- a/Resources/Locale/en-US/_Shitmed/nutrition/components/food-component.ftl
+++ b/Resources/Locale/en-US/_Shitmed/nutrition/components/food-component.ftl
@@ -1,0 +1,5 @@
+## System
+
+food-system-eat-popup = {CAPITALIZE(THE($user))} is trying to eat {THE($food)}!
+food-system-eat-popup-self = You start trying to eat {THE($food)}!
+food-system-force-feed-popup = {CAPITALIZE(THE($user))} is trying to feed {THE($target)} {THE($food)}!

--- a/Resources/Locale/en-US/_Shitmed/nutrition/components/food-component.ftl
+++ b/Resources/Locale/en-US/_Shitmed/nutrition/components/food-component.ftl
@@ -1,5 +1,7 @@
 ## System
 
-food-system-eat-popup = {CAPITALIZE(THE($user))} is trying to eat {THE($food)}!
-food-system-eat-popup-self = You start trying to eat {THE($food)}!
-food-system-force-feed-popup = {CAPITALIZE(THE($user))} is trying to feed {THE($target)} {THE($food)}!
+food-system-eat-broadcasted = {CAPITALIZE(THE($user))} is trying to eat {THE($food)}!
+food-system-eat-broadcasted-self = You start trying to eat {THE($food)}!
+food-system-force-feed-broadcasted = {CAPITALIZE(THE($user))} is trying to feed {THE($target)} {THE($food)}!
+food-system-force-feed-broadcasted-success = {CAPITALIZE(THE($user))} forced {THE($target)} to eat {THE($food)}!
+food-system-eat-broadcasted-success = {CAPITALIZE(THE($user))} ate {THE($food)}!

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -45,7 +45,7 @@
   - type: Food # Shitmed Change
     delay: 5
     forceFeedDelay: 6
-    popupOnEatAttempt: true
+    popupOnEat: true
   - type: Brain # Shitmed
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -42,6 +42,10 @@
     state: brain
   - type: Organ # Shitmed
     slotId: brain
+  - type: Food # Shitmed Change
+    delay: 5
+    forceFeedDelay: 6
+    popupOnEatAttempt: true
   - type: Brain # Shitmed
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -48,7 +48,7 @@
   - type: Food # Shitmed Change
     delay: 5
     forceFeedDelay: 6
-    popupOnEatAttempt: true
+    popupOnEat: true
   - type: Input
     context: "ghost"
   - type: Brain

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -45,6 +45,10 @@
     state: brain
   - type: Organ
     slotId: brain # Shitmed Change
+  - type: Food # Shitmed Change
+    delay: 5
+    forceFeedDelay: 6
+    popupOnEatAttempt: true
   - type: Input
     context: "ghost"
   - type: Brain
@@ -73,7 +77,7 @@
     entries:
       Burger: Brain
       Taco: Brain
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: BaseHumanOrgan

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
@@ -8,6 +8,10 @@
     state: brain
   - type: Organ
     slotId: brain
+  - type: Food
+    delay: 5
+    forceFeedDelay: 6
+    popupOnEatAttempt: true
   - type: Input
     context: "ghost"
   - type: Brain

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
@@ -11,7 +11,7 @@
   - type: Food
     delay: 5
     forceFeedDelay: 6
-    popupOnEatAttempt: true
+    popupOnEat: true
   - type: Input
     context: "ghost"
   - type: Brain


### PR DESCRIPTION
# Description

Increases the delay when eating brains from 1 second to 5 seconds, and when someone starts or finishes eating a brain it shows a red popup to everyone in range.

Eating a character's brain round-removes them. However, it's easy to do with a 1-second timer and very easy to accidentally RR someone through eating their brain by fat-fingering the "Activate item in hand" keybind. (Disclaimer: I did exactly this LOL). This PR will make accidental brain eating very unlikely.

A red popup on eating is also important so everyone in range will be aware if someone might get RR'd through brain eating and be able to try to intervene.

This also fixes a _very hilarious_ bug where the target of a force-feed wouldn't get the popup showing the flavors of the food after the force feed was complete. 

## Media

**Popup on self when eating a brain** 

https://github.com/user-attachments/assets/66cf0952-4005-4c3f-bfed-585829f78369

**Popup on others eating a brain**

https://github.com/user-attachments/assets/bd183de2-c39f-49bd-a633-52cba7b961b1

**Popup on others force-feeding a brain**

https://github.com/user-attachments/assets/459042de-42ae-4064-9f43-be2d7f0c73d0

**Popup of flavors on being force-fed**

https://github.com/user-attachments/assets/c593263f-96b6-40b0-875c-0dc0b160cd62

## Changelog

:cl: Skubman
- tweak: Eating a brain now takes 5 seconds (from 1 second), and feeding someone a brain takes 6 seconds.
- add: Attempting or succeeding to eat a brain now shows a red popup message to everyone else in range, e.g. "Urist McHands is trying to eat the brain!" / "Urist McHands ate the brain!".
- fix: Fixed a bug where players after being force-fed were not shown a popup showing the food's flavors.