### PR TITLE
BSO Paramed Gaming

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -104,6 +104,17 @@
   items:
     - Portafib
 
+- type: loadout
+  id: LoadoutBSOCrewMonitor
+  category: JobsCommandBlueshieldOfficer
+  cost: 6
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+  items:
+    - HandheldCrewMonitor
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -82,6 +82,28 @@
   items:
     - WeaponLeverChester
 
+- type: loadout
+  id: LoadoutBSOMedkitCombatFilled
+  category: JobsCommandBlueshieldOfficer
+  cost: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+  items:
+    - MedkitCombatFilled
+
+- type: loadout
+  id: LoadoutBSOPortafib
+  category: JobsCommandBlueshieldOfficer
+  cost: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+  items:
+    - Portafib
+
 # Eyes
 
 # Gloves


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

BSO as of now is treated as a purely combatant role, and while it is for the most part, I see it being closer to Corpsman. This PR adds new medical options to the BSOs loadout so that they can keep their charges in good health. It can be debated that this is overturned/power creep, and you're right to an extent. BSO is currently in a weird spot, as a lot of people disagree on how it should function, however, I believe that giving them access to medical items will lock in their position as the guardian/caretaker of command, and will overall be good for their kit and performing their jobs duties. 

BSO is the Corpsman of command, and them having access to high-tier equipment to match that makes sense. The crew monitor is a very good item, yes, but due to the fact that BSO will ONLY be using these items on command, I believe that them having it won't disrupt balance too much. 

(Crew monitor makes it possible for BSO to actually keep track of the entirety of command, rather then sitting on one all game and praying they respond to comms)

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
-add: Gave BSO access to a filled combat medkit, a portafib, and a handheld crew monitor
