### PR TITLE
Supermatter Fixes

### DIFF
--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -68,7 +68,7 @@ namespace Content.Server.Atmos.Reactions
             {
                 var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
                 if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
-                    mixture.Temperature = (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity;
+                    mixture.Temperature = MathF.Min(Atmospherics.PlasmaUpperTemperature, (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity);
             }
 
             if (location != null)

--- a/Content.Server/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -14,7 +14,7 @@ public sealed partial class SupermatterSystem
     /// <summary>
     ///     Handle power and radiation output depending on atmospheric things.
     /// </summary>
-    private void ProcessAtmos(EntityUid uid, SupermatterComponent sm)
+    private void ProcessAtmos(EntityUid uid, SupermatterComponent sm, float frameTime)
     {
         var mix = _atmosphere.GetContainingMixture(uid, true, true);
 
@@ -104,7 +104,7 @@ public sealed partial class SupermatterSystem
                 * _config.GetCVar(CCVars.SupermatterRadsModifier);
 
         // Power * 0.55 * 0.8~1
-        var energy = sm.Power * sm.ReactionPowerModifier;
+        var energy = 2 * sm.Power * sm.ReactionPowerModifier * frameTime;
 
         // Keep in mind we are only adding this temperature to (efficiency)% of the one tile the rock is on.
         // An increase of 4°C at 25% efficiency here results in an increase of 1°C / (#tilesincore) overall.

--- a/Content.Server/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -104,6 +104,8 @@ public sealed partial class SupermatterSystem
                 * _config.GetCVar(CCVars.SupermatterRadsModifier);
 
         // Power * 0.55 * 0.8~1
+        // This has to be differentiated with respect to time, since its going to be interacting with systems
+        // that also differentiate. Basically, if we don't multiply by 2 * frameTime, the supermatter will explode faster if your server's tickrate is higher.
         var energy = 2 * sm.Power * sm.ReactionPowerModifier * frameTime;
 
         // Keep in mind we are only adding this temperature to (efficiency)% of the one tile the rock is on.

--- a/Content.Server/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/Supermatter/Systems/SupermatterSystem.cs
@@ -71,18 +71,18 @@ public sealed partial class SupermatterSystem : EntitySystem
             if (sm.UpdateAccumulator >= sm.UpdateTimer)
             {
                 sm.UpdateAccumulator -= sm.UpdateTimer;
-                Cycle(uid, sm);
+                Cycle(uid, sm, frameTime);
             }
         }
     }
 
 
-    public void Cycle(EntityUid uid, SupermatterComponent sm)
+    public void Cycle(EntityUid uid, SupermatterComponent sm, float frameTime)
     {
         sm.ZapAccumulator++;
         sm.YellAccumulator++;
 
-        ProcessAtmos(uid, sm);
+        ProcessAtmos(uid, sm, frameTime);
         HandleDamage(uid, sm);
 
         if (sm.Damage >= sm.DamageDelaminationPoint || sm.Delamming)


### PR DESCRIPTION
# Description

Supermatter was essentially interacting with atmos about 20 to 60 times faster than the atmos system was doing its own calculations, since *at least some of atmos* is differentiated with respect to time, whereas Supermatter was not. Thus supermatter was updating atmos fully every single tick, whereas elsewhere these variables were being divided by the delta time(multiply by Update(frameTime)). You can think of these equations as, "How much it is modified per unit of time", and multiplying by frameTime is the same as making it, "Per second". 

This should rather dramatically cut down on the problem Supermatter has where its seemingly going to explode every single round if even the tiniest thing goes wrong, and that nothing you could do could save it if it catches fire.

# Changelog

:cl:
- fix: Fixed the Supermatter engine math so that it actually respects the server's tickrate. It should now be SIGNIFICANTLY less likely to enter a plasma fire death spiral. If it does catch fire, just make sure coolant is being pumped into the engine, and start blasting it with a fire extinguisher. 
