### PR TITLE
Remove Default Scream Action

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -2,12 +2,14 @@ using Content.Server.Actions;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
 using Content.Shared.ActionBlocker;
+using Content.Shared.CCVar;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -21,6 +23,7 @@ public sealed class VocalSystem : EntitySystem
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     [ValidatePrototypeId<ReplacementAccentPrototype>]
     private const string MuzzleAccent = "mumble";
@@ -38,8 +41,9 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
     {
-        // try to add scream action when vocal comp added
-        _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
+        if (_config.GetCVar(CCVars.AllowScreamAction))
+            _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
+
         LoadSounds(uid, component);
     }
 
@@ -78,7 +82,7 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || !_config.GetCVar(CCVars.AllowScreamAction))
             return;
 
         _chat.TryEmoteWithChat(uid, component.ScreamId);

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -4,10 +4,12 @@ using Content.Server.Language;
 using Content.Server.Popups;
 using Content.Server.Speech.Components;
 using Content.Server.Speech.EntitySystems;
+using Content.Shared.CCVar;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Puppet;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Muting;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.Speech.Muting
 {
@@ -15,6 +17,7 @@ namespace Content.Server.Speech.Muting
     {
         [Dependency] private readonly LanguageSystem _languages = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly IConfigurationManager _config = default!;
 
         public override void Initialize()
         {
@@ -36,7 +39,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
         {
-            if (args.Handled)
+            if (args.Handled || !_config.GetCVar(CCVars.AllowScreamAction))
                 return;
 
             if (HasComp<MimePowersComponent>(uid))

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -100,4 +100,7 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> SiliconNpcUpdateTime =
         CVarDef.Create("silicon.npcupdatetime", 1.5f, CVar.SERVERONLY);
+
+    public static readonly CVarDef<bool> AllowScreamAction =
+        CVarDef.Create("vocal.allow_scream_action", false, CVar.SERVERONLY);
 }


### PR DESCRIPTION
# Description

This PR adds a new server configuration that disables the special Scream Action that all players spawn with. It's stupid, it's NRP. And you can still scream with the emote or emote wheel. If the config is set to false at roundstart, the Scream action simply won't spawn. 

# Changelog

:cl:
- tweak: The "Scream Action" no longer appears by default. It may be set in your server's configuration to spawn or not. 
