### PR TITLE
Fix Rsi Diff Bot Detecting Spaces in File Names

### DIFF
--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -15,9 +15,12 @@ jobs:
 
       - name: Get changed files
         id: files
-        uses: Ana06/get-changed-files@v1.2
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'space-delimited'
+          filter: | 
+            **.rsi
+            **.png
 
       - name: Diff changed RSIs
         id: diff


### PR DESCRIPTION
Ever had the rsi diff bot run and tell you there's spaces in file names in totally unrelated files? Well this should fix that.