### PR TITLE
Telecrystal Rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -284,6 +284,36 @@
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelSyndicateHardsuitCommanderBundle
+  name: syndicate commander hardsuit bundle
+  description: "Contains the Syndicate's signature blood red hardsuit."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitSyndieCommander
+      - id: ClothingMaskGasSyndicate
+      - id: ClothingHandsGlovesCombat
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: DoubleEmergencyNitrogenTankFilled
+      - id: DoubleEmergencyPlasmaTankFilled
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelSyndicateHardsuitMedicBundle
+  name: syndicate medic hardsuit bundle
+  description: "Contains the Syndicate's signature blood red hardsuit."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitSyndieMedic
+      - id: ClothingMaskGasSyndicate
+      - id: ClothingHandsGlovesCombat
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: DoubleEmergencyNitrogenTankFilled
+      - id: DoubleEmergencyPlasmaTankFilled
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   name: syndicate elite hardsuit bundle
   description: "Contains the Syndicate's elite hardsuit, which comes with some more stuff in it."

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -8,9 +8,9 @@
   productEntity: WeaponPistolViper
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWeaponry
 
@@ -21,9 +21,9 @@
   productEntity: WeaponRevolverPythonAP
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 8 # Originally was 13 TC but was not used due to high cost
+    Telecrystal: 40
   categories:
   - UplinkWeaponry
 
@@ -35,9 +35,9 @@
   productEntity: WeaponPistolCobra
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkWeaponry
 
@@ -48,7 +48,7 @@
   description: uplink-rifle-mosin-desc
   productEntity: WeaponSniperMosin
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkWeaponry
 
@@ -59,10 +59,10 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_sword.rsi, state: icon }
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   productEntity: EnergySword
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkWeaponry
 
@@ -74,9 +74,9 @@
   productEntity: EnergyDaggerBox
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkWeaponry
 
@@ -88,9 +88,9 @@
   productEntity: ThrowingKnivesKit
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
     - UplinkWeaponry
 
@@ -102,9 +102,9 @@
   productEntity: ClothingHandsGlovesNorthStar
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkWeaponry
 
@@ -115,9 +115,9 @@
   productEntity: ToolboxElectricalTurretFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkWeaponry
   conditions:
@@ -134,9 +134,9 @@
   productEntity: EnergyShield
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 16
+    Telecrystal: 80
   categories:
   - UplinkWeaponry
   conditions:
@@ -153,9 +153,9 @@
   productEntity: BriefcaseSyndieSniperBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 30
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkWeaponry
 
@@ -167,9 +167,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledSMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 50
   cost:
-    Telecrystal: 17
+    Telecrystal: 85
   categories:
   - UplinkWeaponry
 
@@ -181,9 +181,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledShotgun
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 12
+    Telecrystal: 60
   cost:
-    Telecrystal: 20
+    Telecrystal: 100
   categories:
   - UplinkWeaponry
 
@@ -195,9 +195,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 100
   cost:
-    Telecrystal: 25
+    Telecrystal: 125
   categories:
   - UplinkWeaponry
 
@@ -209,9 +209,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 24
+    Telecrystal: 120
   cost:
-    Telecrystal: 30
+    Telecrystal: 150
   categories:
   - UplinkWeaponry
 
@@ -224,9 +224,9 @@
   productEntity: ExGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkExplosives
 
@@ -236,7 +236,7 @@
   description: uplink-flash-grenade-desc
   productEntity: GrenadeFlashBang
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkExplosives
 
@@ -246,7 +246,7 @@
   description: uplink-smoke-grenade-desc
   productEntity: SmokeGrenade
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkExplosives
 
@@ -257,9 +257,9 @@
   productEntity: SyndieMiniBomb
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
     - UplinkExplosives
 
@@ -270,9 +270,9 @@
   productEntity: SupermatterGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
     - UplinkExplosives
 
@@ -283,9 +283,9 @@
   productEntity: WhiteholeGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
     - UplinkExplosives
 
@@ -296,9 +296,9 @@
   productEntity: MobGrenadePenguin
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
     - UplinkExplosives
   conditions:
@@ -314,9 +314,9 @@
   productEntity: C4
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkExplosives
 
@@ -327,9 +327,9 @@
   productEntity: ClothingBeltMilitaryWebbingGrenadeFilled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 30
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkExplosives
   conditions:
@@ -345,9 +345,9 @@
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 40
   cost:
-    Telecrystal: 12 #you're buying bulk so its a 25% discount, so no additional random discount over it
+    Telecrystal: 60 #you're buying bulk so its a 25% discount, so no additional random discount over it
   categories:
   - UplinkExplosives
 
@@ -358,9 +358,9 @@
   productEntity: EmpGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkExplosives
 
@@ -372,9 +372,9 @@
   productEntity: PenExplodingBox
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkExplosives
 
@@ -384,7 +384,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 55
   categories:
     - UplinkExplosives
   restockTime: 1800
@@ -400,7 +400,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 55
   categories:
     - UplinkExplosives
   conditions:
@@ -416,9 +416,9 @@
   productEntity: ClusterGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 25
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkExplosives
 
@@ -429,9 +429,9 @@
   productEntity: GrenadeShrapnel
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkExplosives
 
@@ -442,9 +442,9 @@
   productEntity: GrenadeIncendiary
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkExplosives
 
@@ -455,9 +455,9 @@
   productEntity: ElectricalDisruptionKit
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
     - UplinkExplosives
 
@@ -470,7 +470,29 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: red-icon }
   productEntity: MagazinePistol
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkPistol9mmMagazineRubber
+  name: uplink-pistol-magazine-rubber-name
+  description: uplink-pistol-magazine-rubber-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolRubber
+  cost:
+    Telecrystal: 5
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkPistol9mmMagazineIncendiary
+  name: uplink-pistol-magazine-incendiary-name
+  description: uplink-pistol-magazine-incendiary-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolIncendiary
+  cost:
+    Telecrystal: 8
   categories:
   - UplinkAmmo
 
@@ -482,7 +504,29 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: red-icon }
   productEntity: MagazinePistolSubMachineGun
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazinePistolSubMachineGunRubber
+  name: uplink-pistol-magazine-c20r-rubber-name
+  description: uplink-pistol-magazine-c20r-rubber-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolSubMachineGunRubber
+  cost:
+    Telecrystal: 10
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazinePistolSubMachineGunIncendiary
+  name: uplink-pistol-magazine-c20r-incendiary-name
+  description: uplink-pistol-magazine-c20r-incendiary-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolSubMachineGunIncendiary
+  cost:
+    Telecrystal: 14
   categories:
   - UplinkAmmo
 
@@ -494,7 +538,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: red-icon }
   productEntity: MagazinePistolCaselessRifle
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkAmmo
 
@@ -506,7 +550,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi, state: icon }
   productEntity: SpeedLoaderMagnumAP
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkAmmo
 
@@ -517,7 +561,7 @@
   description: uplink-mosin-ammo-desc
   productEntity: MagazineBoxLightRifle
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkAmmo
 
@@ -528,7 +572,7 @@
   description: uplink-sniper-ammo-desc
   productEntity: MagazineBoxAntiMateriel
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkAmmo
 
@@ -538,7 +582,7 @@
   description: uplink-ammo-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateAmmoFilled
   cost:
-    Telecrystal: 15
+    Telecrystal: 75
   categories:
   - UplinkAmmo
   conditions:
@@ -561,9 +605,9 @@
   productEntity: HypopenBox
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkChemicals
 
@@ -575,9 +619,9 @@
   productEntity: HypoDartBox
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkChemicals
 
@@ -589,9 +633,9 @@
   productEntity: ChemicalSynthesisKit
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkChemicals
 
@@ -602,7 +646,7 @@
   icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
   productEntity: ClothingBackpackDuffelZombieBundle
   cost:
-    Telecrystal: 40
+    Telecrystal: 200
   categories:
   - UplinkChemicals
   conditions:
@@ -622,9 +666,9 @@
   productEntity: NocturineChemistryBottle
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkChemicals
 
@@ -635,9 +679,9 @@
   productEntity: MedkitCombatFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 5
+    Telecrystal: 20
   categories:
   - UplinkChemicals
 
@@ -648,9 +692,9 @@
   productEntity: CombatMedipen
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 5
   cost:
-    Telecrystal: 4
+    Telecrystal: 10
   categories:
   - UplinkChemicals
 
@@ -661,9 +705,9 @@
   productEntity: Stimpack
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkChemicals
 
@@ -674,9 +718,9 @@
   productEntity: StimkitFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 40
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkChemicals
 
@@ -687,9 +731,9 @@
   productEntity: CigPackSyndicate
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkChemicals
 
@@ -700,9 +744,9 @@
   productEntity: ClothingBackpackDuffelSyndicateMedicalBundleFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 16
+    Telecrystal: 80
   cost:
-    Telecrystal: 24
+    Telecrystal: 120
   categories:
   - UplinkChemicals
   conditions:
@@ -724,9 +768,9 @@
   productEntity: AgentIDCard
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkDeception
 
@@ -737,9 +781,9 @@
   productEntity: StealthBox
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
   - UplinkDeception
 
@@ -750,9 +794,9 @@
   productEntity: ChameleonProjector
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 7
+    Telecrystal: 35
   categories:
   - UplinkDeception
 
@@ -764,9 +808,9 @@
   productEntity: BoxEncryptionKeySyndie # Two for the price of one
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkDeception
 
@@ -777,7 +821,7 @@
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: ai_label }
   productEntity: EncryptionKeyBinarySyndicate
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkDeception
 
@@ -787,7 +831,7 @@
   description: uplink-cyberpen-desc
   productEntity: CyberPen
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkDeception
 
@@ -797,7 +841,7 @@
   description: uplink-decoy-disk-desc
   productEntity: NukeDiskFake
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkDeception
 
@@ -808,9 +852,9 @@
   productEntity: LanternFlash
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkDeception
 
@@ -821,9 +865,9 @@
   productEntity: BriefcaseSyndieLobbyingBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkDeception
   conditions:
@@ -838,9 +882,9 @@
   productEntity: BriefcaseSyndieLobbyingBundlePlasmamanFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkDeception
   conditions:
@@ -866,7 +910,7 @@
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
   discountCategory: usualDiscounts
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkDeception
 
@@ -877,9 +921,9 @@
   productEntity: SyndicateBombFake
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkDeception
 
@@ -892,9 +936,9 @@
   productEntity: Emag
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 2 # DV
+    Telecrystal: 10
   cost:
-    Telecrystal: 4 # DV was 8, can no longer emag doors
+    Telecrystal: 20
   categories:
   - UplinkDisruption
 
@@ -905,9 +949,9 @@
   productEntity: RadioJammer
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkDisruption
 
@@ -918,9 +962,9 @@
   productEntity: BorgModuleSyndicateWeapon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
   - UplinkDisruption
 
@@ -932,9 +976,9 @@
   icon: { sprite: /Textures/Objects/Specific/Robotics/borgmodule.rsi, state: syndicateborgbomb }
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkDisruption
 
@@ -944,7 +988,7 @@
   description: uplink-soap-desc
   productEntity: SoapSyndie
   cost:
-    Telecrystal: 1
+    Telecrystal: 5
   categories:
   - UplinkDisruption
 
@@ -955,9 +999,9 @@
   productEntity: SlipocalypseClusterSoap
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkDisruption
 
@@ -968,9 +1012,9 @@
   productEntity: ToolboxSyndicateFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkDisruption
 
@@ -981,9 +1025,9 @@
   productEntity: SyndicateJawsOfLife
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkDisruption
 
@@ -994,9 +1038,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledMedical
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkDisruption
 
@@ -1007,9 +1051,9 @@
   productEntity: PowerSink
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkDisruption
   conditions:
@@ -1024,7 +1068,7 @@
   description: uplink-super-surplus-bundle-desc
   productEntity: CrateSyndicateSuperSurplusBundle
   cost:
-    Telecrystal: 40
+    Telecrystal: 200
   categories:
   - UplinkDisruption
   conditions:
@@ -1044,9 +1088,9 @@
   productEntity: SingularityBeacon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
     - UplinkDisruption
 
@@ -1060,9 +1104,9 @@
   productEntity: BoxHoloparasite
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 40
   cost:
-    Telecrystal: 14
+    Telecrystal: 70
   categories:
   - UplinkAllies
   conditions:
@@ -1079,9 +1123,9 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 7
+    Telecrystal: 35
   cost:
-    Telecrystal: 16
+    Telecrystal: 80
   categories:
   - UplinkAllies
   conditions:
@@ -1097,7 +1141,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   cost:
-    Telecrystal: 16
+    Telecrystal: 80
   categories:
   - UplinkAllies
   conditions:
@@ -1113,7 +1157,7 @@
   productEntity: ReinforcementRadioSyndicateCyborgAssault
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
-    Telecrystal: 65
+    Telecrystal: 325
   categories:
     - UplinkAllies
   conditions:
@@ -1130,9 +1174,9 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-ancestor }
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkAllies
   conditions:
@@ -1149,9 +1193,9 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-ancestor }
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkAllies
   conditions:
@@ -1167,9 +1211,9 @@
   productEntity: DehydratedSpaceCarp
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkAllies
 
@@ -1181,9 +1225,9 @@
   productEntity: ReinforcementRadioSyndicateSyndiCat
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkAllies
 
@@ -1197,9 +1241,9 @@
   productEntity: StorageImplanter
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
     - UplinkImplants
   conditions:
@@ -1216,9 +1260,9 @@
   productEntity: FreedomImplanter
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
     - UplinkImplants
 
@@ -1230,9 +1274,9 @@
   productEntity: ScramImplanter
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 6 # it's a gamble that may kill you easily so 6 TC per 2 uses, second one more of a backup
+    Telecrystal: 30 # it's a gamble that may kill you easily so 6 TC per 2 uses, second one more of a backup
   categories:
     - UplinkImplants
 
@@ -1244,9 +1288,9 @@
   productEntity: DnaScramblerImplanter
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
     - UplinkImplants
 
@@ -1258,9 +1302,9 @@
   productEntity: EmpImplanter
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
     - UplinkImplants
 
@@ -1271,7 +1315,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
   productEntity: MicroBombImplanter
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkImplants
   conditions:
@@ -1291,7 +1335,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
   productEntity: MacroBombImplanter
   cost:
-    Telecrystal: 13
+    Telecrystal: 65
   categories:
     - UplinkImplants
   conditions:
@@ -1311,7 +1355,7 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkImplants
   conditions:
@@ -1328,9 +1372,9 @@
   productEntity: UplinkImplanter
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkImplants
   conditions:
@@ -1345,7 +1389,7 @@
   description: uplink-deathrattle-implant-desc
   productEntity: BoxDeathRattleImplants
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkImplants
   conditions:
@@ -1367,9 +1411,9 @@
   productEntity: JetpackBlackFilled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkWearables
 
@@ -1380,9 +1424,9 @@
   productEntity: ClothingMaskGasVoiceChameleon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkWearables
 
@@ -1396,9 +1440,9 @@
   icon: { sprite: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi, state: icon }
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkWearables
 
@@ -1409,9 +1453,9 @@
   productEntity: ClothingShoesChameleonNoSlips
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkWearables
 
@@ -1422,9 +1466,9 @@
   productEntity: ThievingGloves
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkWearables
 
@@ -1435,9 +1479,9 @@
   productEntity: ClothingOuterVestWeb
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWearables
 
@@ -1448,9 +1492,9 @@
   productEntity: ClothingShoesBootsMagSyndie
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkWearables
 
@@ -1462,9 +1506,9 @@
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkWearables
 
@@ -1476,9 +1520,9 @@
   productEntity: ClothingOuterHardsuitCarp
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 8
+    Telecrystal: 40
   categories:
   - UplinkWearables
 
@@ -1490,9 +1534,37 @@
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   cost:
-    Telecrystal: 10
+    Telecrystal: 50
+  categories:
+  - UplinkWearables
+
+- type: listing
+  id: UplinkHardsuitSyndieMedic
+  name: uplink-hardsuit-syndie-medic-name
+  description: uplink-hardsuit-syndie-medic-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateHardsuitMedicBundle
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 20
+  cost:
+    Telecrystal: 50
+  categories:
+  - UplinkWearables
+
+- type: listing
+  id: UplinkHardsuitSyndieCommander
+  name: uplink-hardsuit-syndie-commander-name
+  description: uplink-hardsuit-syndie-commander-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateHardsuitCommanderBundle
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 25
+  cost:
+    Telecrystal: 55
   categories:
   - UplinkWearables
 
@@ -1502,7 +1574,7 @@
   description: uplink-clothing-conducting-gloves-desc
   productEntity: ClothingHandsGlovesConducting
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkWearables
   conditions:
@@ -1523,9 +1595,9 @@
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 7
+    Telecrystal: 35
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkWearables
 
@@ -1537,9 +1609,9 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 40
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkWearables
 
@@ -1549,7 +1621,7 @@
   description: uplink-clothing-eyes-hud-syndicate-desc
   productEntity: ClothingEyesHudSyndicate
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
     - UplinkWearables
   conditions:
@@ -1569,9 +1641,9 @@
   productEntity: ClothingEyesNightVisionGogglesSyndie
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWearables
   conditions:
@@ -1587,9 +1659,9 @@
   productEntity: ClothingEyesNightVisionGogglesNukie
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWearables
   conditions:
@@ -1605,9 +1677,9 @@
   productEntity: ClothingEyesThermalVisionGogglesSyndie
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWearables
   conditions:
@@ -1623,9 +1695,9 @@
   productEntity: ClothingEyesThermalVisionGogglesNukie
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkWearables
   conditions:
@@ -1643,7 +1715,7 @@
   productEntity: RubberStampSyndicate
   discountCategory: rareDiscounts
   cost:
-    Telecrystal: 1
+    Telecrystal: 3
   categories:
   - UplinkPointless
 
@@ -1656,9 +1728,9 @@
   productEntity: GatfruitSeeds
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkJob
   conditions:
@@ -1673,9 +1745,9 @@
   productEntity: ClothingHandsGlovesBoxingRigged
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
     - UplinkJob
   conditions:
@@ -1690,9 +1762,9 @@
   productEntity: ClothingHandsGlovesBoxingRigged
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
     - UplinkJob
   conditions:
@@ -1707,9 +1779,9 @@
   productEntity: BibleNecronomicon
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkJob
   conditions:
@@ -1728,9 +1800,9 @@
   productEntity: HolyHandGrenade
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 14
+    Telecrystal: 70
   cost:
-    Telecrystal: 20
+    Telecrystal: 100
   categories:
   - UplinkJob
   conditions:
@@ -1745,9 +1817,9 @@
   productEntity: RevolverCapGunFake
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 25
   cost:
-    Telecrystal: 9
+    Telecrystal: 45
   categories:
   - UplinkJob
   conditions:
@@ -1764,9 +1836,9 @@
   productEntity: TrashBananaPeelExplosiveUnarmed
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 5
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkJob
   conditions:
@@ -1781,9 +1853,9 @@
   productEntity: ClusterBananaPeel
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 15
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkJob
   conditions:
@@ -1799,9 +1871,9 @@
   productEntity: BoxHoloclown
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 30
   cost:
-    Telecrystal: 12
+    Telecrystal: 60
   categories:
   - UplinkJob
   conditions:
@@ -1815,10 +1887,10 @@
   description: uplink-hot-potato-desc
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   productEntity: HotPotato
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkJob
   conditions:
@@ -1836,9 +1908,9 @@
   productEntity: WeaponPistolCHIMPUpgradeKit
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 4
+    Telecrystal: 20
   categories:
   - UplinkJob
   conditions:
@@ -1853,9 +1925,9 @@
   productEntity: WetFloorSignMineExplosive
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 5 # was 4, with my buff made it 5 to be closer to minibomb -panzer
+    Telecrystal: 25
   categories:
   - UplinkJob
   conditions:
@@ -1874,10 +1946,10 @@
   icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 20
   productEntity: SyndicateSpongeBox
   cost:
-    Telecrystal: 7
+    Telecrystal: 35
   categories:
   - UplinkJob
   conditions:
@@ -1897,9 +1969,9 @@
   productEntity: CaneSheathFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 5
+    Telecrystal: 25
   categories:
   - UplinkJob
   conditions:
@@ -1919,9 +1991,9 @@
   productEntity: CombatBakeryKit
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 10
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkJob
   conditions:
@@ -1936,7 +2008,7 @@
   description: uplink-emp-flashlight-desc
   productEntity: FlashlightEmp
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
     - UplinkAllies
 

--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -5,7 +5,7 @@
   productEntity: ReinforcementRadioSyndicateNukieMouse
   icon: { sprite: DeltaV/Objects/Devices/communication.rsi, state: cheese-radio }
   cost:
-    Telecrystal: 3
+    Telecrystal: 15
   categories:
   - UplinkAllies
 
@@ -15,7 +15,7 @@
   description: uplink-bionic-syrinx-implanter-desc
   productEntity: BionicSyrinxImplanter
   cost:
-    Telecrystal: 2
+    Telecrystal: 10
   categories:
   - UplinkImplants
   conditions:
@@ -33,7 +33,7 @@
   description: uplink-doorjack-desc
   productEntity: Doorjack
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkDisruption
 
@@ -46,8 +46,8 @@
     entity: BaseBallBatHomeRun
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 30
   cost:
-    Telecrystal: 16
+    Telecrystal: 80
   categories:
   - UplinkWeaponry

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -78,7 +78,7 @@
   components:
   - type: Store
     balance:
-      Telecrystal: 20
+      Telecrystal: 100
 
 - type: entity
   parent: BaseUplinkRadio
@@ -87,7 +87,7 @@
   components:
   - type: Store
     balance:
-      Telecrystal: 25
+      Telecrystal: 125
 
 #this uplink MUST be used for nukeops, as it has the tag for filtering the listing.
 - type: entity
@@ -97,7 +97,7 @@
   components:
   - type: Store
     balance:
-      Telecrystal: 40
+      Telecrystal: 250 # 5x TC, +cost of a tacsuit they no longer spawn with.
   - type: Tag
     tags:
     - NukeOpsUplink
@@ -109,7 +109,7 @@
   components:
   - type: Store
     balance:
-      Telecrystal: 60
+      Telecrystal: 350 # 5x TC, +cost of a tacsuit they no longer spawn with.
   - type: Tag
     tags:
     - NukeOpsUplink

--- a/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
@@ -4,7 +4,7 @@
   description: uplink-kanabou-desc
   productEntity: Kanabou
   cost:
-    Telecrystal: 10
+    Telecrystal: 50
   categories:
   - UplinkWeaponry
   conditions:
@@ -18,7 +18,7 @@
   description: uplink-rickenbacker4001-desc
   productEntity: Rickenbacker4001Instrument
   cost:
-    Telecrystal: 10
+    Telecrystal: 50
   categories:
   - UplinkJob
   conditions:
@@ -32,7 +32,7 @@
   description: uplink-samurai-crate-desc
   productEntity: CrateSyndicateSamurai
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -31,11 +31,10 @@
     eyes: ClothingEyesHudSyndicate
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndie
     shoes: ClothingShoesBootsCombatFilled
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
-    pocket2: BaseUplinkRadio40TC
+    pocket2: BaseUplinkRadio60TC
     belt: ClothingBeltMilitaryWebbing
   innerClothingSkirt: ClothingUniformJumpskirtOperative
   satchel: ClothingBackpackDuffelSyndicateOperative

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -87,7 +87,6 @@
     eyes: ClothingEyesHudSyndicate
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndie
     shoes: ClothingShoesBootsCombatFilled
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
@@ -110,7 +109,6 @@
     ears: ClothingHeadsetAltSyndicate
     neck: SyndicateWhistle
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndieCommander
     shoes: ClothingShoesBootsCombatFilled
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
@@ -134,7 +132,6 @@
     eyes: ClothingEyesHudSyndicateAgent
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndieMedic
     shoes: ClothingShoesBootsMagSyndie
     id: SyndiAgentPDA
     pocket1: DoubleEmergencyOxygenTankFilled

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -7,7 +7,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: darkgygax }
   productEntity: CrateCybersunDarkGygaxBundle
   cost:
-    Telecrystal: 80 # Einstein Engines -  1/5th the price due to no telecrystal rework
+    Telecrystal: 400
   categories:
   - UplinkAllies
 
@@ -18,8 +18,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
   productEntity: CrateCybersunMaulerBundle
   cost:
-    Telecrystal: 105 # Einstein Engines - lower the price due to no telecrystal rework
-                     # cost reduced such that nukies can still only buy one with all pooled nukies' TC
+    Telecrystal: 525
   categories:
   - UplinkAllies
   conditions:


### PR DESCRIPTION
# Description

This brings over the "Telecrystal Rebalance". To make the TC costs more granular, nearly all values for TC costs have been multiplied by 5x, including the starting TC amounts for each type of uplink. Additionally, Nukies no longer spawn with any of their tacsuits, and have had the cost of said tacsuits refunded as 50 additional TC. Finally, since the Commander and Medic no longer spawn with their respective tacsuits, they've been put into the uplink as new bundles(which traitors can buy as well).

I figure its about time the nukies get some love seeing as on MRP they're facing against Security who can buy an N1984 in their loadouts. Next PR I'm probably going to even further mess with the cost of guns by separating out the guns from their magazines, and adding options for buying more "Special Ammo" types to replace them. Such as for instance, a "Rubber Ammo Bundle" for Nukies, or a more expensive "Incendiary Ammo Bundle". 

# Changelog

:cl:
- tweak: Added the "Telecrystal Rebalance" from Goob. 
