### PR TITLE
BSO Changes - Headset and MedTek

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1143,6 +1143,7 @@
       - SecWatchCartridge # DeltaV: SecWatch replaces WantedList
       - LogProbeCartridge
       - NanoChatCartridge # DeltaV
+      - MedTekCartridge
 
 - type: entity
   parent: ERTLeaderPDA

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -47,7 +47,7 @@
     jumpsuit: ClothingUniformJumpsuitBlueshieldOfficer
     shoes: ClothingShoesBootsCombatFilled
     eyes: ClothingEyesGlassesMedSec
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetCentCom
     gloves: ClothingHandsGlovesCombat
     id: BlueshieldPDA
     pocket1: UniqueBlueshieldOfficerLockerTeleporter


### PR DESCRIPTION
# Description
This gives the Blueshield Officer a Central Command Headset and gives them MedTek as well (by giving ERT Leader MedTek).

The Blueshield Officer should have access to a Central Command Headset to communicate with the other Dignitaries (NTR and MAG) and to communicate with Central Command if they are the only acting Dignitary as well.

The Blueshield Officer should have access to MedTek since they already have access to their sunglasses so that they can check the injuries of an injured command without needing a health analyzer.

---

# Changelog
:cl:
- add: Added MedTek to Blushield Officer PDA.
- tweak: Blueshield Officer now has a Central Command Headset instead of an All-Access Command Headset.
