### PR TITLE
Raikyr's Trait Changes

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -383,7 +383,7 @@ trait-description-StrikingCalluses =
     Striking Calluses consist of bony dermal deposits grafted into a user's hands, either inside the palm
     for "Tiger Style" fighting, or just below the knuckles for those who favor traditional boxing.
     Owners of prosthetic or bionic limbs would instead have a hard plastic shell over their knuckles.
-    These enhancements increase your unarmed strike damage by 1 point base, but do not confer
+    These enhancements increase your unarmed strike damage by 2 point base, but do not confer
     any benefits to any form of armed melee.
 
 trait-name-Spinarette = Bionic Spinarette
@@ -391,8 +391,7 @@ trait-description-Spinarette =
     This vatgrown organ-- trademarked and patented by the Cybersun Corporation, is marketed as a highly
     utilitarian enhancement, and sold in clinics all across known space. It consists of a nodule that is traditionally
     implanted right below the wrist, which absorbs bodily lipids to convert into all natural silk. A small opening
-    in the palm allows the user to 'spin' this thread. Users of this enhancement typically require twice as much food
-    as a standard Sol Human, owing to the high metabolic cost of artificial Sericulture.
+    in the palm allows the user to 'spin' this thread.
 
 trait-name-AddictionNicotine = Nicotine Addiction
 trait-description-AddictionNicotine =
@@ -444,10 +443,14 @@ trait-description-Azaziba =
     A language of Moghes consisting of a combination of spoken word and gesticulation.
     While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.
 
-trait-name-BionicArm = Bionic Arm
-trait-description-BionicArm =
-    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
-    or a more obvious metal limb. This limb provides enhanced strength to its user, allowing one to pry open barriers with their bare hands.
+trait-name-BionicArmBasic = Bionic Arms: Basic System
+trait-description-BionicArmBasic =
+    One or more of your arms have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
+    or a more obvious metal limb. 
+
+trait-name-BionicArmBreach = Bionic Arms: Breaching Module
+trait-description-BionicArmBreach =
+    Your Bionic Arms have been upgraded with a module that allows you to pry open even powered doors.
 
 trait-name-PlateletFactories = Platelet Factories
 trait-description-PlateletFactories =
@@ -530,13 +533,13 @@ trait-description-BrittleBoneDisease =
     Also known as "brittle bone disease", people with this genetic disorder have bones that are easily broken,
     often simply by moving. This trait reduces your threshold for critical injury by 50 points.
 
-trait-name-LightAmplification = CyberEyes Module: Light Amplification
+trait-name-LightAmplification = Cyber-Eyes: Light Amplification Module
 trait-description-LightAmplification =
-    Your CyberEyes have been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
+    Your Cyber-Eyes have been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
 
-trait-name-ThermographicVision = CyberEyes Module: Thermographic Scanner
+trait-name-ThermographicVision = Cyber-Eyes: Thermographic Scanner Module
 trait-description-ThermographicVision =
-    Your CyberEyes have been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
+    Your Cyber-Eyes have been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
     biological life forms. It can even detect individuals through the walls of a station.
 
 trait-name-ShadowkinBlackeye = Blackeye
@@ -547,45 +550,3 @@ trait-name-LyreBird = Lyre Bird
 trait-description-LyreBird =
     Your natural talent for mimicry vastly exceeds that of other Harpies. You have the ability to perfectly imitate songs in their entirety.
     Be your own full symphony orchestra, jazz group, or metal band.
-
-trait-name-NaniteAutoRepairBots = Nanite Auto-Repair Bots
-trait-description-NaniteAutoRepairBots =
-    Your chassis has been outfitted with Nanite Repair Drones. Whenever your sensors detect that you've recieved structural damage, the NRDs will activate to bring you back to operational standards.
-
-trait-name-BionicLeg = Bionic Leg
-trait-description-BionicLeg =
-    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
-    or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
-
-trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
-trait-description-FlareShieldingModule =
-    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
-    This provides immunity from most bright flashes of light, such as those from welding arcs, exclusive to IPCs because it only needs the module
-    skipping the eye insertion process.
-
-trait-name-SecurityEyesModule = I.P.C Eye Module: Sechud
-trait-description-SecurityEyesModule =
-    A module installed in IPCs that work for the security department and similar, this module is considered contraband and may be removed if the unit isn't working for the security department.
-
-trait-name-MedicalEyesModule = I.P.C Eye Module: Medical
-trait-description-MedicalEyesModule =
-    Your eyes have been upgraded to include a built-in Medical Hud, allowing you to track the relative health condition of biological organisms.
-
-trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
-trait-description-DiagnosticEyesModule =
-    You possess a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
-
-trait-name-OmniEyesModule = I.P.C Eye Module: Premium Model
-trait-description-OmniEyesModule =
-    This upgrade provides the combined benefits of a SecHud, MedHud, and a Diagnostics Module.
-    Note that this module is considered Contraband for anyone not under the employ of station Security personel,
-    and may be disabled by your employer before dispatch to the station.
-
-trait-name-LightAmplificationModule = I.P.C Eye Module: Light Amplification
-trait-description-LightAmplificationModule =
-    Your vision has been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
-
-trait-name-ThermographicVisionModule = I.P.C Eye Module: Thermographic Scanner
-trait-description-ThermographicVisionModule =
-    Your vision has been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
-    biological life forms. It can even detect individuals through the walls of a station.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -469,37 +469,23 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
-                # When we get the Character Records system in, I also want to make this require certain Backgrounds.
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
         - Claws
         - Talons
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterTraitRequirement
-          traits:
-            - MartialArtist
-        - !type:CharacterJobRequirement
-          jobs:
-            - Boxer
-            - MartialArtist
-            - Gladiator
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
   functions:
     - !type:TraitModifyUnarmed
       flatDamageIncrease:
         types:
-          Blunt: 1
+          Blunt: 2 # Change - removed majority of requirements and buffed the damage. Flavor text writer good luck.
 
 - type: trait
   id: Spinarette
   category: Physical
-  points: -4
+  points: -3
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -521,31 +507,7 @@
           action: ActionSericulture
           productionLength: 2
           entityProduced: MaterialWebSilk1
-          hungerCost: 4
-
-- type: trait
-  id: BionicArm
-  category: Physical
-  points: -8
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Prying
-          speedModifier: 1
-          pryPowered: true
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bionic-arm-message
-          fontSize: 12
-          requireDetailRange: true
+          hungerCost: 1 # no one takes this in the first place, so the hunger penality was removed and cost lowered.
 
 - type: trait
   id: PlateletFactories
@@ -569,14 +531,14 @@
           allowedStates:
           - Alive
           - Critical
-          damageCap: 200
+          damageCap: 400 # Change - increased to allow to Lamias to fully benefit if they ever return but also for anyone with more than 200 hp
           damage:
             groups:
-              Brute: -0.07
-              Burn: -0.07
-              Airloss: -0.07
-              Toxin: -0.07
-              Genetic: -0.07
+              Brute: -0.35 # Change - increased by 5 times so it doesn't feel like dog shit, round will end before any wounds heal, will be adjusted based on field testing
+              Burn: -0.35
+              Airloss: -0.35
+              Toxin: -0.35
+              Genetic: -0.35
 
 - type: trait
   id: DermalArmor
@@ -602,7 +564,7 @@
 - type: trait
   id: CyberEyes
   category: Physical
-  points: -4
+  points: -3 # Change - Cost decreased
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -639,8 +601,6 @@
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -667,8 +627,6 @@
       inverted: true
       traits:
         - CyberEyesOmni
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -693,8 +651,6 @@
       traits:
         - CyberEyesDiagnostic
         - CyberEyesOmni
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -722,8 +678,6 @@
       traits:
         - CyberEyesMedical
         - CyberEyesOmni
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -753,8 +707,6 @@
         - CyberEyesMedical
         - CyberEyesDiagnostic
         - CyberEyesSecurity
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -830,8 +782,6 @@
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:
@@ -840,7 +790,7 @@
 - type: trait
   id: ThermographicVision
   category: Physical
-  points: -8
+  points: -4 # Change - Comes in the same research tier as night vision 
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -849,13 +799,15 @@
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - StrongThermographicVision
   functions:
     - !type:TraitAddComponent
       components:
         - type: ThermalVision
-          pulseTime: 2
+          pulseTime: 10 # Change - I don't fucking know what's wrong with this since it pings for 0.2 seconds, if i set it to 20, would it ping properly for 2 seconds? Feel free to revert this to 2 if someone fixes it.
           toggleAction: PulseThermalVision
     - !type:TraitPushDescription
       descriptionExtensions:
@@ -863,163 +815,8 @@
           fontSize: 12
           requireDetailRange: true
 
-- type: trait
-  id: NaniteAutoRepairBots
-  category: Physical
-  points: -10
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions: # TODO: Code Platelet factories as an actual obtainable implant, and replace this with TraitAddImplant
-    - !type:TraitReplaceComponent
-      components:
-        - type: PassiveDamage
-          allowedStates:
-          - Alive
-          - Critical
-          - Dead
-          damageCap: 200
-          damage:
-            groups:
-              Brute: -0.9
-              Burn: -0.9
-
-- type: trait
-  id: BionicLeg
-  category: Physical
-  points: -6
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-      - type: MovementBodyPart
-        walkSpeed: 3.125
-        sprintSpeed: 5.625
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bionic-leg-message
-          fontSize: 12
-          requireDetailRange: true
-
-- type: trait
-  id: FlareShieldingModule
-  category: Physical
-  points: -4
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: FlashImmunity
-        - type: EyeProtection
-
-- type: trait
-  id: SecurityEyesModule
-  category: Physical
-  points: -1
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - OmniEyesModule
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-
-- type: trait
-  id: MedicalEyesModule
-  category: Physical
-  points: -1
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - DiagnosticEyesModule
-        - OmniEyesModule
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ShowHealthBars
-          damageContainers:
-          - Biological
-        - type: ShowHealthIcons
-          damageContainers:
-          - Biological
-
-- type: trait
-  id: DiagnosticEyesModule
-  category: Physical
-  points: -1
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - MedicalEyesModule
-        - OmniEyesModule
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ShowHealthBars
-          damageContainers:
-          - Inorganic
-          - Silicon
-
-- type: trait
-  id: OmniEyesModule
+- type: trait # Change - Split Bionic Arms into 2 traits, which is effectively a nerf due to max number of trait useage, more modular stuff planned
+  id: BionicArmBasic
   category: Physical
   points: -3
   requirements:
@@ -1027,37 +824,18 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - MedicalEyesModule
-        - DiagnosticEyesModule
-        - SecurityEyesModule
+        - Gladiator
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
   functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-        - type: ShowHealthIcons
-          damageContainers:
-          - Biological
-        - type: ShowHealthBars
-          damageContainers:
-          - Biological
-          - Inorganic
-          - Silicon
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-arm-message
+          fontSize: 12
+          requireDetailRange: true
 
-- type: trait
-  id: LightAmplificationModule
+- type: trait # Change - 
+  id: BionicArmBreach
   category: Physical
   points: -4
   requirements:
@@ -1065,38 +843,13 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
+        - Gladiator
+    - !type:CharacterTraitRequirement
+      traits:
+        - BionicArmBasic
   functions:
     - !type:TraitAddComponent
       components:
-        - type: NightVision
-
-- type: trait
-  id: ThermographicVisionModule
-  category: Physical
-  points: -8
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: ThermalVision
-          pulseTime: 2
-          toggleAction: PulseThermalVision
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-thermal-vision-message
-          fontSize: 12
-          requireDetailRange: true
+        - type: Prying
+          speedModifier: 1
+          pryPowered: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -799,10 +799,6 @@
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - StrongThermographicVision
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Just a PR on someone else's behalf since they didn't want to. This was made by "raikyr" on discord. Changelog should have everything.

---

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Raikyr
- tweak: Removed Mind over Machine from Cyber-Eyes Modules
- tweak: Renamed Thermal Vision and Night Vision to be more in line with Older modules
- tweak: Thermal vision made greatly cheaper, it's a tier 2 experimental research, it shouldn't cost as much. (Move it to Tier 3 if you want to keep it at 8 cost)
- tweak: Buffed Striking Calluses to no longer require humans martial artist only and +1 to damage
- tweak: Buffed Spinarnette, no longer makes you hungrier and is cheaper
- tweak: Buffed Platelet Factories, increased value healed by 5 times and damage cap to account for people who have health traits past 200 max HP and Lamias
- fix: Bootleg fixed Thermal Vision's 0.2 second pulse, it either pulses for 1 second or 10 seconds or is still broken
- tweak: Split Bionic Arm into Bionic Arm Basic and Bionic Arm Breaching, planning for more Bionic Arm modules, overall it's 1 point cheaper but needs 2 trait slots.