### PR TITLE
Update CCVars.Misc.cs

### DIFF
--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -102,5 +102,5 @@ public sealed partial class CCVars
         CVarDef.Create("silicon.npcupdatetime", 1.5f, CVar.SERVERONLY);
 
     public static readonly CVarDef<bool> AllowScreamAction =
-        CVarDef.Create("vocal.allow_scream_action", false, CVar.SERVERONLY);
+        CVarDef.Create("vocal.allow_scream_action", true, CVar.SERVERONLY);
 }


### PR DESCRIPTION
# Description

Apparently a lot of people were extremely angry that this was defaulted false.

# Changelog

:cl:
- tweak: Scream is once again by default on the action bar. The server configuration for removing it still exists however.
