### PR TITLE
IPCs Can Take High Capacity Batteries with Loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/species.yml
+++ b/Resources/Prototypes/Loadouts/Generic/species.yml
@@ -39,3 +39,14 @@
       group: LoadoutAirTank
   items:
     - DoubleEmergencyNitrogenTankFilled
+
+- type: loadout
+  id: LoadoutSpeciesPowerCellHigh
+  category: Species
+  cost: 6
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+  items:
+    - PowerCellHigh


### PR DESCRIPTION
Gives IPCs access to a high capacity power cell on spawn

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Allows IPCs to choose a high capacity power cell as a loadout item.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Have the power cell spawn in the IPCs battery slot if selected in loadout


---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: High Cap Battery as a loadout item for IPCs
