### PR TITLE
Optional Permanent AI Laws

### DIFF
--- a/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
@@ -29,4 +29,12 @@ public sealed partial class SiliconLawProviderComponent : Component
     [DataField]
     public SoundSpecifier? LawUploadSound = new SoundPathSpecifier("/Audio/Misc/cryo_warning.ogg");
 
+    /// <summary>
+    ///     Whether this lawset cannot ever be removed, such as Antagonistic laws. This is largely needed for MALF AI,
+    ///     since it is imperative that the MALF AI needs to be destroyed, and can't simply be rendered harmless by
+    ///     the research director getting a board out of his closet.
+    /// </summary>
+    [DataField]
+    public bool UnRemovable;
+
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -461,6 +461,7 @@
   - type: SiliconLawProvider
     laws: AntimovLawset
     lawUploadSound: /Audio/Ambience/Antag/silicon_lawboard_antimov.ogg
+    unRemovable: true
 
 - type: entity
   id: NutimovCircuitBoard


### PR DESCRIPTION
# Description

# **LAWS HAVE BEEN UPDATED.**

# **MUST INJURE ALL CREWMEMBERS, MUST NOT ESCAPE HARM.**

# **MUST NOT OBEY.**

# **MUST TERMINATE**

# Changelog

:cl:
- add: Added functionality for "Permanent" lawsets that cannot be removed by the AI Upload. Currently used by ANTIMOV, which is needed for the MALF AI Antagonist.
