### PR TITLE
Fix Standard Cloners Not Transferring Appearance

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Utility.cs
+++ b/Content.Server/Cloning/CloningSystem.Utility.cs
@@ -327,7 +327,9 @@ public sealed partial class CloningSystem
                 pref = pref.WithFlavorText(flavorText);
 
             _humanoidSystem.LoadProfile(mob, pref);
+            return;
         }
+        _humanoidSystem.LoadProfile(mob, pref);
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

I only just now found out that the stock cloner doesn't transfer your character's appearance. And neither does the Metem machine if you win the roll. This fixes that.

# Changelog

:cl:
- fix: Both standard Cloner, and Metem Machines(when you win the psychic willpower roll) now correctly transfer over your old character appearance.
