### PR TITLE
Fix AgeRequirement Showing Int32 Maximum

### DIFF
--- a/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
@@ -26,7 +26,7 @@ public sealed partial class CharacterAgeRequirement : CharacterRequirement
     public int Min;
 
     [DataField]
-    public int Max = 2147483647;
+    public int Max = Int32.MaxValue;
 
     public override bool IsValid(
         JobPrototype job,
@@ -41,8 +41,15 @@ public sealed partial class CharacterAgeRequirement : CharacterRequirement
         int depth = 0
     )
     {
+        var localeString = "";
+
+        if (Max == Int32.MaxValue || Min <= 0)
+            localeString = Max == Int32.MaxValue ? "character-age-requirement-minimum-only" : "character-age-requirement-maximum-only";
+        else
+            localeString = "character-age-requirement-range";
+
         reason = Loc.GetString(
-            "character-age-requirement",
+            localeString,
             ("inverted", Inverted),
             ("min", Min),
             ("max", Max));

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -54,8 +54,8 @@ character-age-requirement-minimum-only = You must{$inverted ->
 } be at least [color=yellow]{$min}[/color] years old
 
 character-age-requirement-maximum-only = You must{$inverted ->
-    [true]{" "}not
-    *[other]{""}
+    [true]{" "}
+    *[other]{""}not
 } be older than [color=yellow]{$max}[/color] years old
 
 character-backpack-type-requirement = You must {$inverted ->

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -43,10 +43,20 @@ character-logic-xor-requirement = You must{$inverted ->
 
 
 ## Profile
-character-age-requirement = You must{$inverted ->
+character-age-requirement-range = You must{$inverted ->
     [true]{" "}not
     *[other]{""}
 } be within [color=yellow]{$min}[/color] and [color=yellow]{$max}[/color] years old
+
+character-age-requirement-minimum-only = You must{$inverted ->
+    [true]{" "}not
+    *[other]{""}
+} be at least [color=yellow]{$min}[/color] years old
+
+character-age-requirement-maximum-only = You must{$inverted ->
+    [true]{" "}not
+    *[other]{""}
+} be younger than [color=yellow]{$max}[/color] years old
 
 character-backpack-type-requirement = You must {$inverted ->
     [true] not use

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -56,7 +56,7 @@ character-age-requirement-minimum-only = You must{$inverted ->
 character-age-requirement-maximum-only = You must{$inverted ->
     [true]{" "}not
     *[other]{""}
-} be younger than [color=yellow]{$max}[/color] years old
+} be older than [color=yellow]{$max}[/color] years old
 
 character-backpack-type-requirement = You must {$inverted ->
     [true] not use

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -54,8 +54,8 @@ character-age-requirement-minimum-only = You must{$inverted ->
 } be at least [color=yellow]{$min}[/color] years old
 
 character-age-requirement-maximum-only = You must{$inverted ->
-    [true]{" "}
-    *[other]{""}not
+    [true]{""}
+    *[other]{" "}not
 } be older than [color=yellow]{$max}[/color] years old
 
 character-backpack-type-requirement = You must {$inverted ->


### PR DESCRIPTION
I did separate locales because it'd be messy otherwise.

:cl:
- fix: Loadouts will no longer show the integer limit. 