### PR TITLE
Fix Sprites Getting Stuck Red when Quickly Damaged

### DIFF
--- a/Content.Client/Effects/ColorFlashEffectSystem.cs
+++ b/Content.Client/Effects/ColorFlashEffectSystem.cs
@@ -87,13 +87,7 @@ public sealed class ColorFlashEffectSystem : SharedColorFlashEffectSystem
                 continue;
             }
 
-            if (!TryComp(ent, out AnimationPlayerComponent? player))
-            {
-                player = (AnimationPlayerComponent) _factory.GetComponent(typeof(AnimationPlayerComponent));
-                player.Owner = ent;
-                player.NetSyncEnabled = false;
-                AddComp(ent, player);
-            }
+            var player = EnsureComp<AnimationPlayerComponent>(ent);
 
             // Need to stop the existing animation first to ensure the sprite color is fixed.
             // Otherwise we might lerp to a red colour instead.
@@ -107,23 +101,20 @@ public sealed class ColorFlashEffectSystem : SharedColorFlashEffectSystem
                 continue;
             }
 
-            if (TryComp<ColorFlashEffectComponent>(ent, out var effect))
+            // having to check lifestage because trycomp is special needs and may return a component which was shut down via RemCompDeferred.
+            // EnsureComp isn't, but we want to get the Color value stored in the component, and EnsureComp would overwrite it with the default value.
+            if (TryComp<ColorFlashEffectComponent>(ent, out var effect) && effect.LifeStage <= ComponentLifeStage.Running)
             {
                 sprite.Color = effect.Color;
             }
 
+
             var animation = GetDamageAnimation(ent, color, sprite, ev.AnimationLength);
 
-            if (animation == null)
+            if (animation == null)  
                 continue;
 
-            if (!TryComp(ent, out ColorFlashEffectComponent? comp))
-            {
-                comp = (ColorFlashEffectComponent) _factory.GetComponent(typeof(ColorFlashEffectComponent));
-                comp.Owner = ent;
-                comp.NetSyncEnabled = false;
-                AddComp(ent, comp);
-            }
+            var comp = EnsureComp<ColorFlashEffectComponent>(ent);
 
             comp.Color = sprite.Color;
             _animation.Play((ent, player), animation, AnimationKey);


### PR DESCRIPTION
# Description

If a damageable entity gets hit three times in a quick succession, it will get stuck slightly red. This effect is clientside-only, but will be present on all clients that had this happen in their PVS range. Presumably this was happening because TryComp returns the requested component even if it's shut down and is about to be removed.

---

# TODO

- [ ] Find a way to cope with the mental illness this gave me

---

<details><summary><h1>Media</h1></summary>
<p>

<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/5f9a8510-8faa-49df-9cac-b9312e330f53

</p>
</details>

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/f1d88ebb-3e6c-460d-b4cc-9e93918f1015

</p>
</details>

</p>
</details>

---

# Changelog

:cl:
- fix: Fixed damageable entities being stuck red after being damaged several times in a quick succession.

