### PR TITLE
Fix Sophia Sending a Massive Float to Chat

### DIFF
--- a/Content.Server/Nyanotrasen/Research/SophicScribe/SophicScribeSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/SophicScribe/SophicScribeSystem.cs
@@ -38,7 +38,7 @@ public sealed partial class SophicScribeSystem : EntitySystem
             if (!TryComp<IntrinsicRadioTransmitterComponent>(scribe, out var radio))
                 continue;
 
-            var message = Loc.GetString("glimmer-report", ("level", _glimmerSystem.GlimmerOutput));
+            var message = Loc.GetString("glimmer-report", ("level", _glimmerSystem.GlimmerOutputString));
             var channel = _prototypeManager.Index<RadioChannelPrototype>("Science");
             _radioSystem.SendRadioMessage(scribe, message, channel, scribe);
 
@@ -62,7 +62,7 @@ public sealed partial class SophicScribeSystem : EntitySystem
 
         component.StateTime = _timing.CurTime + component.StateCD;
 
-        _chat.TrySendInGameICMessage(uid, Loc.GetString("glimmer-report", ("level", _glimmerSystem.GlimmerOutput)), InGameICChatType.Speak, true);
+        _chat.TrySendInGameICMessage(uid, Loc.GetString("glimmer-report", ("level", _glimmerSystem.GlimmerOutputString)), InGameICChatType.Speak, true);
     }
 
     private void OnGlimmerEventEnded(GlimmerEventEndedEvent args)
@@ -79,7 +79,7 @@ public sealed partial class SophicScribeSystem : EntitySystem
                 speaker = swapped.OriginalEntity;
             }
 
-            var message = Loc.GetString(args.Message, ("decrease", args.GlimmerBurned), ("level", _glimmerSystem.GlimmerOutput));
+            var message = Loc.GetString(args.Message, ("decrease", args.GlimmerBurned), ("level", _glimmerSystem.GlimmerOutputString));
             var channel = _prototypeManager.Index<RadioChannelPrototype>("Common");
             _radioSystem.SendRadioMessage(speaker, message, channel, speaker);
         }

--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -32,7 +32,7 @@ public sealed class GlimmerSystem : EntitySystem
     ///     This returns a string that returns a more display-friendly glimmer input.
     ///     For example, 502.03837847 will become 502.03.
     /// </summary>
-    public string GlimmerInputString => _glimmerInput.ToString("0.00");
+    public string GlimmerInputString => _glimmerInput.ToString("#.##");
 
     private float _glimmerOutput = 0;
 
@@ -59,7 +59,7 @@ public sealed class GlimmerSystem : EntitySystem
     ///     This returns a string that returns a more display-friendly glimmer output.
     ///     For example, 502.03837847 will become 502.03.
     /// </summary>
-    public string GlimmerOutputString => _glimmerOutput.ToString("0.00");
+    public string GlimmerOutputString => _glimmerOutput.ToString("#.##");
 
     private bool _enabled;
     public override void Initialize()

--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.GameTicking;
 
 namespace Content.Shared.Psionics.Glimmer;
 
+
 /// <summary>
 /// This handles setting / reading the value of glimmer.
 /// </summary>
@@ -13,6 +14,7 @@ public sealed class GlimmerSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private float _glimmerInput = 0;
+
     /// <summary>
     ///     GlimmerInput represents the system-facing value of the station's glimmer, and is given by f(y) for this graph: https://www.desmos.com/calculator/posutiq38e
     ///     Where x = GlimmerOutput and y = GlimmerInput
@@ -25,6 +27,13 @@ public sealed class GlimmerSystem : EntitySystem
         get { return _glimmerInput; }
         private set { _glimmerInput = _enabled ? Math.Max(value, 0) : 0; }
     }
+
+    /// <summary>
+    ///     This returns a string that returns a more display-friendly glimmer input.
+    ///     For example, 502.03837847 will become 502.03.
+    /// </summary>
+    public string GlimmerInputString => _glimmerInput.ToString("0.00");
+
     private float _glimmerOutput = 0;
 
     /// <summary>
@@ -45,6 +54,13 @@ public sealed class GlimmerSystem : EntitySystem
         get { return _glimmerOutput; }
         private set { _glimmerOutput = _enabled ? Math.Clamp(value, 0, 999.999f) : 0; }
     }
+
+    /// <summary>
+    ///     This returns a string that returns a more display-friendly glimmer output.
+    ///     For example, 502.03837847 will become 502.03.
+    /// </summary>
+    public string GlimmerOutputString => _glimmerOutput.ToString("0.00");
+
     private bool _enabled;
     public override void Initialize()
     {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b53f8a0a-422b-47f8-acda-01d830dc8aaa)


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed full glimmer float being displayed to chat by Sophia.
