### PR TITLE
Make SMES Not SUCK

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -31,7 +31,7 @@
     - type: Smes
     - type: UpgradeBattery
       maxChargeMultiplier: 2
-      baseMaxCharge: 240000000
+      baseMaxCharge: 120000000
     - type: UpgradePowerSupplyRamping
       scaling: Linear
       supplyRampingMultiplier: 1
@@ -100,11 +100,11 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 240MW
+  suffix: Basic, 120MW
   components:
   - type: Battery
-    maxCharge: 240000000
-    startingCharge: 240000000
+    maxCharge: 120000000
+    startingCharge: 120000000
 
 - type: entity
   parent: SMESBasic
@@ -141,8 +141,8 @@
   - type: Machine
     board: SMESAdvancedMachineCircuitboard
   - type: Battery
-    maxCharge: 480000000
-    startingCharge: 480000000
+    maxCharge: 240000000
+    startingCharge: 240000000
   - type: PowerMonitoringDevice
     group: SMES
     sourceNode: input

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -31,10 +31,10 @@
     - type: Smes
     - type: UpgradeBattery
       maxChargeMultiplier: 2
-      baseMaxCharge: 8000000
+      baseMaxCharge: 240000000
     - type: UpgradePowerSupplyRamping
       scaling: Linear
-      supplyRampingMultiplier: 1     
+      supplyRampingMultiplier: 1
     - type: Appearance
     - type: Battery
       startingCharge: 0
@@ -62,10 +62,10 @@
       voltage: High
       node: input
     - type: PowerNetworkBattery
-      maxSupply: 150000
-      maxChargeRate: 5000
-      supplyRampTolerance: 5000
-      supplyRampRate: 1000
+      maxSupply: 750000
+      maxChargeRate: 25000
+      supplyRampTolerance: 25000
+      supplyRampRate: 5000
     - type: PointLight
       radius: 1.5
       energy: 1.6
@@ -100,11 +100,11 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 8MW
+  suffix: Basic, 240MW
   components:
   - type: Battery
-    maxCharge: 8000000
-    startingCharge: 8000000
+    maxCharge: 240000000
+    startingCharge: 240000000
 
 - type: entity
   parent: SMESBasic
@@ -117,7 +117,7 @@
 - type: entity
   parent: BaseSMES
   id: SMESAdvanced
-  suffix: Advanced, 16MJ
+  suffix: Advanced, 480MJ
   name: advanced SMES
   description: An even-higher-capacity superconducting magnetic energy storage (SMES) unit.
   components:
@@ -141,8 +141,8 @@
   - type: Machine
     board: SMESAdvancedMachineCircuitboard
   - type: Battery
-    maxCharge: 16000000
-    startingCharge: 16000000
+    maxCharge: 480000000
+    startingCharge: 480000000
   - type: PowerMonitoringDevice
     group: SMES
     sourceNode: input


### PR DESCRIPTION
# Description

Seriously the power goes out within 2 minute of roundstart on most stations. This is ridiculous. Imagine having battery backups on your station, and they literally cannot provide a power buffer. This increases the power storage of SMES by 15x, going from 8MW of power, to 120MW, which is significantly more in line with reality, and their values in SS13.

# Changelog

:cl:
- tweak: Stations SMES now store 120MW of power, up from 8MW. They should actually do what they are intended to do now. 
