### PR TITLE
Planet Maps Prep For Glacier Rework

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -70,5 +70,11 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [DataField]
         public float SmimshDistance = 0.2f;
+
+        /// <summary>
+        ///     Whether or not the shuttle calls the DoTheDinosaur function upon FTL'ing. I'm not explaining this, you owe it to yourself to do a code search for it.
+        /// </summary>
+        [DataField]
+        public bool DoTheDinosaur = true;
     }
 }

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -64,5 +64,11 @@ namespace Content.Server.Shuttles.Components
 
         [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
         public float AngularDamping = 0.05f;
+
+        /// <summary>
+        ///     How far from the shuttle's bounding box will it crush and destroy things?
+        /// </summary>
+        [DataField]
+        public float SmimshDistance = 0.2f;
     }
 }

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -49,7 +49,6 @@ namespace Content.Server.Shuttles.Components
         /// <summary>
         ///     Tracks whether or not the above "One way trip" has been taken.
         /// </summary>
-        [DataField]
         public bool OneWayTripTaken;
     }
 }

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -20,5 +20,36 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite), DataField("whitelistSpecific")]
         public List<EntityUid> FTLWhitelist = new List<EntityUid>();
+
+        /// <summary>
+        ///     How far the shuttle is allowed to jump(in meters).
+        ///     TODO: This technically won't work until this component is migrated to Shared. The client console screen will only ever know the hardcoded 512 meter constant otherwise. Fix it in ShuttleMapControl.xaml.cs when that's done.
+        /// </summary>
+        [DataField]
+        public float FTLRange = 512f;
+
+        /// <summary>
+        ///     If the shuttle is allowed to "Forcibly" land on planet surfaces, destroying anything it lands on. Used for SSTO capable shuttles.
+        /// </summary>
+        [DataField]
+        public bool FtlToPlanets;
+
+        /// <summary>
+        ///     If the shuttle is allowed to forcibly land on stations, smimshing everything it lands on. This is where the hypothetical "Nukie drop pod" comes into play.
+        /// </summary>
+        [DataField]
+        public bool IgnoreExclusionZones;
+
+        /// <summary>
+        ///     If the shuttle is only ever allowed to FTL once. Also used for the hypothetical "Nukie drop pod."
+        /// </summary>
+        [DataField]
+        public bool OneWayTrip;
+
+        /// <summary>
+        ///     Tracks whether or not the above "One way trip" has been taken.
+        /// </summary>
+        [DataField]
+        public bool OneWayTripTaken;
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -114,6 +114,12 @@ public sealed partial class ShuttleConsoleSystem
     /// </summary>
     private void ConsoleFTL(Entity<ShuttleConsoleComponent> ent, EntityCoordinates targetCoordinates, Angle targetAngle, MapId targetMap)
     {
+        if (ent.Comp.OneWayTrip && ent.Comp.OneWayTripTaken)
+        {
+            // TODO: Play a popup and a message in chat explaining you've already taken the one way trip.
+            return;
+        }
+
         var consoleUid = GetDroneConsole(ent.Owner);
 
         if (consoleUid == null)
@@ -143,7 +149,7 @@ public sealed partial class ShuttleConsoleSystem
         List<ShuttleExclusionObject>? exclusions = null;
         GetExclusions(ref exclusions);
 
-        if (!_shuttle.FTLFree(shuttleUid.Value, targetCoordinates, targetAngle, exclusions))
+        if (!_shuttle.FTLFree(shuttleUid.Value, targetCoordinates, targetAngle, exclusions, ent.Comp.FtlToPlanets, ent.Comp.IgnoreExclusionZones, ent.Comp.FTLRange))
         {
             return;
         }
@@ -163,5 +169,7 @@ public sealed partial class ShuttleConsoleSystem
         RaiseLocalEvent(ref ev);
 
         _shuttle.FTLToCoordinates(shuttleUid.Value, shuttleComp, adjustedCoordinates, targetAngle);
+        if (ent.Comp.OneWayTrip)
+            ent.Comp.OneWayTripTaken = true;
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -381,7 +381,9 @@ public sealed partial class ShuttleSystem
         var uid = entity.Owner;
         var comp = entity.Comp1;
         var xform = _xformQuery.GetComponent(entity);
-        DoTheDinosaur(xform);
+
+        if (entity.Comp2.DoTheDinosaur)
+            DoTheDinosaur(xform);
 
         comp.State = FTLState.Travelling;
         var fromMapUid = xform.MapUid;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -558,7 +558,7 @@ public sealed partial class ShuttleSystem
         comp.StateTime = StartEndTime.FromCurTime(_gameTiming, FTLCooldown);
         _console.RefreshShuttleConsoles(uid);
         _mapManager.SetMapPaused(mapId, false);
-        Smimsh(uid, xform: xform);
+        Smimsh(uid, xform: xform, smimshDistance: entity.Comp2.SmimshDistance);
 
         var ftlEvent = new FTLCompletedEvent(uid, _mapSystem.GetMap(mapId));
         RaiseLocalEvent(uid, ref ftlEvent, true);
@@ -959,7 +959,7 @@ public sealed partial class ShuttleSystem
     /// <summary>
     /// Flattens / deletes everything under the grid upon FTL.
     /// </summary>
-    private void Smimsh(EntityUid uid, FixturesComponent? manager = null, MapGridComponent? grid = null, TransformComponent? xform = null)
+    private void Smimsh(EntityUid uid, FixturesComponent? manager = null, MapGridComponent? grid = null, TransformComponent? xform = null, float smimshDistance = 0.2f)
     {
         if (!Resolve(uid, ref manager, ref grid, ref xform) || xform.MapUid == null)
             return;
@@ -981,7 +981,7 @@ public sealed partial class ShuttleSystem
 
             // Shift it slightly
             // Create a small border around it.
-            aabb = aabb.Enlarged(0.2f);
+            aabb = aabb.Enlarged(smimshDistance);
             aabbs.Add(aabb);
 
             // Handle clearing biome stuff as relevant.

--- a/Content.Server/Station/Components/StationBiomeComponent.cs
+++ b/Content.Server/Station/Components/StationBiomeComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Station.Systems;
 using Content.Shared.Parallax.Biomes;
 using Content.Shared.Parallax.Biomes.Markers;
+using Content.Shared.Procedural;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Station.Components;
@@ -19,6 +20,18 @@ public sealed partial class StationBiomeComponent : Component
     /// </summary>
     [DataField]
     public List<ProtoId<BiomeMarkerLayerPrototype>> BiomeLayers;
+
+    /// <summary>
+    ///     Whether your station comes with one or more complimentary dungeons somewhere in the world.
+    /// </summary>
+    [DataField]
+    public List<DungeonConfigPrototype> Dungeons;
+
+    [DataField]
+    public float DungeonMinDistance = 100f;
+
+    [DataField]
+    public float DungeonMaxDistance = 500f;
 
     // If null, its random
     [DataField]

--- a/Content.Server/Station/Components/StationBiomeComponent.cs
+++ b/Content.Server/Station/Components/StationBiomeComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Station.Systems;
 using Content.Shared.Parallax.Biomes;
+using Content.Shared.Parallax.Biomes.Markers;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Station.Components;
@@ -12,6 +13,12 @@ public sealed partial class StationBiomeComponent : Component
 {
     [DataField(required: true)]
     public ProtoId<BiomeTemplatePrototype> Biome = "Grasslands";
+
+    /// <summary>
+    ///     Adds a list of biome marker layers after creating the planet. Useful if you wish to make your planet station also have ores to mine.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<BiomeMarkerLayerPrototype>> BiomeLayers;
 
     // If null, its random
     [DataField]

--- a/Content.Server/Station/Systems/StationBiomeSystem.cs
+++ b/Content.Server/Station/Systems/StationBiomeSystem.cs
@@ -1,9 +1,12 @@
 using Content.Server.Parallax;
+using Content.Server.Procedural;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Shared.Parallax.Biomes;
 using Robust.Server.GameObjects;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Server.Station.Systems;
 public sealed partial class StationBiomeSystem : EntitySystem
@@ -12,6 +15,8 @@ public sealed partial class StationBiomeSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly DungeonSystem _dungeon = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -45,6 +50,15 @@ public sealed partial class StationBiomeSystem : EntitySystem
 
             biomeComp.MarkerLayers.Add(layer);
             biomeComp.ForcedMarkerLayers.Add(layer);
+        }
+        if (!TryComp(mapUid, out MapGridComponent? mapGrid))
+            return;
+
+        foreach (var dungeonProto in map.Comp.Dungeons)
+        {
+            // TODO: Pester TCJ about adding a _random.NextVector2i to Supermatter Engine, as well as adding methods for "officially" casting vector 2s as integer vectors.
+            var distVector = (Vector2i) _random.NextVector2(map.Comp.DungeonMinDistance, map.Comp.DungeonMaxDistance).Rounded();
+            _dungeon.GenerateDungeon(dungeonProto, mapUid!.Value, mapGrid, distVector, _random.Next());
         }
     }
 }

--- a/Content.Server/Station/Systems/StationBiomeSystem.cs
+++ b/Content.Server/Station/Systems/StationBiomeSystem.cs
@@ -1,17 +1,17 @@
 using Content.Server.Parallax;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
-using Content.Server.Station.Systems;
-using Robust.Shared.Map;
+using Content.Shared.Parallax.Biomes;
+using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Station.Systems;
 public sealed partial class StationBiomeSystem : EntitySystem
 {
     [Dependency] private readonly BiomeSystem _biome = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
 
     public override void Initialize()
     {
@@ -28,8 +28,23 @@ public sealed partial class StationBiomeSystem : EntitySystem
         if (station == null) return;
 
         var mapId = Transform(station.Value).MapID;
-        var mapUid = _mapManager.GetMapEntityId(mapId);
+        if (!_mapSystem.TryGetMap(mapId, out var mapUid)
+            || mapUid is null) // WHAT, IT'S LITERALLY CALLED TRYGET. WHY DO I NEED TO CHECK NULL?
+            return;
 
-        _biome.EnsurePlanet(mapUid, _proto.Index(map.Comp.Biome), map.Comp.Seed, mapLight: map.Comp.MapLightColor);
+        _biome.EnsurePlanet(mapUid!.Value, _proto.Index(map.Comp.Biome), map.Comp.Seed, mapLight: map.Comp.MapLightColor);
+
+        if (!TryComp<BiomeComponent>(mapUid, out var biomeComp))
+            return; // Yea we JUST made a biome component one line above this trycomp. It turns out I need an engine PR to retrieve the component just added.
+                    // Imagine my frustration. On the other hand AddComps like above aren't guaranteed to return a component anyway.
+
+        foreach (var layer in map.Comp.BiomeLayers)
+        {
+            if (biomeComp.MarkerLayers.Contains(layer))
+                continue;
+
+            biomeComp.MarkerLayers.Add(layer);
+            biomeComp.ForcedMarkerLayers.Add(layer);
+        }
     }
 }

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -1,15 +1,13 @@
 using Content.Shared.Parallax.Biomes.Layers;
 using Content.Shared.Parallax.Biomes.Markers;
 using Robust.Shared.GameStates;
-using Robust.Shared.Noise;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Parallax.Biomes;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(SharedBiomeSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class BiomeComponent : Component
 {
     /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -201,6 +201,44 @@
     color: "#c94242"
   - type: Computer
     board: SyndicateShuttleConsoleCircuitboard
+  - type: ShuttleConsole
+    ftlToPlanets: true
+
+- type: entity
+  parent: BaseComputerShuttle
+  id: ComputerShuttleSyndieDropPod
+  name: syndicate drop pod console
+  description: "Used to launch a drop pod. It's a one way trip, make sure you've packed your lunch."
+  components:
+  - type: Sprite
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: syndishuttle
+    - map: ["computerLayerKeys"]
+      state: syndie_key
+    - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+      state: generic_panel_open
+  - type: Tag
+    tags:
+      - Syndicate
+  - type: RadarConsole
+    maxRange: 384
+  - type: WorldLoader
+    radius: 1536
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#c94242"
+  - type: Computer
+    board: SyndicateShuttleConsoleCircuitboard
+  - type: ShuttleConsole
+    ftlToPlanets: true
+    ignoreExclusionZones: true # It can intentionally be crashed into the station, crushing whatever's underneath the target location.
+    oneWayTrip: true
 
 - type: entity
   parent: BaseComputerShuttle
@@ -233,6 +271,8 @@
     board: CargoShuttleConsoleCircuitboard
   - type: StealTarget
     stealGroup: CargoShuttleConsoleCircuitboard
+  - type: ShuttleConsole
+    ftlToPlanets: true
 
 - type: entity
   parent: BaseComputerShuttle
@@ -263,6 +303,8 @@
       board: SalvageShuttleConsoleCircuitboard
     - type: StealTarget
       stealGroup: SalvageShuttleConsoleCircuitboard
+    - type: ShuttleConsole
+      ftlToPlanets: true
 
 - type: entity
   parent: BaseComputerAiAccess


### PR DESCRIPTION
# Description

Goddamn do I love Adderall.

This PR lays the entire groundwork needed for the "Glacier Rework", and it does so by fixing every problem I could think of between FTL and StationBiome that was preventing it from being a reality. Essentially, I'm hitting several birds with one stone by refactoring both systems to be a LOT more flexible. You can technically say that this basically is also partly enabling Lavaland maps, since I conveniently included options in the StationBiomeComponent to generate dungeons. Technically a planet map should probably also have a RestrictedRangeComponent added to it so that players can't wander so far from the station that they generate a truly excessive number of entities. 

Yes, this does infact mean you can now run Nukie gamemodes on planet maps. 

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/7a3730af-c521-42d4-8abd-5aa5989c369c

</p>
</details>

---

# Changelog

:cl:
- add: Shuttles can now take off and land from planet surfaces. They however will still respect exclusion zone beacons set by stations. Maybe in the future there might be a special shuttle (drop pod) that is set to ignore these exclusion zones.
