### PR TITLE
No More Telepathy While Unconscious

### DIFF
--- a/Content.Server/Chat/TelepathicChatSystem.cs
+++ b/Content.Server/Chat/TelepathicChatSystem.cs
@@ -80,6 +80,7 @@ public sealed partial class TelepathicChatSystem : EntitySystem
         return HasComp<TelepathyComponent>(entity)
             && !HasComp<PsionicsDisabledComponent>(entity)
             && !HasComp<PsionicInsulationComponent>(entity)
+            && !HasComp<SleepingComponent>(entity)
             && (!TryComp<MobStateComponent>(entity, out var mobstate) || mobstate.CurrentState == MobState.Alive);
     }
 


### PR DESCRIPTION
# Description

This removes the ability to use telepathy while unconscious.

# Changelog

:cl:
- remove: Removed the ability to use Telepathy while unconscious. It is now safe to sleepy-pen people who have psi powers.
