### PR TITLE
Arsenal Tacsuit Research

### DIFF
--- a/Resources/Locale/en-US/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/lathe/lathe-categories.ftl
@@ -4,5 +4,6 @@ lathe-category-lights = Lights
 lathe-category-mechs = Mechs
 lathe-category-parts = Parts
 lathe-category-robotics = Robotics
+lathe-category-tacsuits = Tacsuits
 lathe-category-tools = Tools
 lathe-category-weapons = Weapons

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -90,7 +90,7 @@ ent-ClothingOuterHardsuitSyndieCommander = CSA-54c - "Tianming" tacsuit
 ent-ClothingOuterHardsuitJuggernaut = CSA-80UA - "Guan Yu" tacsuit
     .desc = The pride and joy of the Cybersun-Armaments Corporation, named after an ancient Sol' War God. Commonly known throughout the galaxy as a "Juggernaut".
     Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy.
-end-ClothingOuterHardsuitJuggernautReverseEngineered = CSA-80UA - "Guan Yu" tacsuit
+ent-ClothingOuterHardsuitJuggernautReverseEngineered = CSA-80UA - "Guan Yu" tacsuit
     .desc = The pride and joy of the Cybersun-Armaments Corporation, named after an ancient Sol' War God. Commonly known throughout the galaxy as a "Juggernaut".
         Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy.
 ent-ClothingOuterHardsuitWizard = WZD-84 - "Mana" tacsuit

--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -31,6 +31,8 @@ research-technology-nonlethal-ammunition = Nonlethal Ammunition
 research-technology-practice-ammunition = Practice Ammunition
 research-technology-advanced-weapons = Advanced Weapons
 research-technology-prototype-weapons = Prototype Weapons
+research-technology-advanced-tacsuits = Advanced Tacsuits
+research-technology-prototype-tacsuits = Prototype Tacsuits
 
 research-technology-basic-robotics = Basic Robotics
 research-technology-basic-anomalous-research = Basic Anomalous Research

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -558,6 +558,7 @@
   description: A webby material.
   suffix: Full
   components:
+  - type: Material
   - type: PhysicalComposition
     materialComposition:
       WebSilk: 100

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -112,6 +112,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: Lathe
     idleState: icon
     runningState: building
@@ -279,6 +283,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: Lathe
     idleState: icon
     runningState: building
@@ -578,6 +586,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: RequireProjectileTarget
 
 - type: entity
@@ -715,6 +727,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: GuideHelp
     guides:
     - Robotics
@@ -745,6 +761,11 @@
       tags:
       - Sheet
       - RawMaterial
+      - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: Lathe
     idleState: icon
     runningState: building
@@ -957,12 +978,22 @@
       - MagazineBoxSpecialMindbreaker
       - SecurityCyberneticEyes
       - MedicalCyberneticEyes
+      - ClothingOuterHardsuitCombatStandard
+      - ClothingOuterHardsuitCombatMedical
+      - ClothingOuterHardsuitCombatRiot
+      - ClothingOuterHardsuitCombatAdvanced
+      - ClothingOuterHardsuitSyndieReverseEngineered
+      - ClothingOuterHardsuitJuggernautReverseEngineered
   - type: MaterialStorage
     whitelist:
       tags:
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
 
 - type: entity
   id: AmmoTechFab
@@ -1020,6 +1051,10 @@
           - Sheet
           - RawMaterial
           - Ingot
+          - Wooden
+          - ClothMade
+          - Gauze
+          - Metal
 
 - type: entity
   id: MedicalTechFab
@@ -1326,6 +1361,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
 
 - type: entity
   parent: [BaseLathe, BaseMaterialSiloUtilizer]
@@ -1604,6 +1643,11 @@
       tags:
       - Sheet
       - RawMaterial
+      - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: Lathe
     idleState: limbgrower_idleoff
     runningState: limbgrower_idleon

--- a/Resources/Prototypes/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Recipes/Lathes/categories.yml
@@ -23,6 +23,10 @@
   name: lathe-category-robotics
 
 - type: latheCategory
+  id: Tacsuits
+  name: lathe-category-tacsuits
+
+- type: latheCategory
   id: Tools
   name: lathe-category-tools
 

--- a/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
+++ b/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
@@ -8,6 +8,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitCombatStandard
   result: ClothingOuterHardsuitCombatStandard
+  category: Tacsuits
   completetime: 60
   materials:
      Plasteel: 3000
@@ -20,6 +21,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitCombatMedical
   result: ClothingOuterHardsuitCombatMedical
+  category: Tacsuits
   completetime: 60
   materials:
      Plasteel: 3000
@@ -33,6 +35,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitCombatRiot
   result: ClothingOuterHardsuitCombatRiot
+  category: Tacsuits
   completetime: 90
   materials:
      Plasteel: 3500
@@ -48,6 +51,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitCombatAdvanced
   result: ClothingOuterHardsuitCombatAdvanced
+  category: Tacsuits
   completetime: 120
   materials:
      Plasteel: 5000
@@ -61,6 +65,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitSyndieReverseEngineered
   result: ClothingOuterHardsuitSyndieReverseEngineered
+  category: Tacsuits
   completetime: 180
   materials:
      Plasteel: 8000
@@ -75,6 +80,7 @@
 # - type: latheRecipe
 #   id: ClothingOuterHardsuitCybersunEliteUnpainted
 #   result: ClothingOuterHardsuitCybersunEliteUnpainted
+#   category: Tacsuits
 #   completetime: 120
 #   materials:
 #      Plasteel: 8000
@@ -89,6 +95,7 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitJuggernautReverseEngineered
   result: ClothingOuterHardsuitJuggernautReverseEngineered
+  category: Tacsuits
   completetime: 300
   materials: # GOOD LUCK.
      Plasteel: 30000

--- a/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
+++ b/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
@@ -1,0 +1,101 @@
+# Tier 1 Vacsuits
+
+# Tier 2 Hardsuits
+
+# Tier 3 Hardsuits
+
+# Tier 2 Tacsuits
+- type: latheRecipe
+  id: ClothingOuterHardsuitCombatStandard
+  result: ClothingOuterHardsuitCombatStandard
+  completetime: 60
+  materials:
+     Plasteel: 3000
+     Durathread: 300
+     ReinforcedGlass: 1000
+     Uranium: 100
+     Plastic: 500
+     Gold: 100
+
+- type: latheRecipe
+  id: ClothingOuterHardsuitCombatMedical
+  result: ClothingOuterHardsuitCombatMedical
+  completetime: 60
+  materials:
+     Plasteel: 3000
+     Durathread: 300
+     ReinforcedGlass: 1000
+     Uranium: 100
+     Plastic: 500
+     Gold: 100
+
+# Unpainted variant of the Warden's tacsuit.
+- type: latheRecipe
+  id: ClothingOuterHardsuitCombatRiot
+  result: ClothingOuterHardsuitCombatRiot
+  completetime: 90
+  materials:
+     Plasteel: 3500
+     ReinforcedGlass: 1250
+     Durathread: 500
+     Plastic: 500
+     Uranium: 200
+     Gold: 200
+
+# Tier 3 Tacsuits
+
+# Notably, this is not the Head of Security's tacsuit. It's the base version that's unpainted.
+- type: latheRecipe
+  id: ClothingOuterHardsuitCombatAdvanced
+  result: ClothingOuterHardsuitCombatAdvanced
+  completetime: 120
+  materials:
+     Plasteel: 5000
+     WebSilk: 3000
+     ReinforcedGlass: 1500
+     Plastic: 1000
+     Uranium: 400
+     Gold: 400
+
+# TODO: I still need to make these "Unpainted"
+- type: latheRecipe
+  id: ClothingOuterHardsuitSyndieReverseEngineered
+  result: ClothingOuterHardsuitSyndieReverseEngineered
+  completetime: 180
+  materials:
+     Plasteel: 8000
+     WebSilk: 3000
+     ReinforcedGlass: 1500
+     Plastic: 1500
+     Uranium: 800
+     Plasma: 800
+     Gold: 600
+
+# This one's an IOU.
+# - type: latheRecipe
+#   id: ClothingOuterHardsuitCybersunEliteUnpainted
+#   result: ClothingOuterHardsuitCybersunEliteUnpainted
+#   completetime: 120
+#   materials:
+#      Plasteel: 8000
+#      WebSilk: 3000
+#      ReinforcedGlass: 1500
+#      Plastic: 1500
+#      Uranium: 800
+#      Plasma: 800
+#      Gold: 600
+
+# TODO: IOU one "Unpainted" juggsuit sprite.
+- type: latheRecipe
+  id: ClothingOuterHardsuitJuggernautReverseEngineered
+  result: ClothingOuterHardsuitJuggernautReverseEngineered
+  completetime: 300
+  materials: # GOOD LUCK.
+     Plasteel: 30000
+     ReinforcedPlasmaGlass: 4500
+     WebSilk: 3500
+     Plastic: 3000
+     Uranium: 1500
+     Gold: 1500
+     Plasma: 1000
+     Diamond: 300

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -112,19 +112,19 @@
 
 # Tier 2
 
-# TODO: Make lathe recipes for a variety of advanced tacsuits.
-# TODO: Also make the "Unpainted Gunmetal Grey" versions of the suits.
-# - type: technology
-#   id: AdvancedTacsuits
-#   name: research-technology-advanced-tacsuits
-#   icon:
-#     sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/standard.rsi
-#     state: icon
-#   discipline: Arsenal
-#   tier: 2
-#   cost: 15000
-#   recipeUnlocks:
-#   - ClothingOuterHardsuitCombatStandard
+- type: technology
+  id: AdvancedTacsuits
+  name: research-technology-advanced-tacsuits
+  icon:
+    sprite: DeltaV/Clothing/OuterClothing/Hardsuits/Combat/standard.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 2
+  cost: 15000
+  recipeUnlocks:
+  - ClothingOuterHardsuitCombatStandard
+  - ClothingOuterHardsuitCombatMedical
+  - ClothingOuterHardsuitCombatRiot
 
 - type: technology
   id: ExplosiveTechnology
@@ -172,19 +172,22 @@
 
 # Tier 3
 
-# TODO: Make lathe recipes for a variety of prototype tacsuits.
-# TODO: Also make the "Unpainted Gunmetal Grey" versions of the suits.
-# - type: technology
-#   id: PrototypeTacsuits
-#   name: research-technology-prototype-tacsuits
-#   icon:
-#     sprite: Nyanotrasen/Clothing/OuterClothing/ReverseEngineering/syndicate.rsi
-#     state: icon
-#   discipline: Arsenal
-#   tier: 3
-#   cost: 20000
-#   recipeUnlocks:
-#   - ClothingOuterHardsuitSyndieReverseEngineered
+- type: technology
+  id: PrototypeTacsuits
+  name: research-technology-prototype-tacsuits
+  icon:
+    sprite: Nyanotrasen/Clothing/OuterClothing/ReverseEngineering/syndicate.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 3
+  cost: 25000
+  recipeUnlocks:
+  - ClothingOuterHardsuitCombatAdvanced
+  - ClothingOuterHardsuitSyndieReverseEngineered
+  - ClothingOuterHardsuitJuggernautReverseEngineered
+  #- ClothingOuterHardsuitCybersunEliteUnpainted # IOU
+  technologyPrerequisites:
+  - AdvancedTacsuits
 
 - type: technology
   id: PrototypeWeapons


### PR DESCRIPTION
# Description

This PR fills in the basics for the previously commented placeholders for "Advanced Tacsuits" and "Prototype Tacsuits", both new Arsenal researches. These both unlock recipes for manufacturing tacsuits at a Security Techfab, and are an alternative method to making them outside of buying them through Cargo. Here's a genuine reason for Epistemics to consider doing Arsenal T3. 

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/697e70cb-e1da-4590-aa2b-01555b88f40d)

![image](https://github.com/user-attachments/assets/60977362-18aa-4253-9045-61129866fad7)

![image](https://github.com/user-attachments/assets/79ed2ffd-19a3-4a4d-9412-51ba96de82ac)

![image](https://github.com/user-attachments/assets/070e99d0-48d6-40ad-add5-a1e51b23f77b)

</p>
</details>

# Changelog

:cl:
- add: Added Advanced Tacsuits, and Prototype Tacsuits to Arsenal research. Along with them comes Security Techfab recipes for said tacsuits.
