### PR TITLE
Hotfix for Disk Burner Examine

### DIFF
--- a/Content.Shared/_Arcadis/Computer/DiskBurnerSystem.cs
+++ b/Content.Shared/_Arcadis/Computer/DiskBurnerSystem.cs
@@ -87,7 +87,7 @@ public sealed class DiskBurnerSystem : EntitySystem
                 missing.Add("disk");
 
             if (boardSlot.Item is null)
-                missing.Add("or");
+                missing.Add("board");
 
             args.PushMarkup(Loc.GetString("disk-burner-missing", ("missing", string.Join(", or ", missing))));
             return;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Had an aneurysm seeing this live on arcadis and webedited a fix. Fixes an issue on examining a disk burner without a board.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

no
