### PR TITLE
Yet Another "OnPlayerSpawn" Crash Fix Attempt

### DIFF
--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -45,6 +45,7 @@ public sealed class LoadoutSystem : EntitySystem
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
         if (ev.JobId == null || Deleted(ev.Mob) || !Exists(ev.Mob)
+            || !HasComp<MetaDataComponent>(ev.Mob) // TODO: FIND THE STUPID RACE CONDITION THAT IS MAKING ME CHECK FOR THIS.
             || !_protoMan.TryIndex<JobPrototype>(ev.JobId, out _)
             || !_configurationManager.GetCVar(CCVars.GameLoadoutsEnabled))
             return;

--- a/Content.Server/Paint/PaintSystem.cs
+++ b/Content.Server/Paint/PaintSystem.cs
@@ -160,7 +160,8 @@ public sealed class PaintSystem : SharedPaintSystem
     public void Paint(EntityWhitelist? whitelist, EntityWhitelist? blacklist, EntityUid target, Color color)
     {
         if (_whitelist.IsWhitelistFail(whitelist, target)
-            || _whitelist.IsBlacklistPass(blacklist, target))
+            || _whitelist.IsBlacklistPass(blacklist, target)
+            || !HasComp<MetaDataComponent>(target)) // TODO: FIND THE STUPID RACE CONDITION THAT IS MAKING ME CHECK FOR THIS.
             return;
 
         EnsureComp<PaintedComponent>(target, out var paint);


### PR DESCRIPTION
There absolutely should not be something deleting the player characters when starting a round. 