### PR TITLE
Fix Possible Loadout Related Crash

### DIFF
--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -44,7 +44,7 @@ public sealed class LoadoutSystem : EntitySystem
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
-        if (ev.JobId == null
+        if (ev.JobId == null || Deleted(ev.Mob) || !Exists(ev.Mob)
             || !_protoMan.TryIndex<JobPrototype>(ev.JobId, out _)
             || !_configurationManager.GetCVar(CCVars.GameLoadoutsEnabled))
             return;


### PR DESCRIPTION
# Description

Servers are occasionally experiencing roundstart crashes, and the logs I received concerning this crash imply that LoadoutSystem is SOMEHOW being handed a player character that doesn't actually exist. Well an easy solution I guess is to just make LoadoutSystem check if the entity *factually* exists, before attempting to apply a loadout to it.

# Changelog

:cl:
- fix: Possibly fixed a crash related to Loadouts being applied to entities that don't exist.
