### PR TITLE
Some More BSO Options

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -87,6 +87,7 @@ character-item-group-LoadoutHeadOfPersonnelUniforms = Head of Personnel Uniforms
 character-item-group-LoadoutBlueshieldOfficerBackpacks = Blueshield Officer Backpacks
 character-item-group-LoadoutBlueshieldOfficerVests = Blueshield Officer Vests
 character-item-group-LoadoutBlueshieldOfficerUniforms = Blueshield Officer Uniforms
+character-item-group-LoadoutBlueshieldOfficerPrimary = Blueshield Officer Primary Weapon
 
 # Dignitary - Magistrate
 character-item-group-LoadoutMagistrateHead = Magistrate Headgear

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/blueshield_officer.yml
@@ -9,6 +9,63 @@
     - type: loadout
       id: LoadoutClothingDuffelBlueshield
 
+#- type: characterItemGroup
+#  id: LoadoutJOBBelt
+#  maxItems: 1
+#  items:
+#
+#- type: characterItemGroup
+#  id: LoadoutJOBEars
+#  maxItems: 1
+#  items:
+
+- type: characterItemGroup
+  id: LoadoutBlueshieldOfficerPrimary
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutBSORifleChester
+    - type: loadout
+      id: LoadoutBSOEnergyShield
+    - type: loadout
+      id: LoadoutBSORifleBRDIR25
+
+#- type: characterItemGroup
+#  id: LoadoutJOBEyes
+#  maxItems: 1
+#  items:
+#
+#- type: characterItemGroup
+#  id: LoadoutJOBGloves
+#  maxItems: 1
+#  items:
+
+- type: characterItemGroup
+  id: LoadoutBlueshieldOfficerHats
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutClothingBlueshieldBeretNavy
+    - type: loadout
+      id: LoadoutClothingBlueshieldBeretOfficer
+    - type: loadout
+      id: LoadoutClothingBlueshieldCowboyHat
+
+#- type: characterItemGroup
+#  id: LoadoutJOBId
+#  maxItems: 1
+#  items:
+#
+#- type: characterItemGroup
+#  id: LoadoutJOBNeck
+#  maxItems: 1
+#  items:
+#
+#- type: characterItemGroup
+#  id: LoadoutJOBMask
+#  maxItems: 1
+#  items:
+
 - type: characterItemGroup
   id: LoadoutBlueshieldOfficerVests
   maxItems: 1
@@ -28,6 +85,11 @@
     - type: loadout
       id: LoadoutClothingBlueshieldArmoredCoat
 
+#- type: characterItemGroup
+#  id: LoadoutJOBShoes
+#  maxItems: 1
+#  items:
+
 - type: characterItemGroup
   id: LoadoutBlueshieldOfficerUniforms
   maxItems: 1
@@ -36,14 +98,3 @@
       id: LoadoutClothingUniformJumpskirtBlueshieldOfficer
     - type: loadout
       id: LoadoutClothingUniformJumpsuitBlueshieldOfficer
-
-- type: characterItemGroup
-  id: LoadoutBlueshieldOfficerHats
-  maxItems: 1
-  items:
-    - type: loadout
-      id: LoadoutClothingBlueshieldBeretNavy
-    - type: loadout
-      id: LoadoutClothingBlueshieldBeretOfficer
-    - type: loadout
-      id: LoadoutClothingBlueshieldCowboyHat

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -87,7 +87,7 @@
 - type: loadout
   id: LoadoutBSORifleBRDIR25
   category: JobsCommandBlueshieldOfficer
-  cost: 4 # Significant upgrade over a Chester, offered here for the STYLE.
+  cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy a crew monitor with it.
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -74,6 +74,8 @@
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBlueshieldOfficerPrimary
     - !type:CharacterJobRequirement
       jobs:
         - BlueshieldOfficer
@@ -81,6 +83,40 @@
       min: 21
   items:
     - WeaponLeverChester
+
+- type: loadout
+  id: LoadoutBSORifleBRDIR25
+  category: JobsCommandBlueshieldOfficer
+  cost: 4 # Significant upgrade over a Chester, offered here for the STYLE.
+  canBeHeirloom: true
+  guideEntry: SecurityWeapons
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBlueshieldOfficerPrimary
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+    - !type:CharacterAgeRequirement
+      min: 21
+  items:
+    - WeaponSubMachineGunBRDIR25
+
+- type: loadout
+  id: LoadoutBSOEnergyShield
+  category: JobsCommandBlueshieldOfficer
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SecurityWeapons
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBlueshieldOfficerPrimary
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+    - !type:CharacterAgeRequirement
+      min: 21
+  items:
+    - EnergyShield
 
 - type: loadout
   id: LoadoutBSOMedkitCombatFilled


### PR DESCRIPTION
# Description

Adds a new "Primary Weapon" category for Blueshield Officer, which the Chester rifle is the origin point for. Per discord discussions, this list includes an option to replace the Chester with an energy shield(It's way more fitting for a bodyguard to have an energy shield oddly enough), or to pay extra points to swap it for the new BRDI-R25 rifle. 

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/32443925-e53d-4f00-a94b-93650211a3b4)

</p>
</details>

# Changelog

:cl:
- add: Added "Blueshield primary weapon" loadout group. His primary selection currently consists of the classic Chester rifle, an energy shield, and an R25.
