### PR TITLE
Muted Trait Gives Sign Language

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -98,7 +98,16 @@
   functions:
     - !type:TraitAddComponent
       components:
-        - type: Muted
+      - type: Muted
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+      - Sign
+      languagesUnderstood:
+      - Sign
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - SignLanguage
 
 - type: trait
   id: Uncloneable


### PR DESCRIPTION
SIGN LANGUAGE FROM MTUE

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

I didn't make this, Diggy in the goob MRP discord did, they just requested I PR it.
This change makes it so taking the Muted trait gives you access to sign language by default

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Diggy
- add: Muted trait gives sign language by default
