### PR TITLE
Fix Surplus Bundles

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -2,10 +2,10 @@
   id: CrateSyndicateSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate surplus crate
-  description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+  description: Contains 250 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
     - type: SurplusBundle
-      totalPrice: 50
+      totalPrice: 250
 
 - type: entity
   id: CrateCybersunJuggernautBundle
@@ -27,7 +27,7 @@
   id: CrateSyndicateSuperSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate super surplus crate
-  description: Contains 125 telecrystals worth of completely random Syndicate items.
+  description: Contains 625 telecrystals worth of completely random Syndicate items.
   components:
     - type: SurplusBundle
-      totalPrice: 125
+      totalPrice: 625


### PR DESCRIPTION
# Description

This updates Surplus bundles to actually contain the correct number of TC to match the TC Rebalance. For instance, 200tc for the standard surplus crate, which contains 250tc worth of stuff.

# Changelog

:cl:
- tweak: Syndicate Surplus Crates are now included in the TC Rework. 