### PR TITLE
Update pebble.yml

### DIFF
--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -6581,12 +6581,6 @@ entities:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
-    - type: Door
-      secondsUntilStateChange: -6886.2603
-      state: Opening
-    - type: DeviceLinkSource
-      lastSignals:
-        DoorStatus: True
 - proto: AirlockMedicalGlassLocked
   entities:
   - uid: 10736
@@ -47691,13 +47685,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,4.5
-      parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 9383
-    components:
-    - type: Transform
-      pos: -10.5,-28.5
       parent: 2
 - proto: GlimmerProber
   entities:


### PR DESCRIPTION
# Description

Fixes a small issue with pebble that was causing test fails. Also removes the captain's laser from being mapped. He gets it from loadouts now, and chooses between it and other options that take the place of the traitor steal objective target. It should not be mapped like this anymore because that would create a duplicate of an item which is only supposed to be one of on the map.