### PR TITLE
Fix Mining Drills & Reduce Stamina Cost

### DIFF
--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -60,7 +60,7 @@ namespace Content.Server.Damage.Systems
 
             var staminaCostMarkup = FormattedMessage.FromMarkupOrThrow(
                 Loc.GetString("damage-stamina-cost",
-                ("type", Loc.GetString("damage-throw")), ("cost", component.StaminaCost)));
+                ("type", Loc.GetString("damage-throw")), ("cost", Math.Round(component.StaminaCost, 2).ToString("0.##"))));
             args.Message.PushNewline();
             args.Message.AddMessage(staminaCostMarkup);
         }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -69,7 +69,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             {
                 var staminaCostMarkup = FormattedMessage.FromMarkupOrThrow(
                     Loc.GetString("damage-stamina-cost",
-                    ("type", Loc.GetString("damage-melee-heavy")), ("cost", component.HeavyStaminaCost)));
+                    ("type", Loc.GetString("damage-melee-heavy")), ("cost", Math.Round(component.HeavyStaminaCost, 2).ToString("0.##"))));
                 args.Message.PushNewline();
                 args.Message.AddMessage(staminaCostMarkup);
             }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -105,7 +105,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         // If someone swaps to this weapon then reset its cd.
         var curTime = Timing.CurTime;
-        var minimum = curTime + TimeSpan.FromSeconds(1 / attackRate);
+        var minimum = curTime + TimeSpan.FromSeconds(GetAttackRate(uid, args.User, component));
 
         if (minimum < component.NextAttack)
             return;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -59,7 +59,7 @@
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
     angle: 0
-    attackRate: 0.75
+    attackRate: 1.3333
     animation: WeaponArcPunch
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -72,6 +72,15 @@
         Brute: 3
       types:
         Structural: 15
+  - type: DamageOtherOnHit
+    staminaCost: 12
+    damage:
+      groups:
+        Brute: 8
+      types:
+        Structural: 15
+  - type: ThrowingAngle
+    angle: 270
 
 - type: entity
   name: diamond tipped mining drill
@@ -92,6 +101,12 @@
     damage:
       groups:
         Brute: 6
+      types:
+        Structural: 30
+  - type: DamageOtherOnHit
+    damage:
+      groups:
+        Brute: 16
       types:
         Structural: 30
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -11,20 +11,28 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
-    attackRate: 0.7
+    attackRate: 0.85
+    range: 1.5
     wideAnimationRotation: -135
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
       params:
         volume: -3
     damage:
-      groups:
-        Brute: 5
+      types:
+        Blunt: 6
+        Piercing: 3
+    bluntStaminaDamageFactor: 2.0
+    heavyDamageBaseModifier: 1.75
+    maxTargets: 5
+    angle: 80
+  - type: DamageOtherOnHit
+    staminaCost: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       groups:
-        Brute: 10
+        Brute: 5
       types:
         Structural: 30
   - type: Item
@@ -56,7 +64,9 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-    attackRate: 4
+    attackRate: 0.25
+    range: 1.5
+    heavyStaminaCost: 0.7
     damage:
       groups:
         Brute: 3
@@ -78,7 +88,7 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-    attackRate: 4
+    heavyStaminaCost: 0.55 # More efficient so less stamina needed to use
     damage:
       groups:
         Brute: 6

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -73,10 +73,10 @@
       types:
         Structural: 15
   - type: DamageOtherOnHit
-    staminaCost: 12
+    staminaCost: 9
     damage:
       groups:
-        Brute: 8
+        Brute: 9
       types:
         Structural: 15
   - type: ThrowingAngle
@@ -106,7 +106,7 @@
   - type: DamageOtherOnHit
     damage:
       groups:
-        Brute: 16
+        Brute: 18
       types:
         Structural: 30
 


### PR DESCRIPTION
# Description

Fixes the attack values of mining weapons which were messed up in the Wizmerge.

For the pickaxe, I reverted all damage values to be the same as before. For the mining drill however, I opted to keep the rapid fire rate because it was an interesting effect and just added the extra range from pre-wizmerge and the throwing damage back. I also **greatly reduced the mining drill's stamina cost** because it was a common complaint among players.

Before the wizmerge, the mining weapons (pickaxe and drill) were in `Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml`  but they got moved to `Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml` and thus the EE-specific changes got wiped.

Also fixes a subtle bug in `SharedMeleeWeaponSystem.OnMeleeSelected`, responsible for resetting the cooldown of a melee weapon upon selecting it, that treated attack rate as attacks per second as opposed to seconds per attack  :
```diff
    private void OnMeleeSelected(EntityUid uid, MeleeWeaponComponent component, HandSelectedEvent args)
    {
        ...
-       var minimum = curTime + TimeSpan.FromSeconds(1 / attackRate);
+       var minimum = curTime + TimeSpan.FromSeconds(GetAttackRate(uid, args.User, component));

        if (minimum < component.NextAttack)
            return;
        component.NextAttack = minimum;
        DirtyField(uid, component, nameof(MeleeWeaponComponent.NextAttack));
    }
```

Bug above was particularly noticeable for weapons with a very fast attack rate like the mining drill and north stars, which caused the `NextAttack` delay on select to be 4 seconds instead of 0.25 seconds. 

Another subtle issue, the Goliath's attack rate field was `0.75` but the field was set from Wizden and means attacks per second, not seconds per attack so I changed it `1.33`. 

## Media

**Pickaxe**
<img width=300px src="https://github.com/user-attachments/assets/8bf1290e-6506-4ac8-9b8b-2bb23a2013b6">

**Mining Drill**
<img width=300px src="https://github.com/user-attachments/assets/2f852a29-7b58-4e33-8264-67bab87254fd">

**Diamond Tipped Mining Drill**
<img width=300px src="https://github.com/user-attachments/assets/750fa019-17dc-4d21-900c-88526c873771">

**Mining with Mining Drill**

https://github.com/user-attachments/assets/a9822ccb-c991-4341-a076-fd89a8689e0c

## Changelog

:cl: Skubman
- fix: The mining drill now has a fast fire rate and extra range again.
- fix: The pickaxe and the mining drill can now be used as throwing weapons again.
- fix: Fixed a bug where selecting weapons with a fast attack rate took a few seconds before you could attack with them.
- fix: Fixed the Goliath attacking too fast. 
- tweak: The power attack stamina cost of mining drills has been reduced to 0.7 stamina.
- tweak: Re-adjusted the damage of the pickaxe.