### PR TITLE
Fix Plasmaman Temperature Perma-Slow

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/plasmaman.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/plasmaman.yml
@@ -116,7 +116,7 @@
   - type: Inventory
     templateId: plasmaman
   - type: Temperature
-    heatDamageThreshold: 313    # 40 celsius, -12 from base heat damage threshold
+    heatDamageThreshold: 308    # 35 celsius, -17 from base heat damage threshold
     currentTemperature: 270.15  # -3 celsius
     specificHeat: 46
     coldDamage:
@@ -125,6 +125,9 @@
     heatDamage:
       types:
         Heat: 3
+  - type: TemperatureSpeed
+    thresholds:
+      243: 0.8
   - type: ThermalRegulator
     normalBodyTemperature: 270.15
   - type: Flammable


### PR DESCRIPTION
# Description

Fixed plasmamen being permanently slowed after their temperature changes significantly. And slightly lowered their heat damage threshold by -5 C because why not.

Bug reported after several Plasmamen entered the same room with a different temperature and all came out with permanent movement slows.

![ahelp](https://github.com/user-attachments/assets/667d4922-e863-44ee-b724-a154fefca4da)

## Technical Details

The default `TemperatureSpeed` component has the following thresholds:
https://github.com/Simple-Station/Einstein-Engines/blob/aaadc3b7d9bf93200e03a596ce5fef159206ab88/Resources/Prototypes/Entities/Mobs/Species/base.yml#L316-L320

At 293 Kelvin it causes a 20% slow, at 280K it causes a 40% slow. Since Plasmamen have a different normal temperature of 270.15 K instead of 310.15 K, whenever their temperature changes above or below the defined thresholds they will start to be slowed permanently.

https://github.com/Simple-Station/Einstein-Engines/blob/aaadc3b7d9bf93200e03a596ce5fef159206ab88/Resources/Prototypes/Entities/Mobs/Species/plasmaman.yml#L118-L129

`SharedTemperatureSystem` only sets the temperature slowdown AFTER the temperature changes above or below a threshold, which caused this bug to go unnoticed.

https://github.com/Simple-Station/Einstein-Engines/blob/aaadc3b7d9bf93200e03a596ce5fef159206ab88/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs#L30-L51

This is fixed by setting the Plasmaman temperature speed threshold to only give a 20% slow at 243 Kelvin, -50 Kelvin less than the default threshold and way below the Plasmaman default temperature.

```yml
  - type: TemperatureSpeed
    thresholds:
      243: 0.8
```

## Changelog

:cl: Skubman
- fix: Plasmamen will no longer be slowed down near-permanently after their temperature changes.
- tweak: Slightly lowered the temperature threshold in which Plasmamen start getting Heat damage.