### PR TITLE
Fix Industrial Ore Processor Inheritance

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1513,23 +1513,6 @@
   - type: Lathe
     materialUseMultiplier: 0.75
     timeMultiplier: 0.5
-    staticRecipes:
-    - BluespaceCrystal
-    - NormalityCrystal
-    - SheetSteel
-    - SheetGlass1
-    - SheetRGlass
-    - SheetPlasma1
-    - SheetPGlass1
-    - SheetRPGlass1
-    - SheetPlasteel1
-    - SheetUranium1
-    - SheetUGlass1
-    - SheetRUGlass1
-    - IngotGold1
-    - IngotSilver1
-    - MaterialBananium1
-    - MaterialDiamond
 
 - type: entity
   parent: [BaseLathe, BaseMaterialSiloUtilizer]


### PR DESCRIPTION
# Description

Fixes inheritance on the industrial ore processor so that it correctly inherits its recipes from the regular ore processor. Now you can make Tungsten on your fancier ore processor with a material multiplier. 

# Changelog

:cl:
- fix: Fixed industrial ore processor not inheriting its recipes from the standard one. You are now able to make Tungsten Carbide on your upgraded ore processor.