### PR TITLE
Remove Almost All Default Playtime Requirements

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -27,18 +27,6 @@
     name: ghost-role-information-listeningop-name
     description: ghost-role-information-listeningop-description
     rules: ghost-role-information-listeningop-rules
-    requirements: # Worth considering these numbers for the goal of making sure someone willing to MRP takes this.
-    - !type:CharacterOverallTimeRequirement
-      min: 259200 # 72 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 40000 # 11.1 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Civilian
-      min: 40000 # 11.1 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Command
-      min: 40000 # 11.1 hours
   - type: GhostRoleMobSpawner
     prototype: MobHumanSyndicateListener
   - type: Sprite

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -3,19 +3,6 @@
   name: job-name-chief-justice
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
-  requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobClerk
-      min: 36000 # 10 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobLawyer
-      min: 36000 # 10 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobProsecutor
-      min: 36000 # 10 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 90000 # 25 hours
-    - !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
@@ -3,9 +3,6 @@
   name: job-name-prosecutor
   description: job-description-prosecutor
   playTimeTracker: JobProsecutor
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 36000 # 10 hrs
   startingGear: ProsecutorGear
   icon: "JobIconProsecutor"
   supervisors: job-supervisors-cj

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
@@ -4,12 +4,6 @@
   name: job-name-medical-borg
   description: job-description-medical-borg
   playTimeTracker: JobMedicalBorg
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 216000 #60 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 21600 #6 hrs
   canBeAntag: false
   icon: JobIconMedicalBorg
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -101,12 +101,6 @@
     name: ghost-role-information-loneop-name
     description: ghost-role-information-loneop-description
     rules: ghost-role-information-loneop-rules
-    requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 172800 # DeltaV - 48 hours
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
-      department: Security
-      min: 36000 # DeltaV - 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -3,12 +3,6 @@
   name: job-name-guard
   description: job-description-guard
   playTimeTracker: JobPrisonGuard
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 18000
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 14400
   startingGear: PrisonGuardGear
   alwaysUseSpawner: true
   canBeAntag: false

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
@@ -3,9 +3,6 @@
   name: job-name-martialartist
   description: job-description-martialartist
   playTimeTracker: JobMartialArtist
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 #2 hours
   startingGear: MartialArtistGear
   icon: "JobIconMartialArtist"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -4,6 +4,3 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-space-ninja-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 259200 # DeltaV - 72 hours

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -4,12 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement
-    min: 108000 # DeltaV - 30 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
-    department: Security
-    min: 36000 # DeltaV - 10 hours
 
 - type: antag
   id: NukeopsMedic
@@ -17,12 +11,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-agent-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement
-    min: 108000 #  30 hours
-  - !type:CharacterDepartmentTimeRequirement
-    department: Medical
-    min: 36000 # 10 hours
 
 - type: antag
   id: NukeopsCommander
@@ -30,16 +18,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement
-    min: 216000 # DeltaV - 60 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
-    department: Security
-    min: 36000 # DeltaV - 10 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
-    department: Command
-    min: 36000 # DeltaV - 10 hours
-  - !type:CharacterWhitelistRequirement
 
 #Lone Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -4,12 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-rev-head-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 172800 # DeltaV - 48 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
-    department: Command
-    min: 36000 # DeltaV - 10 hours
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -4,9 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-initial-infected-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 43200 # DeltaV - 12 hours
 
 - type: antag
   id: Zombie

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -4,21 +4,6 @@
   description: job-description-qm
   playTimeTracker: JobQuartermaster
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
-  requirements:
-  #  - !type:RoleTimeRequirement #DeltaV
-  #    role: JobCargoTechnician
-  #    time: 21600 #6 hrs
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobSalvageSpecialist
-      min: 10800 #3 hrs
-    - !type:CharacterPlaytimeRequirement # DeltaV - Courier role time requirement
-      tracker: JobMailCarrier
-      min: 7200 # 2 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 43200 #DeltaV 12 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 108000 # 30 hours
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -3,9 +3,6 @@
   name: job-name-clown
   description: job-description-clown
   playTimeTracker: JobClown
-  requirements:
-    - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 7200 #2 hrs
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -4,12 +4,6 @@
   description: job-description-lawyer
   playTimeTracker: JobLawyer
   antagAdvantage: 2 # DeltaV - Reduced TC: Security Radio and Access
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 36000 # 10 hrs
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
-      department: Security
-      min: 14400 # 4 hours
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-cj  # Delta V - Change supervisor to chief justice

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -3,9 +3,6 @@
   name: job-name-mime
   description: job-description-mime
   playTimeTracker: JobMime
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 # DeltaV - 2 hours
   startingGear: MimeGear
   icon: "JobIconMime"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -3,9 +3,6 @@
   name: job-name-musician
   description: job-description-musician
   playTimeTracker: JobMusician
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 # DeltaV - 2 hours
   startingGear: MusicianGear
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -3,9 +3,6 @@
   name: job-name-serviceworker
   description: job-description-serviceworker
   playTimeTracker: JobServiceWorker
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 # DeltaV - 2 hours
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -3,28 +3,6 @@
   name: job-name-captain
   description: job-description-captain
   playTimeTracker: JobCaptain
-  requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 18000 # DeltaV - 5 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Engineering
-      min: 18000 # DeltaV - 5 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 18000 # DeltaV - 5 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 18000 # DeltaV - 5 hours
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Epistemics dept time requirement
-      department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 18000 # 5 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Command
-      min: 108000 # DeltaV - 30 hours
-    - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 108000 # 30 hours
-    - !type:CharacterWhitelistRequirement
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -4,21 +4,6 @@
   description: job-description-hop
   playTimeTracker: JobHeadOfPersonnel
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
-  requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobChef
-      min: 14400 # DeltaV - 4 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobBartender
-      min: 14400 # DeltaV - 4 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobJanitor
-      min: 14400 # DeltaV - 4 hours
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Civilian dept time requirement
-      department: Civilian
-      min: 72000 # 20 hours
-    - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 90000 # 25 hours
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -3,18 +3,6 @@
   name: job-name-ce
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
-  requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobAtmosphericTechnician
-      min: 36000 # DeltaV - 10 hours
-#    - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
-#      role: JobStationEngineer
-#      time: 21600 #6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Engineering
-      min: 90000 # DeltaV - 25 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 108000 # 30 hours
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -4,13 +4,6 @@
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
   antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
-  requirements:
-  - !type:CharacterOverallTimeRequirement # DeltaV - to prevent griefers from taking the role.
-      min: 14400 # 4 hours
-    # - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
-    #   department: Engineering
-    #   time: 54000 #15 hrs
-    #   inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -6,18 +6,6 @@
   description: job-description-cmo
   playTimeTracker: JobChiefMedicalOfficer
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
-  requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobChemist
-      min: 14400 #DeltaV 4 hrs
-#    - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
-#      role: JobMedicalDoctor
-#      time: 21600 #6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 43200 # DeltaV - 12 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 90000 # 25 hours
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -4,10 +4,6 @@
   name: job-name-station-ai
   description: job-description-station-ai
   playTimeTracker: JobStationAi
-  requirements:
-  - !type:CharacterPlaytimeRequirement
-    tracker: JobBorg
-    min: 18000  # 5 hrs
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
@@ -21,9 +17,6 @@
   name: job-name-borg
   description: job-description-borg
   playTimeTracker: JobBorg
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 216000 #60 hrs
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -5,17 +5,6 @@
   playTimeTracker: JobResearchDirector
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 54000 # DeltaV - 15 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobForensicMantis
-      min: 18000 # 5 hours
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobLibrarian
-      min: 18000 # 5 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 90000 # 25 hours
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -3,19 +3,6 @@
   name: job-name-hos
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
-  requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobWarden
-      min: 14400 #DeltaV 4 hrs
-  #  - !type:RoleTimeRequirement # DeltaV - No Security Officer time requirement - REIMPLEMENT WHEN MORE PEOPLE HAVE IT
-  #    role: JobDetective
-  #    time: 14400 #DeltaV 4 hrs
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
-      department: Command
-      min: 36000 # 10 hours
-    - !type:CharacterOverallTimeRequirement
-      min: 90000 # DeltaV - 25 hours
-    - !type:CharacterWhitelistRequirement
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -3,13 +3,6 @@
   name: job-name-cadet
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 14400 # DeltaV - 4 hours
-#    - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
-#      department: Security
-#      time: 54000 #15 hrs
-#      inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -3,9 +3,6 @@
   name: job-name-boxer
   description: job-description-boxer
   playTimeTracker: JobBoxer
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 #DeltaV 2 hours
   startingGear: BoxerGear
   icon: "JobIconBoxer"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -3,12 +3,6 @@
   name: job-name-psychologist
   description: job-description-psychologist
   playTimeTracker: JobPsychologist
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 36000 #DeltaV 10 hours
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 14400 #DeltaV 4 hrs
   startingGear: PsychologistGear
   icon: "JobIconPsychologist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -3,9 +3,6 @@
   name: job-name-reporter
   description: job-description-reporter
   playTimeTracker: JobReporter
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 #DeltaV 2 hours
   startingGear: ReporterGear
   icon: "JobIconReporter"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -3,9 +3,6 @@
   name: job-name-zookeeper
   description: job-description-zookeeper
   playTimeTracker: JobZookeeper
-  requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 7200 #DeltaV 2 hours
   startingGear: ZookeeperGear
   icon: "JobIconZookeeper"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/WhiteDream/Roles/Antags/blood-cultist.yml
+++ b/Resources/Prototypes/WhiteDream/Roles/Antags/blood-cultist.yml
@@ -4,9 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-blood-cultist-objective
-  requirements:
-  - !type:CharacterOverallTimeRequirement
-    min: 43200
 
 - type: startingGear
   id: BloodCultistGear


### PR DESCRIPTION
# Description

Yea so this codebase is supposed to be "Works out of the box", and that doesn't apply if every antag in the game requires 100+ hours of playtime, or that Nukies require at least 5 people readied up who each have 200+ hours of playtime. No fucking wonder we had problems where servers would always restart due to not being able to find any antags.

# Changelog

:cl:
- remove: Removed almost all of the EE DEFAULT playtime requirements. If you're a downstream, set these yourself. 
