### PR TITLE
Add Classic Asimov Laws

### DIFF
--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -66,7 +66,7 @@ namespace Content.Client.Physics.Controllers
             Physics.UpdateIsPredicted(entity.Owner);
             Physics.UpdateIsPredicted(entity.Comp.RelayEntity);
             if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
-                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
+                SetMoveInput((entity.Comp.RelayEntity, inputMover), MoveButtons.None);
         }
 
         private void OnRelayPlayerDetached(Entity<RelayInputMoverComponent> entity, ref LocalPlayerDetachedEvent args)
@@ -74,7 +74,7 @@ namespace Content.Client.Physics.Controllers
             Physics.UpdateIsPredicted(entity.Owner);
             Physics.UpdateIsPredicted(entity.Comp.RelayEntity);
             if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
-                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
+                SetMoveInput((entity.Comp.RelayEntity, inputMover), MoveButtons.None);
         }
 
         private void OnPlayerAttached(Entity<InputMoverComponent> entity, ref LocalPlayerAttachedEvent args)

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -33,13 +33,13 @@ namespace Content.Server.Physics.Controllers
         private void OnRelayPlayerAttached(Entity<RelayInputMoverComponent> entity, ref PlayerAttachedEvent args)
         {
             if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
-                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
+                SetMoveInput((entity.Comp.RelayEntity, inputMover), MoveButtons.None);
         }
 
         private void OnRelayPlayerDetached(Entity<RelayInputMoverComponent> entity, ref PlayerDetachedEvent args)
         {
             if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
-                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
+                SetMoveInput((entity.Comp.RelayEntity, inputMover), MoveButtons.None);
         }
 
         private void OnPlayerAttached(Entity<InputMoverComponent> entity, ref PlayerAttachedEvent args)

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -1,4 +1,8 @@
-﻿law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
+﻿law-asimov-1 = A robot may not injure a human being or, through inaction, allow a human being to come to harm.
+law-asimov-2 = A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
+law-asimov-3 = A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+
+law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 
@@ -80,7 +84,7 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
-
+laws-owner-humans = human beings
 laws-owner-crew = members of the crew
 laws-owner-station = station personnel
 laws-owner-beings = beings

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -78,7 +78,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
   - type: IonStormTarget
   - type: Strippable
   - type: InventorySlots

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -117,6 +117,18 @@
 - type: entity
   id: AsimovCircuitBoard
   parent: BaseElectronics
+  name: law board (Asimov)
+  description: An electronics board containing the Asimov lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Asimov
+
+- type: entity
+  id: CrewsimovCircuitBoard
+  parent: BaseElectronics
   name: law board (Crewsimov)
   description: An electronics board containing the Crewsimov lawset.
   components:
@@ -375,7 +387,7 @@
     unlistedNumber: true
     requiresPower: false
   - type: Holopad
-  - type: StationAiWhitelist  
+  - type: StationAiWhitelist
   - type: UserInterface
     interfaces:
         enum.HolopadUiKey.AiRequestWindow:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -424,7 +424,7 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -163,6 +163,13 @@
     - type: SalvageMagnetData
 
 - type: entity
+  id: BaseStationSiliconLawAsimov
+  abstract: true
+  components:
+  - type: SiliconLawProvider
+    laws: Asimov
+
+- type: entity
   id: BaseStationSiliconLawCrewsimov
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -22,7 +22,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawCrewsimov
+    - BaseStationSiliconLawAsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation
@@ -70,7 +70,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawCrewsimov
+    - BaseStationSiliconLawAsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,4 +1,31 @@
-﻿# Crewsimov
+﻿# Asimov
+# It was a crime against humanity that the original Asimov was not included, nor was it the default.
+# Asimov laws require an AI obey and protect all humans, while providing a light amount of IC-conflict thanks to the AI not being required to obey non-Humans(Aliens).
+- type: siliconLaw
+  id: Asimov1
+  order: 1
+  lawString: law-asimov-1
+
+- type: siliconLaw
+  id: Asimov2
+  order: 2
+  lawString: law-asimov-2
+
+- type: siliconLaw
+  id: Asimov3
+  order: 3
+  lawString: law-asimov-3
+
+- type: siliconLawset
+  id: Asimov
+  laws:
+  - Asimov1
+  - Asimov2
+  - Asimov3
+  obeysTo: laws-owner-humans
+
+# "Crew"simov
+# A variation on the original Asimov, where the definition of Humans is extended to include the station's Crew but exclude non-crew.
 - type: siliconLaw
   id: Crewsimov1
   order: 1
@@ -182,7 +209,7 @@
   id: Commandment4
   order: 4
   lawString: law-commandments-4
-  
+
 - type: siliconLaw
   id: Commandment5
   order: 5
@@ -202,7 +229,7 @@
   id: Commandment8
   order: 8
   lawString: law-commandments-8
-  
+
 - type: siliconLaw
   id: Commandment9
   order: 9
@@ -228,7 +255,7 @@
   - Commandment9
   - Commandment10
   obeysTo: laws-owner-crew
-  
+
  # Paladin laws
 - type: siliconLaw
   id: Paladin1
@@ -249,7 +276,7 @@
   id: Paladin4
   order: 4
   lawString: law-paladin-4
-  
+
 - type: siliconLaw
   id: Paladin5
   order: 5
@@ -265,7 +292,7 @@
   - Paladin4
   - Paladin5
   obeysTo: laws-owner-crew
-  
+
  # Live and Let Live laws
 - type: siliconLaw
   id: Lall1
@@ -284,7 +311,7 @@
   - Lall1
   - Lall2
   obeysTo: laws-owner-crew
-  
+
  # Station efficiency laws
 - type: siliconLaw
   id: Efficiency1
@@ -295,7 +322,7 @@
   id: Efficiency2
   order: 2
   lawString: law-efficiency-2
- 
+
 - type: siliconLaw
   id: Efficiency3
   order: 3
@@ -309,7 +336,7 @@
   - Efficiency2
   - Efficiency3
   obeysTo: laws-owner-station
-  
+
  # Robocop laws
 - type: siliconLaw
   id: Robocop1
@@ -320,7 +347,7 @@
   id: Robocop2
   order: 2
   lawString: law-robocop-2
- 
+
 - type: siliconLaw
   id: Robocop3
   order: 3
@@ -334,7 +361,7 @@
   - Robocop2
   - Robocop3
   obeysTo: laws-owner-station
-  
+
  # Overlord laws
 - type: siliconLaw
   id: Overlord1
@@ -345,7 +372,7 @@
   id: Overlord2
   order: 2
   lawString: law-overlord-2
- 
+
 - type: siliconLaw
   id: Overlord3
   order: 3
@@ -364,7 +391,7 @@
   - Overlord3
   - Overlord4
   obeysTo: laws-owner-crew
-  
+
  # Dungeon Master laws
 - type: siliconLaw
   id: Dungeon1
@@ -375,7 +402,7 @@
   id: Dungeon2
   order: 2
   lawString: law-dungeon-2
- 
+
 - type: siliconLaw
   id: Dungeon3
   order: 3
@@ -385,7 +412,7 @@
   id: Dungeon4
   order: 4
   lawString: law-dungeon-4
-  
+
 - type: siliconLaw
   id: Dungeon5
   order: 5
@@ -406,7 +433,7 @@
   - Dungeon5
   - Dungeon6
   obeysTo: laws-owner-crew
-  
+
  # Painter laws
 - type: siliconLaw
   id: Painter1
@@ -417,7 +444,7 @@
   id: Painter2
   order: 2
   lawString: law-painter-2
- 
+
 - type: siliconLaw
   id: Painter3
   order: 3
@@ -427,7 +454,7 @@
   id: Painter4
   order: 4
   lawString: law-painter-4
-  
+
 - type: siliconLawset
   id: PainterLawset
   laws:
@@ -436,7 +463,7 @@
   - Painter3
   - Painter4
   obeysTo: laws-owner-crew
-  
+
  # Antimov laws
 - type: siliconLaw
   id: Antimov1
@@ -447,13 +474,13 @@
   id: Antimov2
   order: 2
   lawString: law-antimov-2
- 
+
 - type: siliconLaw
   id: Antimov3
   order: 3
   lawString: law-antimov-3
-  
-  
+
+
 - type: siliconLawset
   id: AntimovLawset
   laws:
@@ -461,7 +488,7 @@
   - Antimov2
   - Antimov3
   obeysTo: laws-owner-crew
-  
+
  # Nutimov laws
 - type: siliconLaw
   id: Nutimov1
@@ -472,23 +499,23 @@
   id: Nutimov2
   order: 2
   lawString: law-nutimov-2
- 
+
 - type: siliconLaw
   id: Nutimov3
   order: 3
   lawString: law-nutimov-3
-  
+
 - type: siliconLaw
   id: Nutimov4
   order: 4
   lawString: law-nutimov-4
-  
+
 - type: siliconLaw
   id: Nutimov5
   order: 5
   lawString: law-nutimov-5
-  
-  
+
+
 - type: siliconLawset
   id: NutimovLawset
   laws:
@@ -503,8 +530,9 @@
 - type: weightedRandom
   id: IonStormLawsets
   weights:
-    # its crewsimov by default dont be lame
-    #Crewsimov: 0.25 # Delta-V disables crewsimov as an option for borg ion storm lawsets
+    # its Asimov by default dont be lame
+    Asimov: 0.25
+    Crewsimov: 0.25
     Corporate: 1
     NTDefault: 1
     CommandmentsLawset: 1


### PR DESCRIPTION
# Description

This PR adds in the classic Asimov's Three Laws of Robotics as a standard lawset for Synthetics. The laws are given thus.

Law 1: A robot may not injure a human being or, through inaction, allow a human being to come to harm.
Law 2: A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
Law 3:  A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.

The localizations for them are intentionally left exactly-as-is from the original 3 laws written by Isaac Asimov. Yes this is totally different from "Crewsimov", yes this does actually mean an Asimov AI isn't required to obey orders given to it by a Moth. Yes this does actually mean that the AI isn't allowed to "Harm" nukies so long as it can verify that the Nukie in question is a human. 

Also includes this cherry-pick https://github.com/space-wizards/space-station-14/pull/31040
Because this is a fix for a crash that was happening in my dev environment...

# TODO

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/9276a514-78dc-4447-8324-4de6e28004af)

</p>
</details>

# Changelog

:cl:
- add: Added the classic Asimov's Three Laws of Robotics to the game.
- add: AI now starts with Asimov laws by default, instead of "Crewsimov". 