### PR TITLE
Arachne Standing Up Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
@@ -102,7 +102,7 @@
         - MobLayer
   - type: Body
     prototype: Arachne
-    requiredLegs: 8
+    requiredLegs: 0 # TODO: set required legs to 8 once arachne legs are properly set up
   - type: Speech
     speechSounds: Alto
   - type: Inventory

--- a/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachne.yml
@@ -102,7 +102,7 @@
         - MobLayer
   - type: Body
     prototype: Arachne
-    requiredLegs: 0 # TODO: set required legs to 8 once arachne legs are properly set up
+    requiredLegs: 8
   - type: Speech
     speechSounds: Alto
   - type: Inventory

--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Parts/spider.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Parts/spider.yml
@@ -36,6 +36,7 @@
     sprite: Mobs/Species/Moth/parts.rsi
     state: "torso_m"
   - type: BodyPart #"Other" type
+    slotId: thorax
   - type: Extractable
     juiceSolution:
       reagents:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/arachne.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/arachne.yml
@@ -38,27 +38,28 @@
     thorax:
       part: ThoraxSpider
       connections:
-        - left foreleg
-        - left second leg
-        - left third leg
-        - left hind leg
-        - right foreleg
-        - right second leg
-        - right third leg
-        - right hind leg
-    left foreleg:
+        # The slots needs to start with (symmetry) (part) or they're not gonna be registered
+        - left leg (fore)
+        - left leg (second)
+        - left leg (third)
+        - left leg (hind)
+        - right leg (fore)
+        - right leg (second)
+        - right leg (third)
+        - right leg (hind)
+    left leg (fore):
       part: LeftLegSpider
-    left second leg:
+    left leg (second):
       part: LeftLegSpider
-    left third leg:
+    left leg (third):
       part: LeftLegSpider
-    left hind leg:
+    left leg (hind):
       part: LeftLegSpider
-    right foreleg:
+    right leg (fore):
       part: RightLegSpider
-    right second leg:
+    right leg (second):
       part: RightLegSpider
-    right third leg:
+    right leg (third):
       part: RightLegSpider
-    right hind leg:
+    right leg (hind):
       part: RightLegSpider


### PR DESCRIPTION
# Description

Arachne can now stand up after lying down again.

## Media

Arachne with 8 registered legs lying down and standing up

https://github.com/user-attachments/assets/b7b5c83b-b741-4d4f-88b6-1133834104de

## Technical Details

I don't even really understand what I'm about to say, just trying to explain the issue for documentation purposes. 

`LayingDownSystem.TryStandUp` checks if the entity's `BodyComponent.LegEntities` element count is less than `BodyComponent.RequiredLegs`, which for Arachne is 8.

https://github.com/Simple-Station/Einstein-Engines/blob/78347d76fb50908888c77df5e3b935b773297620/Content.Shared/Standing/SharedLayingDownSystem.cs#L141-L151

However, due to some issues with the part slot naming, `BodyComponent.LegEntities` for Arachne has no elements, because of Shitmed being hardcoded and being built with the expectation that all slot IDs start with "{body part symmetry} {part type}" like "left leg" and "right leg", from `GetSlotFromBodyPart`. This means that Arachne legs which were not following the format were not registered after being inserted into the thorax part's container.

https://github.com/Simple-Station/Einstein-Engines/blob/78347d76fb50908888c77df5e3b935b773297620/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs#L1044-L1060

This is where the function is used:

https://github.com/Simple-Station/Einstein-Engines/blob/78347d76fb50908888c77df5e3b935b773297620/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs#L216-L236

For the left foreleg for example, the container ID (`slotId`) is `body_part_slot_right foreleg` but the result of `PartSlotContainerIdPrefix + GetSlotFromBodyPart(part)` is `body_part_slot_right leg`, and slotId does not contain `right leg` so the check fails.

This is resolved by renaming `left foreleg` to `left leg (fore)`, `right hind leg` to `right leg (hind)` , so on and so forth.

For unconventional body parts like a thorax, you need to explicitly set the `BodyPart.SlotId` field to override `GetSlotFromBodyPart` returning `other`, when it should return `thorax` to pass the slotId check. This will make sure the thorax is registered and thus can recursively register the legs attached to it.

## Changelog

:cl: Skubman
- fix: Arachne can now stand up after lying down.