### PR TITLE
Scroll to Bottom when Selecting a New Chat

### DIFF
--- a/Content.Client/DeltaV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
+++ b/Content.Client/DeltaV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
@@ -146,6 +146,9 @@ public sealed partial class NanoChatUiFragment : BoxContainer
             UpdateChatList(_recipients);
         }
 
+        if (MessageList.Parent is ScrollContainer scroll)
+            scroll.SetScrollValue(new Vector2(0, float.MaxValue));
+
         ActionSendUiMessage?.Invoke(NanoChatUiMessageType.SelectChat, number, null, null);
         UpdateCurrentChat();
     }

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -53,7 +53,7 @@ namespace Content.IntegrationTests.Tests
             "MeteorArena",
             "NukieOutpost",
             "Core", // No current maintainer. In need of a rework...
-            "Pebble",
+            // "Pebble", // De-rotated, no current maintainer.
             // "Edge", // De-rotated, no current maintainer.
             "Saltern", // Maintained by the Sin Mapping Team, ODJ, and TCJ.
             "Shoukou", // Maintained by Violet

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -53,7 +53,7 @@ namespace Content.IntegrationTests.Tests
             "MeteorArena",
             "NukieOutpost",
             "Core", // No current maintainer. In need of a rework...
-            "Pebble",
+            "Pebble", // Maintained by Plyushsune
             // "Edge", // De-rotated, no current maintainer.
             "Saltern", // Maintained by the Sin Mapping Team, ODJ, and TCJ.
             "Shoukou", // Maintained by Violet

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -53,7 +53,7 @@ namespace Content.IntegrationTests.Tests
             "MeteorArena",
             "NukieOutpost",
             "Core", // No current maintainer. In need of a rework...
-            // "Pebble", // De-rotated, no current maintainer.
+            "Pebble",
             // "Edge", // De-rotated, no current maintainer.
             "Saltern", // Maintained by the Sin Mapping Team, ODJ, and TCJ.
             "Shoukou", // Maintained by Violet

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -53,7 +53,7 @@ namespace Content.IntegrationTests.Tests
             "MeteorArena",
             "NukieOutpost",
             "Core", // No current maintainer. In need of a rework...
-            "Pebble", // Maintained by Plyushsune
+            "Pebble",
             // "Edge", // De-rotated, no current maintainer.
             "Saltern", // Maintained by the Sin Mapping Team, ODJ, and TCJ.
             "Shoukou", // Maintained by Violet


### PR DESCRIPTION
Previously, NanoChat set you to the "center" of your chat box scroll with selecting a new chat. This fixes that.

:cl:
- tweak: NanoChat will now scroll to the bottom of your chat history when selecting a new chat.