### PR TITLE
Give BSO Access to HoS Energy Sword (for Now)

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -47,6 +47,20 @@
 # Ears
 
 # Equipment
+# Blueshield Officer Weapon Selection
+# Currently just stolen from HOS until BSO gets its own unique weapon(s) 
+# There was no group for BSO weapons so I just removed the requirement, should be fine for now.
+- type: loadout
+  id: LoadoutCommandHoSEnergySword
+  category: JobsCommandBlueshieldOfficer
+  cost: 0
+  canBeHeirloom: true
+  requirements:
+   - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+  items:
+    - EnergySwordHoS
 
 # Eyes
 


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

I have no idea what I'm doing I'm sure this will all work out. Literally all it does is gives BSO access to the HOS Energy Sword because I think BSO is underwhelming in terms of combative abilities, and needs a melee option.

Also the HoS energy sword is blue and I think that would be cool for BSO to have until they have their own unique weapons.

---




# Changelog

- Add: Added HoS energy sword to BSO loadout
