### PR TITLE
Plasmaman Hotfix + Other Fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -117,7 +117,7 @@
   - type: GasTank
     outputPressure: 5.325
     air:
-      # 36 minutes with Plasmaman lungs
+      # 37 minutes with Plasmaman lungs
       volume: 1.5
       moles:
         - 0           # oxygen
@@ -163,7 +163,7 @@
   - type: GasTank
     outputPressure: 5.325
     air:
-      # 60 minutes with Plasmaman lungs
+      # 62 minutes with Plasmaman lungs
       volume: 1.5
       moles:
         - 0           # oxygen
@@ -260,9 +260,9 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.3
+    outputPressure: 5.325
     air:
-      # 6 minutes of agony
+      # 125.2 minutes with Plasmaman lungs
       volume: 5
       moles:
         - 0           # oxygen
@@ -270,13 +270,3 @@
         - 0           # CO2
         - 2.051379050 # plasma
       temperature: 293.15
-
-- type: entity
-  id: PlasmaTankFilledInternals
-  parent: PlasmaTankFilled
-  name: plasma tank
-  suffix: Filled, Plasmaman Internals
-  components:
-  - type: GasTank
-    # 120 minutes with Plasmaman lungs
-    outputPressure: 5.325

--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -43,3 +43,5 @@
       id: Southern
     - type: trait
       id: ScottishAccent
+    - type: trait
+      id: SkeletonAccent

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -19,10 +19,8 @@
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
-      maxRange:
-        min: 1
-        max: 3
-      playerRatio: 1
+      max: 3
+      playerRatio: 15
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: All

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -47,7 +47,7 @@
   weights:
     RandomTraitorAliveObjective: 1
     RandomTraitorProgressObjective: 1
-    RaiseGlimmerObjective: 0.5 # Nyanotrasen - Raise glimmer to a target amount, see Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
+    # RaiseGlimmerObjective: 0.5 # Nyanotrasen - Raise glimmer to a target amount, see Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
 
 #Thief groups
 - type: weightedRandom

--- a/Resources/Prototypes/Roles/Jobs/Fun/plasmaman_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/plasmaman_startinggear.yml
@@ -48,7 +48,7 @@
     species: [ Plasmaman ]
   equipment:
     jumpsuit: ClothingUniformEnvirosuitColorBlack # TODO: actual ninja envirosuit
-    suitstorage: PlasmaTankFilledInternals
+    suitstorage: PlasmaTankFilled
 
 # ERT starting gear
 - type: startingGear
@@ -65,7 +65,7 @@
   id: ERTPlasmamanGear
   parent: ERTPlasmamanGearNoTank
   equipment:
-    suitstorage: PlasmaTankFilledInternals
+    suitstorage: PlasmaTankFilled
 
 - type: startingGear
   id: CBURNPlasmamanGear
@@ -98,7 +98,7 @@
   - !type:CharacterSpeciesRequirement
     species: [ Plasmaman ]
   inhand:
-    - PlasmaTankFilledInternals
+    - PlasmaTankFilled
 
 - type: startingGear
   id: DeathMatchPlasmamanGear

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -350,6 +350,7 @@
       inverted: true
       species:
         - Vulpkanin # This trait functions exactly as-is for the Vulpkanin trait.
+        - Plasmaman # Plasmamen have cold immunity so this trait is unnecessary
   functions:
     - !type:TraitReplaceComponent
       components:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -18,7 +18,8 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
   productEntity: CrateCybersunMaulerBundle
   cost:
-    Telecrystal: 130 # Einstein Engines - 1/5th the price due to no telecrystal rework
+    Telecrystal: 105 # Einstein Engines - lower the price due to no telecrystal rework
+                     # cost reduced such that nukies can still only buy one with all pooled nukies' TC
   categories:
   - UplinkAllies
   conditions:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -7,7 +7,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: darkgygax }
   productEntity: CrateCybersunDarkGygaxBundle
   cost:
-    Telecrystal: 400
+    Telecrystal: 80 # Einstein Engines -  1/5th the price due to no telecrystal rework
   categories:
   - UplinkAllies
 
@@ -18,7 +18,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
   productEntity: CrateCybersunMaulerBundle
   cost:
-    Telecrystal: 650
+    Telecrystal: 130 # Einstein Engines - 1/5th the price due to no telecrystal rework
   categories:
   - UplinkAllies
   conditions:


### PR DESCRIPTION
# Description

- Added the `SkeletonAccent` trait to the `TraitsAccents` item group prototype (was mistakenly not included)
- Set all plasma tank's output pressure to 5.325 (was 21.3), same as the smaller plasma internals tank
  - Apparently the Output Pressure is not really meaningful for engineering on plasma tanks so this is just a QoL feature for plasmamen
- Prevent plasmamen from taking the Temperature Tolerance trait that is useless due to their cold immunity.
- Fix price of uplink mechs due to lack of https://github.com/Goob-Station/Goob-Station/pull/332
  - We absolutely want to bring the Telecrystal Rework here, but for now reduce the price Pending Rework™.
- https://github.com/space-wizards/space-station-14/pull/30393 (cherry-picked from Wizden)
- Disable the Raise Glimmer objective due to the glimmer rework.

## Media

**Plasma Tank Output Pressure**
<img width=300px src="https://github.com/user-attachments/assets/4632a93d-25b9-4b16-b941-d7d2b39c2d77">

**Uplink Mechs**
<img width=300px src="https://github.com/user-attachments/assets/6494d693-ca01-497d-a1bf-784058ffc1f6">

# Changelog

:cl: Skubman
- tweak: All plasma tanks of all kinds now have the correct output pressure for use as Plasmamen internals.
- tweak: Plasmamen can no longer select the Temperature Tolerance trait which has no effect since they are already immune to Cold damage.
- fix: Reduced the price of mechs on the uplink.
- fix: Thief game rule now properly selects more than one thief.
- remove: Remove the Raise Glimmer To 500 traitor objective.