### PR TITLE
The Great IPC Death

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -3,6 +3,11 @@
   name: job-name-captain
   description: job-description-captain
   playTimeTracker: JobCaptain
+  requirements:
+    - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+      - IPC
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -3,6 +3,11 @@
   name: job-name-hos
   description: job-description-hos
   playTimeTracker: JobHeadOfSecurity
+  requirements:
+    - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+      - IPC
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -5,9 +5,9 @@
   playTimeTracker: JobHeadOfSecurity
   requirements:
     - !type:CharacterSpeciesRequirement
-    inverted: true
-    species:
-      - IPC
+      inverted: true
+      species:
+        - IPC
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -11,6 +11,10 @@
       tracker: JobDetective
       min: 14400 # DeltaV - 4 hours
     - !type:CharacterWhitelistRequirement
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
# Description

This doesn't actually kill IPCs at all. Really, all this does is remove IPCs from HoS, Warden, and Captain. IPCs are *very* vulnerable to EMPs & these are the most important jobs where an EMP is likely due to the nature of it. I *was* planning on doing it to all of sec but that seemed excessively cruel and the vast majority are organics anyways. 

---

# TODO

- [x] Remove IPCs from Captain
- [x] Remove IPCs from Head of Security
- [x] Remove IPCs from Warden

---

# Changelog

:cl: ShirouAjisai
- tweak: Removed IPCs from Captain
- tweak: Removed IPCs from Warden
- tweak: Removed IPCs from Head of Security