### PR TITLE
Flying Objects Ignore Laying Down

### DIFF
--- a/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Standing;
 
 namespace Content.Shared.Damage.Systems
 {
@@ -34,6 +35,7 @@ namespace Content.Shared.Damage.Systems
         [Dependency] private readonly MeleeSoundSystem _meleeSound = default!;
         [Dependency] private readonly IPrototypeManager _protoManager = default!;
         [Dependency] private readonly ContestsSystem _contests = default!;
+        [Dependency] private readonly StandingStateSystem _standing = default!;
 
         public override void Initialize()
         {
@@ -91,7 +93,8 @@ namespace Content.Shared.Damage.Systems
         private void OnDoHit(EntityUid uid, DamageOtherOnHitComponent component, ThrowDoHitEvent args)
         {
             if (TerminatingOrDeleted(args.Target)
-                || component.HitQuantity >= component.MaxHitQuantity)
+                || component.HitQuantity >= component.MaxHitQuantity
+                || _standing.IsDown(args.Target))
                 return;
 
             var modifiedDamage = _damageable.TryChangeDamage(args.Target, GetDamage(uid, component, args.Component.Thrower),

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using Content.Shared.Standing;
 
 namespace Content.Shared.Projectiles;
 
@@ -36,6 +37,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     public override void Initialize()
     {
@@ -145,8 +147,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
     private void OnEmbedThrowDoHit(EntityUid uid, EmbeddableProjectileComponent component, ThrowDoHitEvent args)
     {
-        if (!component.EmbedOnThrow ||
-            HasComp<ThrownItemImmuneComponent>(args.Target))
+        if (!component.EmbedOnThrow
+            || HasComp<ThrownItemImmuneComponent>(args.Target)
+            || _standing.IsDown(args.Target))
             return;
 
         Embed(uid, args.Target, null, component, args.TargetPart);
@@ -154,6 +157,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
     private void OnEmbedProjectileHit(EntityUid uid, EmbeddableProjectileComponent component, ref ProjectileHitEvent args)
     {
+        if (_standing.IsDown(args.Target))
+            return;
+
         Embed(uid, args.Target, args.Shooter, component);
 
         // Raise a specific event for projectiles.


### PR DESCRIPTION
# Description

Stops this from happening:

![0d12727a28b7792aa0e35e61a3903bc9](https://github.com/user-attachments/assets/9cdb1477-77d1-4a34-a198-52677b0127b5)

# Changelog

:cl:
- fix: Thrown objects will no longer collide with entities that are laying down(voluntarily or otherwise). This includes objects thrown by space wind, which will now fly over you once you've been critted by floor tiles.
