### PR TITLE
Tweak Lava Ore Rates

### DIFF
--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -126,19 +126,19 @@
   id: RandomOreDistributionBasalt
   weights:
     OreSteel: 20
-    OreCoal: 0.1
-    OreSpaceQuartz: 0.1
+    OreCoal: 0.8
+    OreSpaceQuartz: 0.8
     OreGold: 10
-    OrePlasma: 0.4
-    OreSilver: 0.1
-    OreUranium: 0.1
-    OreBananium: 0.1
-    OreArtifactFragment: 0.1
+    OrePlasma: 0.32
+    OreSilver: 0.8
+    OreUranium: 0.8
+    OreBananium: 0.8
+    OreArtifactFragment: 0.8
     OreBluespace: 0.5
     OreNormality: 0.3
     OreAluminium: 8
-    OreLead: 0.2
-    OreCopper: 0.2
+    OreLead: 1.6
+    OreCopper: 1.6
     OreTungsten: 5
 
 - type: weightedRandomOre

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -126,7 +126,7 @@
   id: RandomOreDistributionBasalt
   weights:
     OreSteel: 20
-    OreCoal: 0.8
+    OreCoal: 1.6
     OreSpaceQuartz: 0.8
     OreGold: 10
     OrePlasma: 0.32


### PR DESCRIPTION
# Description

This tweaks the ore rates a little for Lava planets, so that they aren't actually completely useless for getting things other than "Shitton of iron". In practice the previous ore rates would get you like, "Two sheets of glass, maybe a sheet of uranium if you were lucky" when two people were mining fulltime. They're still scarce, just not quite that ridiculously scarce.

# Changelog

:cl:
- tweak: Tweaked ore rates for lava planets so that they give more than "Two sheets of silver per 2000 sheets of iron". Ores other than Iron, Gold, and Tungsten are still scarce, just not quite that scarce. 
