### PR TITLE
Fix Melee Attack Speed Again

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # hasn't specified or all
-* @sleepyyapril @VMSolidus @Remuchi
+* @sleepyyapril @Remuchi
 
 /.* @DEATHB4DEFEAT
 *.sln @DEATHB4DEFEAT
@@ -95,3 +95,13 @@
 /Content.*/ProjectileSystem @angelofallars
 /Content.*/ThrownItem @angelofallars
 /Content.*/ThrowEvent @angelofallars
+
+# Nyano Systems
+/Content.*/Weapons @VMSolidus
+/Content.*/Abilities/Psionics @VMSolidus
+/Content.*/Psionics @VMSolidus
+/Content.*/Contests @VMSolidus
+/Content.*/Carrying @VMSolidus
+
+# Physics Stuff
+/Content.*/Atmos @VMSolidus

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -105,7 +105,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         // If someone swaps to this weapon then reset its cd.
         var curTime = Timing.CurTime;
-        var minimum = curTime + TimeSpan.FromSeconds(GetAttackRate(uid, args.User, component));
+        var minimum = curTime + TimeSpan.FromSeconds(attackRate);
 
         if (minimum < component.NextAttack)
             return;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -53,16 +53,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
-    /// <summary>
-    /// Maximum amount of targets allowed for a wide-attack.
-    /// </summary>
-    public const int MaxTargets = 5;
-
-    /// <summary>
-    /// If an attack is released within this buffer it's assumed to be full damage.
-    /// </summary>
-    public const float GracePeriod = 0.05f;
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -13,7 +13,7 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Weapons/chainsaw.ogg"
-    attackRate: 3.5
+    attackRate: 0.3
     damage:
       types:
         Structural: 35


### PR DESCRIPTION
# Description

Melee Weapons were accidentally given the wrong attack speed formula again. It took me awhile of reviewing the entire history, but eventually I found the line where the wizmerge introduced a new check that used the old formula.

Also to help prevent this from happening again, I've put in a request to be set as codeowner for the relevant systems I have significantly modified.

# Changelog

:cl:
- fix: Fixed melee weapons having the wrong attack speed calculations(again)
