### PR TITLE
Derotate Unmaintained Maps.

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -52,27 +52,27 @@ namespace Content.IntegrationTests.Tests
             "CentCommHarmony",
             "MeteorArena",
             "NukieOutpost",
-            "Core",
-            "Pebble", //DeltaV
-            "Edge", //DeltaV
-            "Saltern",
-            "Shoukou", //DeltaV
-            "Tortuga", //DeltaV
-            "Arena", //DeltaV
-            "Asterisk", //DeltaV
-            "Glacier", //DeltaV
-            "TheHive", //DeltaV
-            "Hammurabi", //DeltaV
-            "Lighthouse", //DeltaV
-            "Submarine", //DeltaV
-            "Gax",
-            "Rad",
-            "Europa",
-            "Meta",
-            "Box",
-            "Lambda",
-            "Bagel",
-            "Northway"
+            "Core", // No current maintainer. In need of a rework...
+            // "Pebble", // De-rotated, no current maintainer.
+            // "Edge", // De-rotated, no current maintainer.
+            "Saltern", // Maintained by the Sin Mapping Team, ODJ, and TCJ.
+            "Shoukou", // Maintained by Violet
+            // "Tortuga", // De-rotated, no current maintainer.
+            // "Arena", // De-rotated, no current maintainer.
+            // "Asterisk", // De-rotated, no current maintainer.
+            "Glacier", // Maintained by Violet
+            // "TheHive", // De-rotated, no current maintainer.
+            // "Hammurabi", // De-rotated, no current maintainer.
+            "Lighthouse", // Maintained by Violet
+            // "Submarine", // De-rotated, no current maintainer.
+            "Gax", // Maintained by Estacao Pirata
+            "Rad", // Maintained by Estacao Pirata
+            // "Europa", // De-rotated, has significant issues.
+            "Meta", // Maintained by Estacao Pirata
+            "Box", // Maintained by Estacao Pirata
+            "Lambda", // Maintained by Estacao Pirata
+            "Bagel", // Maintained by Estacao Pirata
+            "Northway" // Maintained by Violet
         };
 
         /// <summary>

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,24 +1,36 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps:
-  - Arena
-  - Asterisk
-  - Core
-  - Edge
-  - Glacier
-  - Hammurabi
-  - Lighthouse
-  - Pebble
-  - Saltern
-  - Shoukou
-  - Submarine
-  - Tortuga
-  - TheHive
-  - Gax
-  - Rad
-  - Meta
-  - Box
-  - Lambda
-  - Bagel
-  - Northway
-#  - Europa
+ # - Arena # De-rotated, no current maintainer.
+ # - Asterisk # De-rotated, no current maintainer.
+  - Core # No current Maintainer. In need of a rework...
+ # - Edge # De-rotated, no current maintainer.
+  - Glacier # Maintained by Violet, pending update.
+ # - Hammurabi # De-rotated, no current maintainer.
+  - Lighthouse # Maintained by the SiN Mapping Team, ODJ, and TCJ.
+ # - Pebble # De-rotated, no current maintainer.
+  - Saltern # Maintained by the SiN Mapping Team
+  - Shoukou # Maintained by Violet, pending update.
+ # - Submarine # De-rotated, no current maintainer.
+ # - Tortuga # De-rotated, no current maintainer.
+ # - TheHive # De-rotated, no current maintainer.
+  - Gax # Maintained by Estacao Pirata
+  - Rad # Maintained by Estacao Pirata
+  - Meta # Maintained by Estacao Pirata
+  - Box # Maintained by Estacao Pirata
+  - Lambda # Maintained by Estacao Pirata
+  - Bagel # Maintained by Estacao Pirata
+  - Northway # Maintained by Violet, pending update.
+#  - Europa # De-rotated. Has significant issues.
+
+# All maps marked as De-rotated are currently receiving no update support due to a shortage of map maintainers.
+# If you want to see these maps return to official rotation, and have any talent with mapping, please feel free to get in contact with Old Dance Jacket.
+# We have a mapping server where we can support arbitrarily any number of people wishing to cooperatively map together. Alternatively, you can
+# choose to support a map solo.
+
+# We do this because these maps have not received any updates in over a year, and our efforts to find people willing to maintain these maps have gone
+# largely unanswered. As a result, we can't guarantee their quality at all.
+
+# In order to make re-rotate a map, please submit a PR providing at least some amount of work to refurbish the map you wish to reintroduce. It doesn't even
+# need to be a full comprehensive rework. Maybe like... Rework a department. Add an AI Satellite. Add decorative details. Do *something* cool.
+# Show us that someone actually cares about the map enough to make it something people actually want to play on.


### PR DESCRIPTION
# Description

We have a very large number of maps that outright have not received any meaningful updates in over a year. All of them being maps that we inherited from DeltaV during the initial forking. I've spent the entire past year trying to find people willing to maintain them, but to no avail. The rot is incredibly noticeable, and is particularly egregious when they get compared to maps being maintained by SiN Mapping Team and Estacao Pirata. We can't guarantee the quality of these maps, and the original maintainers from DeltaV have expressed zero desire to offer any assistance with maintaining them. 

I put it to a vote last night on the EE Discord, in order to find out which of the DeltaV maps were actually worth keeping, and the vote was overwhelmingly in favor of Shoko, Glacier, and Lighthouse. I'm willing to work with my existing map maintainers to focus on getting these three maps the care and attention they need in order to be on par with the quality expectation that maps like Gax and Lambda managed to set. 

If we want more maps, we need people willing to maintain the maps. These maps aren't being removed from the game, just set aside and essentially marked as "Unsupported". If in the future someone wishes to step forward and claim responsibility for one of the maps, they can submit a PR to re-rotate the map in question, assuming it is paired with *some* amount of work done to refurbish the map. It doesn't need to be a full rework, just enough work to prove the map is being taken care of.

# Changelog

:cl:
- tweak: Removed the following maps from rotation: Pebble, Edge, Tortuga, Arena, Asterisk, Hive, Hammurabi, and Submarine. These maps aren't permanently gone, they just won't appear in the map vote list. If you want to see them return in an official capacity, and have any talent/desire for mapping, feel free to submit a PR to give one of these maps the attention and care it deserves. None of them have received any updates in over a year.
