### PR TITLE
Better Teach Lesson Code

### DIFF
--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -19,17 +19,18 @@ public sealed class TeachLessonConditionSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<KillTrackerComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
     }
 
-    private void OnMobStateChanged(EntityUid uid, KillTrackerComponent trackerComponent, MobStateChangedEvent args)
+    private void OnMobStateChanged(MobStateChangedEvent args)
     {
-        if (args.NewMobState != trackerComponent.KillState || args.OldMobState >= args.NewMobState
+        if (args.NewMobState != MobState.Critical || args.OldMobState >= args.NewMobState
             || !TryComp<MindContainerComponent>(args.Target, out var mc) || mc.OriginalMind is not { } mindId)
             return;
 
         // If the attacker actually has the objective, we can just skip any enumeration outright.
         if (args.Origin is not null
+            && HasComp<TeachLessonConditionComponent>(args.Origin)
             && TryComp<TargetObjectiveComponent>(args.Origin, out var targetComp)
             && targetComp.Target == mindId)
         {
@@ -51,7 +52,7 @@ public sealed class TeachLessonConditionSystem : EntitySystem
 
             var distance = (userWorldPos - targetWorldPos).Length();
             if (distance > conditionComp.MaxDistance
-                || Transform(uid).MapID != Transform(args.Target).MapID)
+                || Transform(ent).MapID != Transform(args.Target).MapID)
                 continue;
 
             _codeCondition.SetCompleted(ent);

--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.DeltaV.Objectives.Components;
+using Content.Server.KillTracking;
 using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Shared.Mind.Components;
@@ -18,38 +19,42 @@ public sealed class TeachLessonConditionSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<KillTrackerComponent, MobStateChangedEvent>(OnMobStateChanged);
     }
 
     // TODO: subscribe by ref at some point in the future
-    private void OnMobStateChanged(MobStateChangedEvent args)
+    private void OnMobStateChanged(EntityUid uid, KillTrackerComponent trackerComponent, MobStateChangedEvent args)
     {
-        if (args.NewMobState != MobState.Dead)
+        if (args.NewMobState != trackerComponent.KillState || args.OldMobState >= args.NewMobState
+            || !TryComp<MindContainerComponent>(args.Target, out var mc) || mc.OriginalMind is not { } mindId)
             return;
 
-        // Get the mind of the entity that just died (if it had one)
-        // Uses OriginalMind so if someone ghosts or otherwise loses control of a mob, you can still greentext
-        if (!TryComp<MindContainerComponent>(args.Target, out var mc) || mc.OriginalMind is not {} mindId)
+        if (args.Origin is not null
+            && TryComp<TargetObjectiveComponent>(args.Origin, out var targetComp)
+            && targetComp.Target == mindId)
+        {
+            _codeCondition.SetCompleted(args.Origin!.Value);
             return;
+        }
 
         // Get all TeachLessonConditionComponent entities
         var query = EntityQueryEnumerator<TeachLessonConditionComponent, TargetObjectiveComponent>();
 
-        while (query.MoveNext(out var uid, out var conditionComp, out var targetObjective))
+        while (query.MoveNext(out var ent, out var conditionComp, out var targetObjective))
         {
             // Check if this objective's target matches the entity that died
             if (targetObjective.Target != mindId)
                 continue;
 
-            var userWorldPos = _transform.GetWorldPosition(uid);
+            var userWorldPos = _transform.GetWorldPosition(ent);
             var targetWorldPos = _transform.GetWorldPosition(args.Target);
-            
+
             var distance = (userWorldPos - targetWorldPos).Length();
             if (distance > conditionComp.MaxDistance
                 || Transform(uid).MapID != Transform(args.Target).MapID)
                 continue;
 
-            _codeCondition.SetCompleted(uid);
+            _codeCondition.SetCompleted(ent);
         }
     }
 }

--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -22,13 +22,13 @@ public sealed class TeachLessonConditionSystem : EntitySystem
         SubscribeLocalEvent<KillTrackerComponent, MobStateChangedEvent>(OnMobStateChanged);
     }
 
-    // TODO: subscribe by ref at some point in the future
     private void OnMobStateChanged(EntityUid uid, KillTrackerComponent trackerComponent, MobStateChangedEvent args)
     {
         if (args.NewMobState != trackerComponent.KillState || args.OldMobState >= args.NewMobState
             || !TryComp<MindContainerComponent>(args.Target, out var mc) || mc.OriginalMind is not { } mindId)
             return;
 
+        // If the attacker actually has the objective, we can just skip any enumeration outright.
         if (args.Origin is not null
             && TryComp<TargetObjectiveComponent>(args.Origin, out var targetComp)
             && targetComp.Target == mindId)

--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.DeltaV.Objectives.Components;
-using Content.Server.KillTracking;
 using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Shared.Mind.Components;


### PR DESCRIPTION
# Description

Thanks to Router for pointing out we can actually reuse code that is apparently just always running exclusively on player characters. So it turns out that this game actually has a system for tracking who the killer is. We can skip enumeration outright if the killer was the one who downed the player. There's still BETTER ways to do this, like subscribing to KillReportedEvent instead of MobStateChanged, but I'm a bit too zonked out to pursue that right now.