### PR TITLE
More Gunsmithing

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -57,3 +57,13 @@
   cost: 5200
   category: cargoproduct-category-name-armory
   group: market
+
+- type: cargoProduct
+  id: ArmoryBRDIR25
+  icon:
+    sprite: _EE/Objects/Weapons/Guns/SMGs/BRDI_R25.rsi
+    state: icon
+  product: CrateArmoryBRDIR25
+  cost: 12000
+  category: cargoproduct-category-name-armory
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -69,3 +69,16 @@
       amount: 2
     - id: MagazinePistol
       amount: 4
+
+- type: entity
+  id: CrateArmoryBRDIR25
+  parent: CrateWeaponSecure
+  name: BRDI-R25 crate
+  description: Contains two integrally suppressed bullpup rifles. Imported from Biesel Republic Defense Industries. Requires Armory access to open.
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunBRDIR25
+      amount: 2
+    - id: MagazineCaselessRifle
+      amount: 4

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -309,3 +309,16 @@
     contents:
     - id: WeaponLaserCarbine
       amount: 3
+
+- type: entity
+  id: GunSafeRifleBRDIR25
+  suffix: BRDI-R25
+  parent: GunSafe
+  name: BRDI-R25 safe
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponSubMachineGunBRDIR25
+      amount: 2
+    - id: MagazineCaselessRifle
+      amount: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -125,6 +125,21 @@
 - type: entity
   name: viper
   parent: WeaponPistolViper
+  id: WeaponPistolViperEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+      gun_chamber:
+        name: Chamber
+        startingItem: null
+
+- type: entity
+  name: viper
+  parent: WeaponPistolViper
   id: WeaponPistolViperSecurity
   description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century.
                Uses .35 auto ammo. The serial number on the handguard marks this gun as belonging to an NT Security Officer.
@@ -220,6 +235,21 @@
       gun_chamber: !type:ContainerSlot
 
 - type: entity
+  name: cobra
+  parent: WeaponPistolCobra
+  id: WeaponPistolCobraEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+      gun_chamber:
+        name: Chamber
+        startingItem: null
+
+- type: entity
   name: mk 58
   parent: BaseWeaponPistol
   id: WeaponPistolMk58
@@ -241,6 +271,21 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg
     fireOnDropChance: 0.5
+
+- type: entity
+  name: mk58
+  parent: WeaponPistolMk58
+  id: WeaponPistolMk58Empty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+      gun_chamber:
+        name: Chamber
+        startingItem: null
 
 - type: entity
   name: mk 58
@@ -333,6 +378,21 @@
         whitelist:
           tags:
             - CartridgeMagnum
+
+- type: entity
+  name: N1984
+  parent: WeaponPistolN1984
+  id: WeaponPistolN1984Empty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+      gun_chamber:
+        name: Chamber
+        startingItem: null
 
 - type: entity
   name: N1984

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1102,6 +1102,10 @@
       - EnergyCutlass
       - WeaponSubMachineGunFPA90
       - WeaponSubMachineGunBRDIR25
+      - WeaponPistolMk58
+      - WeaponPistolN1984
+      - WeaponPistolViper
+      - WeaponPistolCobra
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -64,6 +64,7 @@
     CrateArmoryLaser: 1.0
     CrateArmoryShotgun: 1.0
     CrateArmoryPistols: 1.0
+    CrateArmoryBRDIR25: 0.5
     # rare armor
     ClothingOuterArmorARC: 1.0 # DeltaV - ClothingOuterArmorRiot replaced in favour of ARC suit
     # rare chemicals

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -1192,7 +1192,7 @@
     Aluminum: 900
     Plasteel: 100
     Plastic: 150
-    silver: 100
+    Silver: 100
 
 - type: latheRecipe
   id: WeaponPistolCobra
@@ -1203,4 +1203,4 @@
     Aluminum: 600
     Plasteel: 100
     Plastic: 450
-    silver: 100
+    Silver: 100

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -1159,3 +1159,48 @@
     Steel: 500
     Circuitry: 500
     Tungsten: 200
+
+- type: latheRecipe
+  id: WeaponPistolMk58
+  result: WeaponPistolMk58Empty
+  category: Weapons
+  completetime: 6
+  materials:
+    Aluminum: 800
+    Steel: 100
+    Plastic: 150
+
+- type: latheRecipe
+  id: WeaponPistolN1984
+  result: WeaponPistolN1984Empty
+  category: Weapons
+  completetime: 6
+  materials:
+    Steel: 800 #Yes, Steel and not Aluminum, the original M1911 handguns that this is in reference to are steel frame.
+               #For balancing reasons(Steel is way easier to get), it includes other rarer materials.
+    Plasteel: 100
+    Plastic: 250
+    Gold: 200
+    Silver: 100
+
+- type: latheRecipe
+  id: WeaponPistolViper
+  result: WeaponPistolViperEmpty
+  category: Weapons
+  completetime: 6
+  materials:
+    Aluminum: 900
+    Plasteel: 100
+    Plastic: 150
+    silver: 100
+
+- type: latheRecipe
+  id: WeaponPistolCobra
+  result: WeaponPistolCobraEmpty
+  category: Weapons
+  completetime: 6
+  materials:
+    Aluminum: 600
+    Plasteel: 100
+    Plastic: 450
+    silver: 100

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -26,6 +26,7 @@
   - WeaponMechCombatDisabler # Goobstation
   #- WeaponPistolMk58 #todo: Add a bunch of basic ballistic guns to the list and make lathe recipes for them.
   - MechEquipmentKineticAccelerator # Goobstation
+  - WeaponPistolMk58
   # These are roundstart but not replenishable for salvage
 
 - type: technology
@@ -139,6 +140,9 @@
   - WeaponLaserCannon
   - WeaponMechCombatSolarisLaser # Goobstation
   - WeaponSubMachineGunFPA90
+  - WeaponPistolN1984
+  - WeaponPistolViper
+  - WeaponPistolCobra
   technologyPrerequisites:
   - BasicWeapons
 


### PR DESCRIPTION
# Description

I said I was going to do this previously, so here I am. this adds a few more "Common Handgun" recipes to the Arsenal research, to be manufactured at a security techfab. Currently the list just includes Mk58(available at Tier 1), and N1984, Viper, and Cobra at Tier 2. Most common firearms are manufactured primarily using Aluminium as their main body material, which is (currently) only obtainable by Salvage.

Also adds an option to order the new BRDI-R25 from Cargo. They are somewhat expensive, although not quite to the extreme extent something imported from Sol' would be. Instead they're a highly sought after gun from a manufacturer local to the same region NT operates in and is friendly towards. So more the "Normal" kind of scarcity.

# Changelog

:cl:
- add: Added handgun manufacturing to Arsenal research. Most firearms made this way require Aluminium mined from planets to manufacture.
- add: The BRDI-R25 rifle can now be purchased via cargo. 
