### PR TITLE
Corpsman Crew Monitor

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -60,6 +60,16 @@
 # Ears
 
 # Equipment
+- type: loadout
+  id: LoadoutCrewMonitor
+  category: JobsSecurityCorpsman
+  cost: 6
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - BrigMedic
+  items:
+    - HandheldCrewMonitor
 
 # Eyes
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -67,7 +67,7 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - BrigMedic
+        - Brigmedic
   items:
     - HandheldCrewMonitor
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Gives Corpsman the portable crew monitor. It's a criminally underutilized item that more jobs should have access to.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Corpsman can take portable crew mon
