### PR TITLE
1984 "Unobtainium Chemistry"

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -223,8 +223,8 @@
   reactants:
     Ambuzol:
       amount: 5
-    Epinephrine:
-      amount: 15
+    Necrosol:
+      amount: 1
     Plasma:
       amount: 5
   products:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -223,7 +223,9 @@
   reactants:
     Ambuzol:
       amount: 5
-    Omnizine:
+    Epinephrine:
+      amount: 15
+    Plasma:
       amount: 5
   products:
     AmbuzolPlus: 10
@@ -280,9 +282,9 @@
     HeartbreakerToxin:
       amount: 1
     Plasma:
-      amount: 1
-    Vestine:
-      amount: 1
+      amount: 3
+    Impedrezene:
+      amount: 3
   products:
     Lexorin: 2
 
@@ -561,7 +563,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Acetone:
       amount: 1
     Plasma:
       amount: 2
@@ -577,8 +579,10 @@
   reactants:
     Blood:
       amount: 3
-    Omnizine:
-      amount: 1
+    Ammonia:
+      amount: 10
+    Doxarubixadone:
+      amount: 2
     Cryoxadone:
       amount: 2
   products:


### PR DESCRIPTION
# Description

Making chems use Unobtainium Reagents doesn't make chemistry interesting, it makes medical gameplay boring. This PR replaces the unobtainium recipes with suitably expensive and/or complicated recipes. Have fun memorizing how to make Acetone, Ammonia and Impedrezine. 

# Changelog

:cl:
- remove: 1984'd most instances of "Unobtainium" chemistry. Chems like Necrosol that previously required normally unobtainable reagents such as Cognizine or Vestine now instead have long production chains of chems that are obtainable, but complicated to produce. Check the chemistry menu for more information.
