### PR TITLE
Fixes Rejuvenation Rune to Heal Specific Damage Types Instead of Groups

### DIFF
--- a/Content.Server/WhiteDream/BloodCult/Runes/Revive/CultRuneReviveComponent.cs
+++ b/Content.Server/WhiteDream/BloodCult/Runes/Revive/CultRuneReviveComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage;
+using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 
 namespace Content.Server.WhiteDream.BloodCult.Runes.Revive;
@@ -14,9 +14,12 @@ public sealed partial class CultRuneReviveComponent : Component
     {
         DamageDict = new Dictionary<string, FixedPoint2>
         {
-            ["Brute"] = -100,
-            ["Burn"] = -100,
-            ["Heat"] = -100,
+            ["Blunt"] = -33,
+            ["Slash"] = -33,
+            ["Piercing"] = -33,
+            ["Heat"] = -33,
+            ["Cold"] = -33,
+            ["Shock"] = -33,
             ["Asphyxiation"] = -100,
             ["Bloodloss"] = -100,
             ["Poison"] = -50,


### PR DESCRIPTION
# Description

Rune of rejuvenation was trying to heal the group damage type and not the specific damage types resulting in no healing for any brutes, cold, or shock. Changed to the specific types of damage to actually heal. The healing is probably a bit low especially if you get mag dumped or laser'd but it works and can actually revive people now.

---

:cl:
- fixed: Rune of Rejuvenation to actually heal brutes, cold, and shock
