### PR TITLE
Removes Asphyxiation From Lamia in Favor of Pierce/Poison

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/lamia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/lamia.yml
@@ -167,9 +167,8 @@
     animation: WeaponArcBite
     damage:
       types:
-        Piercing: 1
-        Poison: 2
-        Asphyxiation: 2
+        Piercing: 2
+        Poison: 3
   - type: SolutionContainerManager
     solutions:
       melee:


### PR DESCRIPTION
# Description

The asphyxiation damage was extremely temporary and it took less than a cycle to get it healed up. In the current stage where you can't strangle someone, this kind of damage is irrelevant.

Thus I have moved the 2 points of asphyx equaly to piercing and poison instead, making the lamia melee feel a bit stronger.

---

# Changelog

:cl:
- tweak: Tweaked lamia bite
