### PR TITLE
Pathfinder And ATS Protected Grid

### DIFF
--- a/Resources/Maps/Shuttles/pathfinder.yml
+++ b/Resources/Maps/Shuttles/pathfinder.yml
@@ -19,7 +19,6 @@ entities:
     components:
     - type: MetaData
       name: Pathfinder
-    - type: ProtectedGrid
     - type: Transform
     - type: MapGrid
       chunks:

--- a/Resources/Maps/Shuttles/pathfinder.yml
+++ b/Resources/Maps/Shuttles/pathfinder.yml
@@ -19,6 +19,7 @@ entities:
     components:
     - type: MetaData
       name: Pathfinder
+    - type: ProtectedGrid
     - type: Transform
     - type: MapGrid
       chunks:

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -37,6 +37,7 @@ entities:
     components:
     - type: MetaData
       name: Automated Trade Station
+    - type: ProtectedGrid
     - type: Transform
       pos: -2.9375,-1.625
       parent: 1


### PR DESCRIPTION
# Description

This is ostensibly to prevent Salvage from moving the refinery and an ammo techfab to the Pathfinder so they can no longer hoard materials from the station, or engage in the toxic playstyle of "Let's revamp the shuttle and never contribute to the round". If you want to do that, go play Frontier.

# Changelog

:cl:
- fix: Fixed salvage being able to fuck off into space by building everything they need to play 3-man Frontier mode on the Pathfinder. The roundstart Pathfinder and ATS are now Protected Grids.
