### PR TITLE
Change Time Requirements for Command Positions & Mystagogue

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -18,7 +18,7 @@
       department: Logistics # DeltaV - Logistics Department replacing Cargo
       min: 43200 #DeltaV 12 hours
     - !type:CharacterOverallTimeRequirement
-      min: 144000 #40 hrs
+      min: 108000 # 30 hours
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,8 +13,8 @@
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
       min: 90000 # DeltaV - 25 hours
-#    - !type:OverallPlaytimeRequirement
-#      time: 72000 # DeltaV - 20 hours
+    - !type:CharacterOverallTimeRequirement
+      min: 108000 # 30 hours
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -17,7 +17,7 @@
       department: Medical
       min: 43200 # DeltaV - 12 hours
     - !type:CharacterOverallTimeRequirement
-      min: 72000 # DeltaV - 20 hours
+      min: 90000 # 25 hours
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -8,8 +8,14 @@
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
       min: 54000 # DeltaV - 15 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobForensicMantis
+      min: 18000 # 5 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobLibrarian
+      min: 18000 # 5 hours
     - !type:CharacterOverallTimeRequirement
-      min: 72000 # DeltaV - 20 hours
+      min: 90000 # 25 hours
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement


### PR DESCRIPTION
# Description
Normalizes the time requirements for some of the command positions, specifically the `Logistics Officer`, `Chief Engineer`, `Chief Medical Officer`, and `Mystagogue`.

The Logistics Officer has too much overall time requirement. 40 hours compared to other positions that only have 30 and 25? Lowered it.
The Chief Engineer and CMO have their times raised since Chief Engineer should know more and CMO now has Surgery that they should know and be familiar with as well.
The Mystagogue should have a slightly higher time requirement with Psionics and should also be required to be a Mantis and Cataloguer for a minimum of 5 hours so they know how their innate abilities and how to deal with Psionics.

---

# Changelog
:cl:
- tweak: Logistics Officer now has 30 hours instead of 40 hours of time requirement overall.
- tweak: Chief Engineer and CMO have 25 hours instead of 30 hours of time requirement.
- tweak: Mystagogue now has 5 hours of time requirement as Mantis and Cataloguer.
