### PR TITLE
Don't Assume Sessions Are Real

### DIFF
--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -105,13 +105,11 @@ namespace Content.Server.Administration.Systems
 
             foreach (var (id, data) in _playerList)
             {
-                if (!data.ActiveThisRound)
+                if (!data.ActiveThisRound
+                    || !_playerManager.TryGetPlayerData(id, out var playerData)
+                    || !_playerManager.TryGetSessionById(id, out var session))
                     continue;
 
-                if (!_playerManager.TryGetPlayerData(id, out var playerData))
-                    return;
-
-                _playerManager.TryGetSessionById(id, out var session);
                 _playerList[id] = GetPlayerInfo(playerData, session);
             }
 
@@ -218,7 +216,7 @@ namespace Content.Server.Administration.Systems
             RaiseNetworkEvent(ev, playerSession.Channel);
         }
 
-        private PlayerInfo GetPlayerInfo(SessionData data, ICommonSession? session)
+        private PlayerInfo GetPlayerInfo(SessionData data, ICommonSession session)
         {
             var name = data.UserName;
             var entityName = string.Empty;


### PR DESCRIPTION
# Description

This system was just blindly assuming a session couldn't be null without proving it wasn't, and two different functions both incorrectly made this assumption. I have no idea how the hell they managed to sneak it past the compiler's null reference test. 
