### PR TITLE
Fix Fent Zombies in Medbay

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -346,7 +346,6 @@ public abstract partial class SharedBuckleSystem
 
         _audio.PlayPredicted(strap.Comp.BuckleSound, strap, user);
 
-        SetBuckledTo(buckle, strap!);
         Appearance.SetData(strap, StrapVisuals.State, true);
         Appearance.SetData(buckle, BuckleVisuals.Buckled, true);
         _rotationVisuals.SetHorizontalAngle(buckle.Owner, strap.Comp.Rotation);
@@ -366,6 +365,8 @@ public abstract partial class SharedBuckleSystem
                 _standing.Down(buckle, false, false);
                 break;
         }
+
+        SetBuckledTo(buckle, strap!); // DeltaV - Allow standing system to handle Down/Stand before buckling
 
         var ev = new StrappedEvent(strap, buckle);
         RaiseLocalEvent(strap, ref ev);


### PR DESCRIPTION
(fix medbays making people go up/down if they speak)

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: The medbay fent zombie epidemic is now fixed.