### PR TITLE
More AI QOL Stuff

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -244,6 +244,10 @@
         prob: 0.3
       - id: PsiWatchCartridge
       - id: StationAiUploadCircuitboard
+      - id: AsimovCircuitBoard
+      - id: AugustineCircuitBoard
+      - id: CrewsimovCircuitBoard
+      - id: AntimovCircuitBoard
 
 - type: entity
   id: LockerResearchDirectorFilled
@@ -268,6 +272,10 @@
         prob: 0.3
       - id: PsiWatchCartridge
       - id: StationAiUploadCircuitboard
+      - id: AsimovCircuitBoard
+      - id: AugustineCircuitBoard
+      - id: CrewsimovCircuitBoard
+      - id: AntimovCircuitBoard
 
 - type: entity
   id: LockerHeadOfSecurityFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -243,6 +243,7 @@
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: PsiWatchCartridge
+      - id: StationAiUploadCircuitboard
 
 - type: entity
   id: LockerResearchDirectorFilled
@@ -266,6 +267,7 @@
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: PsiWatchCartridge
+      - id: StationAiUploadCircuitboard
 
 - type: entity
   id: LockerHeadOfSecurityFilledHardsuit

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -30,7 +30,7 @@
   components:
     - type: ComputerBoard
       prototype: ComputerAlert
-      
+
 - type: entity
   parent: BaseComputerCircuitboard
   id: AtmosMonitoringComputerCircuitboard
@@ -459,3 +459,14 @@
       state: cpu_science
     - type: ComputerBoard
       prototype: ComputerRoboticsControl
+
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: StationAiUploadCircuitboard
+  name: station ai upload console board
+  description: A computer printed circuit board for a station AI upload console.
+  components:
+    - type: Sprite
+      state: cpu_science
+    - type: ComputerBoard
+      prototype: StationAiUploadComputer

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -64,7 +64,8 @@
       path: /Audio/Ambience/Objects/gas_pump.ogg
   - type: AtmosMonitoringConsoleDevice
     navMapBlip: GasFlowRegulator
-    
+  - type: StationAiWhitelist
+
 - type: entity
   parent: GasBinaryBase
   id: GasVolumePump
@@ -115,7 +116,8 @@
     - type: WiredNetworkConnection
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasFlowRegulator
-    
+    - type: StationAiWhitelist
+
 - type: entity
   parent: GasBinaryBase
   id: GasPassiveGate
@@ -146,7 +148,7 @@
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasValve
-      
+
 - type: entity
   parent: GasBinaryBase
   id: GasValve
@@ -196,7 +198,7 @@
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasValve
-      
+
 - type: entity
   parent: GasBinaryBase
   id: SignalControlledValve
@@ -257,7 +259,7 @@
       path: /Audio/Ambience/Objects/gas_hiss.ogg
   - type: AtmosMonitoringConsoleDevice
     navMapBlip: GasValve
-      
+
 - type: entity
   parent: GasBinaryBase
   id: GasPort
@@ -288,7 +290,7 @@
       node: port
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasVentOpening
-      
+
 - type: entity
   parent: GasVentPump
   id: GasDualPortVentPump
@@ -345,7 +347,7 @@
       enabled: true
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasVentOpening
-      
+
 - type: entity
   parent: [ BaseMachine, ConstructibleMachine ]
   id: GasRecycler
@@ -408,7 +410,7 @@
     board: GasRecyclerMachineCircuitboard
   - type: AtmosMonitoringConsoleDevice
     navMapBlip: GasValve
-    
+
 - type: entity
   parent: GasBinaryBase
   id: HeatExchanger

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -72,7 +72,8 @@
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasFlowRegulator
-      
+    - type: StationAiWhitelist
+
 - type: entity
   parent: GasFilter
   id: GasFilterFlipped
@@ -162,7 +163,8 @@
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasFlowRegulator
-      
+    - type: StationAiWhitelist
+
 - type: entity
   parent: GasMixer
   id: GasMixerFlipped
@@ -263,3 +265,4 @@
       node: pneumaticvalve
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasFlowRegulator
+    - type: StationAiWhitelist

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -25,6 +25,7 @@
   - type: Wires
     boardName: wires-board-name-pa
     layoutId: ParticleAccelerator
+  - type: StationAiWhitelist
 
 # Unfinished
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -102,3 +102,4 @@
       - On
       - Off
       - Toggle
+  - type: StationAiWhitelist


### PR DESCRIPTION
# Description

Needed for antagonistic AI gameplay. Currently any variant of "Antagonistic AI" is extremely limited in their options for harming crew. Traditionally SS13 AIs would have had a larger variety of options for Harming Crew, the most iconic of which was by Plasmaflooding. With this change, AI can "Assist" in setting up Atmos by turning on pumps and configuring gas mixers to provide the station with breathable air. Or a more murderous AI can "Assist" by configuring the air supply to include plasma. 

Also whitelists the Emitters and Singularity Controller for the same purpose. 

The Research Director now starts with a spare AI Upload circuitboard, as well as 4 basic AI law boards in his locker.

I suggest writing it in your server rules whether or not plasmaflooding is acceptable for MALF AI. 

# Changelog

:cl:
- add: Station AI can now helpfully assist by configuring the station's Atmos system, in order to provide crew with breathable oxygen, and definitely not anything malicious. You can also now ask the AI to assist with the station's power by having it turn on or off the supermatter for safe operation.
- add: The Mystagogue's locker now starts with an AI Upload circuitboard, as well as 4 basic AI lawset chips in his locker.
