### PR TITLE
Disable Blood Traits For Lamia

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -235,6 +235,7 @@
       inverted: true
       species:
         - IPC
+        - Lamia
   functions:
     - !type:TraitAddComponent
       components:
@@ -255,6 +256,7 @@
       inverted: true
       species:
         - IPC
+        - Lamia
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
# Description

It turns out that when you have a species that has 20x the blood volume of a human, letting them take a trait that makes them constantly bleed some percentage of their blood volume causes a lot of problems. Usually by FLOODING the station with blood. This PR just makes Lamia ineligible for the two blood traits, it unfortunately doesn't fix the issue of them excessively bleeding when you attack them(I actually don't fully consider it to be an issue. I have issues instead with system instances of hardcoded blood amounts). 

# Changelog

:cl:
- remove: Lamia can no longer take blood related traits, such as Blood Deficiency.
