### PR TITLE
Blueshield CPR Update

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -39,11 +39,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-  - !type:AddComponentSpecial
-    components:
-    - type: CPRTraining
-    - type: SurgerySpeedModifier
-      speedModifier: 1.75
+      - type: CPRTraining
   afterLoadoutSpecial:
   - !type:ModifyEnvirosuitSpecial
     charges: 8

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -39,6 +39,11 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+  - !type:AddComponentSpecial
+    components:
+    - type: CPRTraining
+    - type: SurgerySpeedModifier
+      speedModifier: 1.75
   afterLoadoutSpecial:
   - !type:ModifyEnvirosuitSpecial
     charges: 8


### PR DESCRIPTION
# Description

Blueshield gets the same CPR trait that doctors and the Corpsman get. SOP says he's responsible for first aid on command so this reflects that. Plus, wouldn't it make sense for a highly-trained bodyguard to know basic CPR???

---

# TODO

- [x] Give BSO the CPR trait

# Changelog

:cl: ShirouAjisai
- add: Blueshield Officer now has CPR as a roundstart trait.