### PR TITLE
Cybernetic Trait Changes - 20/02/2025

### DIFF
--- a/physical.yml
+++ b/physical.yml
@@ -1,0 +1,1076 @@
+- type: trait
+  id: WillToLive
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Redshirt
+        - WillToDie
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: DeadModifier
+          deadThresholdModifier: 10
+
+- type: trait
+  id: WillToDie
+  category: Physical
+  points: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - WillToLive
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: DeadModifier
+          deadThresholdModifier: -15
+
+- type: trait
+  id: Tenacity
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - GlassJaw
+        - BrittleBoneDisease
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: CritModifier
+          critThresholdModifier: 5
+
+- type: trait
+  id: GlassJaw
+  category: Physical
+  points: 2
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Tenacity
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: CritModifier
+          critThresholdModifier: -10
+
+- type: trait
+  id: Vigor
+  category: Physical
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Lethargy
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Oni
+        - IPC
+  functions:
+    - !type:TraitModifyStamina
+      staminaModifier: 10
+      decayModifier: 0.6
+      cooldownModifier: -0.75
+
+- type: trait
+  id: Lethargy
+  category: Physical
+  points: 4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Vigor
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
+        - Tajaran
+  functions:
+    - !type:TraitModifyStamina
+      staminaModifier: -15
+      decayModifier: -0.6
+      cooldownModifier: 0.75
+
+- type: trait
+  id: HighAdrenaline
+  category: Physical
+  points: -5
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - AdrenalDysfunction
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: Adrenaline
+          rangeModifier: 0.4
+          inverse: true
+
+- type: trait
+  id: AdrenalDysfunction
+  category: Physical
+  points: 3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - HighAdrenaline
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: Adrenaline
+          rangeModifier: 0.8
+
+- type: trait
+  id: Masochism
+  category: Physical
+  points: -5
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - LowPainTolerance
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: PainTolerance
+          rangeModifier: 0.4
+          inverse: true
+
+- type: trait
+  id: LowPainTolerance
+  category: Physical
+  points: 3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Masochism
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: PainTolerance
+          rangeModifier: 0.6
+
+- type: trait
+  id: Steadfast
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
+        - Tajaran
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Feeble
+  functions:
+    - !type:TraitModifySlowOnDamage
+      damageThresholdsModifier: 10
+      speedModifierMultiplier: 0.68
+
+- type: trait
+  id: Feeble
+  category: Physical
+  points: 3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
+        - Tajaran
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Steadfast
+  functions:
+    - !type:TraitModifySlowOnDamage
+      damageThresholdsModifier: -15
+      speedModifierMultiplier: 1.2
+
+- type: trait
+  id: MartialArtist
+  category: Physical
+  points: -5
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+      - Borg
+      - MedicalBorg
+      - Boxer
+      - MartialArtist
+      - Gladiator
+  functions:
+    - !type:TraitModifyUnarmed
+      heavyOnLightMiss: true
+      attackRateModifier: 0.8
+      rangeModifier: 1.1
+    - !type:TraitReplaceComponent
+      components:     # Keep BoxerComponent for now until we have After/Before on traits prototypes
+        - type: Boxer # for potential conflicts with other traits that replace unarmed damage
+          modifiers:
+            coefficients:
+              Blunt: 1.2
+              Slash: 1.2
+              Piercing: 1.2
+              Heat: 1.2
+              Poison: 1.2
+              Asphyxiation: 1.2
+      # An attack rate of 1.25 hits per second (1 / 0.8 = 1.25) multiplied by 20% extra damage
+      # effectively means 50% more overall DPS, same DPS bonus as before (1 * 1.25 * 1.2 = 1.5)
+      # but the extra attack rate makes it visually apparent that it's Martial Artist.
+
+- type: trait
+  id: Small
+  category: Physical
+  points: -2
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid # Felinids/Tajaran already have this feature by default.
+        - Tajaran
+    - !type:CharacterHeightRequirement
+      max: 150
+    - !type:CharacterWidthRequirement
+      max: 32
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: PseudoItem
+          storedOffset: 0,17
+          shape:
+            - 0,0,1,4
+            - 0,2,3,4
+            - 4,0,5,4
+
+- type: trait
+  id: TemperatureTolerance
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Vulpkanin # This trait functions exactly as-is for the Vulpkanin trait.
+        - Plasmaman # Plasmamen have cold immunity so this trait is unnecessary
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: TemperatureProtection
+          coefficient: 0.1 # Enough resistance to walk into the chef's freezer, or tolerate daytime temperatures on Glacier without a jacket.
+
+# These traits largely exist to demonstrate more of the "Component Removals" functionality. This way contributors
+# can get used to seeing that they can "Remove and Replace" a pre-existing component.
+# When declared, componentRemovals work like a "RemComp" that activates upon joining a round.
+- type: trait
+  id: Talons
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy # Harpies already have talons
+        - Arachnid # Apparently they have a "piercing" bite
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Claws
+  functions:
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: AlienClaw
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Piercing: 5 # No, this isn't "OP", this is literally the worst brute damage type in the game.
+                      # Same deal as Slash, except that a majority of all armor provides Piercing resistance.
+    - !type:TraitRemoveComponent # Plasmamen have self-damage on melee attacks
+      components:
+        - type: DamageOnHit
+          damage:
+            types:
+              Blunt: 0
+
+
+- type: trait
+  id: Claws
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid # Felinids already have cat claws.
+        - Tajaran # Tajaran also have cat claws
+        - Reptilian # Reptilians also have cat claws.
+        - Shadowkin # Shadowkins also have claws.
+        # - Vulpkanin # Vulpkanin have "Blunt" claws. One could argue this trait "Sharpens" their claws.
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Talons
+  functions:
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: AlienClaw
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Slash: 5 # Trade stamina damage on hit for a very minor amount of extra bleed.
+                  # Blunt also deals bleed damage, so this is more of a sidegrade.
+    - !type:TraitRemoveComponent
+      components:
+        - type: DamageOnHit
+          damage:
+            types:
+              Blunt: 0
+
+- type: trait
+  id: NaturalWeaponRemoval
+  category: Physical
+  points: 0
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Human
+        - Oni
+        - SlimePerson
+        - Diona
+        - Dwarf
+        - Arachne
+        - IPC # Other species could justify getting this trait for Blunt stamina damage,
+              # but 6 blunt -> 5 blunt is a straight up downgrade.
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Talons
+        - Claws
+  functions:
+    - !type:TraitModifyUnarmed
+      soundHit:
+        collection: Punch
+      animation: WeaponArcFist
+      damage:
+        types:
+          Blunt: 5
+    - !type:TraitRemoveComponent
+      components:
+        - type: DamageOnHit
+          damage:
+            types:
+              Blunt: 0
+
+- type: trait
+  id: StrikingCalluses
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Claws
+        - Talons
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitModifyUnarmed
+      flatDamageIncrease:
+        types:
+          Blunt: 2
+
+- type: trait
+  id: Spinarette
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Arachnid
+        - Arachne
+        - Shadowkin
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Sericulture
+          action: ActionSericulture
+          productionLength: 2
+          entityProduced: MaterialWebSilk1
+          hungerCost: 1 
+
+- type: trait
+  id: BionicArm
+  category: Physical
+  points: -8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Prying
+          speedModifier: 1
+          pryPowered: true
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-arm-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
+  id: PlateletFactories
+  category: Physical
+  points: -10
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions: # TODO: Code Platelet factories as an actual obtainable implant, and replace this with TraitAddImplant
+    - !type:TraitReplaceComponent
+      components:
+        - type: PassiveDamage
+          allowedStates:
+          - Alive
+          - Critical
+          damageCap: 400
+          damage:
+            groups:
+              Brute: -0.35
+              Burn: -0.35
+              Airloss: -0.35
+              Toxin: -0.35
+              Genetic: -0.35
+
+- type: trait
+  id: DermalArmor
+  category: Physical
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddArmor
+      damageModifierSets:
+        - DermalArmor
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-dermal-armor-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
+  id: CyberEyes
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Photophobia
+        - Blindness
+        - Nearsighted
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-cybereyes-message
+          fontSize: 12
+          requireDetailRange: true
+    - !type:TraitReplaceComponent
+      components:
+        - type: Flashable # Effectively, removes any flash-vulnerability species traits.
+
+
+- type: trait
+  id: FlareShielding
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: FlashImmunity
+        - type: EyeProtection
+
+
+- type: trait
+  id: CyberEyesSecurity
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - CyberEyesOmni
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+
+- type: trait
+  id: CyberEyesMedical
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - CyberEyesDiagnostic
+        - CyberEyesOmni
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowHealthBars
+          damageContainers:
+          - Biological
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
+
+- type: trait
+  id: CyberEyesDiagnostic
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - CyberEyesMedical
+        - CyberEyesOmni
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowHealthBars
+          damageContainers:
+          - Inorganic
+          - Silicon
+
+- type: trait
+  id: CyberEyesOmni
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+        - Command
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - CyberEyesMedical
+        - CyberEyesDiagnostic
+        - CyberEyesSecurity
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
+        - type: ShowHealthBars
+          damageContainers:
+          - Biological
+          - Inorganic
+          - Silicon
+
+- type: trait
+  id: Redshirt
+  category: Physical
+  points: 8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - WillToLive
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: DeadModifier
+          deadThresholdModifier: -100
+
+- type: trait
+  id: BrittleBoneDisease
+  category: Physical
+  points: 10
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Tenacity
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+        - type: CritModifier
+          critThresholdModifier: -50
+
+- type: trait
+  id: LightAmplification
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: NightVision
+
+- type: trait
+  id: ThermographicVision
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ThermalVision
+          pulseTime: 2
+          toggleAction: PulseThermalVision
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-thermal-vision-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
+  id: NaniteAutoRepairBots
+  category: Physical
+  points: -10
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions: # TODO: Code Platelet factories as an actual obtainable implant, and replace this with TraitAddImplant
+    - !type:TraitReplaceComponent
+      components:
+        - type: PassiveDamage
+          allowedStates:
+          - Alive
+          - Critical
+          - Dead
+          damageCap: 250
+          damage:
+            groups:
+              Brute: -0.9
+              Burn: -0.9
+
+- type: trait
+  id: BionicLeg
+  category: Physical
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+      - type: MovementBodyPart
+        walkSpeed: 3.125
+        sprintSpeed: 5.625
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-leg-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
+  id: FlareShieldingModule
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: FlashImmunity
+        - type: EyeProtection
+
+- type: trait
+  id: SecurityEyesModule
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - OmniEyesModule
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+
+- type: trait
+  id: MedicalEyesModule
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - DiagnosticEyesModule
+        - OmniEyesModule
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowHealthBars
+          damageContainers:
+          - Biological
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
+
+- type: trait
+  id: DiagnosticEyesModule
+  category: Physical
+  points: -1
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - MedicalEyesModule
+        - OmniEyesModule
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowHealthBars
+          damageContainers:
+          - Inorganic
+          - Silicon
+
+- type: trait
+  id: OmniEyesModule
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+        - Command
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - MedicalEyesModule
+        - DiagnosticEyesModule
+        - SecurityEyesModule
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
+        - type: ShowHealthBars
+          damageContainers:
+          - Biological
+          - Inorganic
+          - Silicon
+
+- type: trait
+  id: LightAmplificationModule
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: NightVision
+
+- type: trait
+  id: ThermographicVisionModule
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterSpeciesRequirement
+      species:
+        - IPC
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: ThermalVision
+          pulseTime: 2
+          toggleAction: PulseThermalVision
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-thermal-vision-message
+          fontSize: 12
+          requireDetailRange: true

--- a/traits.ftl
+++ b/traits.ftl
@@ -1,0 +1,590 @@
+trait-name-Blindness = Blindness
+trait-description-Blindness = You are legally blind, and can't see clearly past a few meters in front of you.
+trait-examined-Blindness = [color=lightblue]{CAPITALIZE(POSS-ADJ($target))} eyes are glassy and unfocused. It doesn't seem like {SUBJECT($target)} can see you well, if at all.[/color]
+
+trait-name-Narcolepsy = Narcolepsy
+trait-description-Narcolepsy =
+    Due to a neurological disorder, controlling your sleep-wake cycles is difficult for you.
+    As a result, you may repeatedly fall asleep for short periods of time throughout the day.
+
+trait-name-Pacifist = Pacifist
+trait-description-Pacifist =
+    Either due to moral principles, or as a result of body modification,
+    you cannot bring yourself to harm or to risk harming any other living being,
+    regardless of what threat they may pose.
+
+trait-name-SelfAware = Self-Aware
+trait-description-SelfAware =
+    You possess a keen intuition of your body and senses.
+    You can accurately examine the severity of your wounds and burns like a health analyzer,
+    and can gauge if you have toxin or airloss damage.
+
+trait-name-LightweightDrunk = Lightweight Drunk
+trait-description-LightweightDrunk =
+    Your body exhibits a significantly heightened susceptibility to alcohol intoxication.
+    As a result, alcohol has a more significant effect on your cognitive functions.
+    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alchohol poisoning threshold.
+
+trait-name-HeavyweightDrunk = Alcohol Tolerance
+trait-description-HeavyweightDrunk =
+    Your body has developed an exceptionally high level of alcohol tolerance, leaving the very beverages you consume intimidated.
+    As a result, the effects of alcohol on your cognitive functions are considerably less noticeable.
+    Note: This pertrains solely to the [color=blue]visual effects[/color] of intoxication, and does not affect the alchohol poisoning threshold.
+
+trait-name-LiquorLifeline = Liquor Lifeline
+trait-description-LiquorLifeline =
+    Forget the doctor — just hit the bar for your "ethanol prescription"!
+    While drunk, you slowly heal [color=red]Brute[/color], [color=orange]Heat[/color], [color=orange]Shock[/color], and [color=orange]Cold[/color] damage, scaling with how drunk you are.
+    You also gain the benefits of [color=lightblue]Alcohol Tolerance[/color].
+
+trait-name-Muted = Muted
+trait-description-Muted =
+    Either due to to an abnormality in your body development, or due to some body augmentation, you are unable to utilize spoken language.
+    Consequently, you may encounter difficulties in communicating with others or using radio communication.
+    To compensate for this limitation, you have been taught the Galactic Sign Language.
+
+trait-name-BloodDeficiency = Blood Deficiency
+trait-description-BloodDeficiency =
+    Your body loses more blood than it can replenish.
+    You lose blood over time, and when left untreated you will eventually die from blood loss.
+
+trait-name-Hemophilia = Hemophilia
+trait-description-Hemophilia =
+    Your body's ability to form blood clots is impaired.
+    You bleed twice as long, and you have easy bruising, taking 10% more Blunt damage.
+
+trait-name-Paracusia = Paracusia
+trait-description-Paracusia =
+    The challenges of deep space life have led you to experience chronic and frequent auditory hallucinations,
+    causing you to perceive sounds that are not really there.
+
+trait-name-PirateAccent = Pirate Accent
+trait-description-PirateAccent =
+    Your interactions with space pirates or a fascination with their culture
+    have influenced your speech, causing you to communicate in a manner characteristic of pirates.
+
+trait-name-Accentless = Accentless
+trait-description-Accentless =
+    You may have developed in isolation or separation from other repsentatives of your species,
+    which resulted in you not having the typical accent that your species peers may possess.
+
+trait-name-FrontalLisp = Frontal Lisp
+trait-description-FrontalLisp =
+    An abnormality in the development of your speech has caused you to pronounce the "s" and "z" sounds similarly to "th".
+    In other words, you thpeak with a lithp.
+
+trait-name-Stutter = Stutter
+trait-description-Stutter =
+    Either due to a speech disorder, or due to anxiety or stress, you often find yourself stuttering while trying to speak.
+
+trait-name-Southern = Southern Drawl
+trait-description-Southern = You have a different way of speakin'.
+
+trait-name-GermanAccent = German accent
+trait-description-GermanAccent = You speak with a German accent.
+
+trait-name-RussianAccent = Russian accent
+trait-description-RussianAccent = You speak with a Russian accent.
+
+trait-name-FrenchAccent = French accent
+trait-description-FrenchAccent = You speak with a French accent.
+
+trait-name-ItalianAccent = Italian accent
+trait-description-ItalianAccent = You speak with a Italian accent.
+
+trait-name-SpanishAccent = Spanish accent
+trait-description-SpanishAccent = You speak with a Spanish accent.
+
+trait-name-Snoring = Snoring
+trait-description-Snoring = You tend to snore loudly while sleeping.
+
+trait-name-CPRTraining = CPR Training
+trait-description-CPRTraining = At some point in your life, you have received training in how to perform CPR.
+                                This trait is automatically given for free to medical doctors, and is intended for non-medical characters
+
+trait-name-Nearsighted = Nearsighted
+trait-description-Nearsighted = Your eyes are not what they once were, you have difficulty seeing things far away without corrective glasses.
+
+trait-name-NormalVisionHarpy = Trichromat Modification
+trait-description-NormalVisionHarpy =
+    Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
+    You do not have the usual vision anomaly that your species may possess.
+
+trait-name-SkeletonAccent = Skeleton Accent
+trait-description-SkeletonAccent = You have a humerus skeleton accent that will rattle others to the bone!
+
+trait-name-NormalVision = Trichromat Modification
+trait-description-NormalVision =
+    Your eyes have been modified by means of advanced medicine to see in the standard colors of Red, Green, and Blue.
+    You do not have the usual vision anomaly that your species may possess.
+
+trait-name-Thieving = Thieving
+trait-description-Thieving =
+    You are deft with your hands, and talented at convincing people of their belongings.
+    You can identify pocketed items, steal them quieter, and steal ~33% faster.
+
+trait-name-ForeignerLight = Foreigner (light)
+trait-description-ForeignerLight =
+    You struggle to learn this station's primary language, and as such, cannot speak it. You can, however, comprehend what others say in that language.
+    To help you overcome this obstacle, you are equipped with a translator that helps you speak in this station's primary language.
+
+trait-name-Foreigner = Foreigner
+trait-description-Foreigner =
+    For one reason or another you do not speak this station's primary language.
+    Instead, you have a translator issued to you that only you can use.
+
+trait-name-Saturnine = Saturnine
+trait-description-Saturnine = You are naturally dour and morose. Your mood is permanently decreased by a large amount.
+
+trait-name-Sanguine = Sanguine
+trait-description-Sanguine = You are naturally upbeat and cheerful! Your mood is permanently increased by a large amount.
+
+trait-name-WillToLive = Will To Live
+trait-description-WillToLive =
+    You have an unusually strong "will to live", and will resist death more than others.
+    Your damage threshold for becoming Dead is increased by 10 points.
+
+trait-name-WillToDie = Will To Die
+trait-description-WillToDie =
+    You have an unusually weak "will to live", and will succumb to injuries sooner than others.
+    Your damage threshold for becoming Dead is decreased by 15 points.
+
+trait-name-Tenacity = Tenacity
+trait-description-Tenacity =
+    Whether it be through raw grit, willpower, or subtle bionic augmentations, you are hardier than others.
+    Your damage threshold for becoming Critical is increased by 5 points.
+
+trait-name-GlassJaw = Glass Jaw
+trait-description-GlassJaw =
+    Your body is more fragile than others, resulting in a greater susceptibility to critical injuries
+    Your damage threshold for becoming Critical is decreased by 10 points.
+
+trait-name-HighAdrenaline = High Adrenaline
+trait-description-HighAdrenaline =
+    Whether by natural causes, genetic or bionic augmentation, you have a more potent adrenal gland.
+    When injured, your melee/throwing attacks deal up to 10% more damage, in addition to the natural bonuses from adrenaline.
+    The standard adrenaline bonuses to melee/throwing damage are up to a 20% increase.
+
+trait-name-AdrenalDysfunction = Adrenal Dysfunction
+trait-description-AdrenalDysfunction =
+    Your adrenal gland is completely nonfunctional, or potentially missing outright.
+    Your melee/throwing attacks do not benefit from Adrenaline when injured.
+    The standard adrenaline bonuses to melee/throwing damage are up to a 20% increase.
+
+trait-name-Masochism = Masochism
+trait-description-Masochism =
+    Deriving enjoyment from your own pain, you are not as inhibited by it as others.
+    You ignore the first 10% of stamina damage penalties to your melee/throwing attacks.
+
+trait-name-LowPainTolerance = Low Pain Tolerance
+trait-description-LowPainTolerance =
+    Your tolerance for pain is far below average, and its effects are more inhibiting.
+    Your melee/throwing damage is penalized by up to an additional 15% when taking stamina damage.
+
+trait-name-Steadfast = Steadfast
+trait-description-Steadfast =
+    When others would buckle from the weight of your injuries, you still march forward unrelentingly.
+    For most species [color=gray](excluding IPC/Shadowkin)[/color], this trait modifies:
+    - [color=yellow]25%[/color] movement slow at [color=red]60[/color] damage ➔ [color=yellow]17%[/color] movement slow at [color=red]70[/color] damage
+    - [color=yellow]45%[/color] movement slow at [color=red]80[/color] damage ➔ [color=yellow]30%[/color] movement slow at [color=red]90[/color] damage
+
+trait-name-Feeble = Feeble
+trait-description-Feeble =
+    Your body responds poorly to injuries, making damage affect your movement more severely.
+    For most species [color=gray](excluding IPC/Shadowkin)[/color], this trait modifies:
+    - [color=yellow]25%[/color] movement slow at [color=red]60[/color] damage ➔ [color=yellow]30%[/color] movement slow at [color=red]45[/color] damage
+    - [color=yellow]45%[/color] movement slow at [color=red]80[/color] damage ➔ [color=yellow]54%[/color] movement slow at [color=red]65[/color] damage
+
+trait-name-MartialArtist = Martial Artist
+trait-description-MartialArtist =
+    You have received formal training in unarmed combat, whether with fists, claws, feet, or teeth.
+    Your unarmed melee attack is now considered a single-target [color=orange]Power Attack[/color], requiring less precision.
+    Additionally, your unarmed melee attacks deal [color=yellow]20%[/color] more damage, attack [color=yellow]25%[/color] faster, and have [color=yellow]10%[/color] increased range.
+    This has no effect on damage dealt with any form of armed melee.
+    The [color=#9FED58]Boxer[/color], [color=#9FED58]Martial Artist[/color], and [color=#9FED58]Gladiator[/color] jobs start with this trait by default.
+
+-stamina-info = [color=gray]Most species start with [color=#919039]100 points[/color] of stamina and [color=#919039]3 points[/color] of stamina regen per second.[/color]
+
+trait-name-Vigor = Vigor
+trait-description-Vigor =
+    Whether by pure determination, fitness, or bionic augmentations, your endurance is enhanced.
+    Your stamina is increased by [color=yellow]10 points[/color].
+    Your stamina regen per second is increased by [color=yellow]0.6 points[/color].
+    Stamina regen now starts [color=lightblue]2.25 seconds[/color] after taking stamina damage, instead of [color=lightblue]3 seconds[/color].
+    { -stamina-info }
+
+trait-name-Lethargy = Lethargy
+trait-description-Lethargy =
+    You become tired faster than others, making you more vulnerable to exhaustion and fatigue.
+    Your stamina is decreased by [color=yellow]15 points[/color].
+    Your stamina regen per second is decreased by [color=yellow]0.6 points[/color].
+    Stamina regen now starts [color=lightblue]3.75 seconds[/color] after taking stamina damage, instead of [color=lightblue]3 seconds[/color].
+    { -stamina-info }
+
+trait-name-SignLanguage = Sign Language
+trait-description-SignLanguage =
+    You can understand and use Tau-Ceti Basic Sign Language (TCB-SL).
+    If you are mute for any reason, you can still communicate with sign language.
+
+trait-name-SolCommon = Sol Common
+trait-description-SolCommon =
+    With its roots in Mandarin Chinese - Common evolved as the official language of the Sol Alliance - with officials working to tie it together with a common tongue.
+    It's spoken by state officials - taught in schools - and spoken by those who either feel a sense of national pride in the Alliance or otherwise fell sway to the culture.
+
+trait-name-Tradeband = Tradeband
+trait-description-Tradeband =
+    Descended from latin and romance languages of old Earth - Tradeband remains the main tongue of the upper class of humanity.
+    The language sounds elegant and well structured to most ears. It remains in popular use with traders - diplomats - and those seeking to hold onto a piece of a romantic past.
+
+trait-name-Freespeak = Freespeak (Gutter)
+trait-description-Freespeak =
+    A language of renegades and frontiersmen descending from various languages from Earth like Hindi combined into a multi-rooted jumble that sounds incoherent or even barbarian to non-native speakers.
+    This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit.
+    Often called 'Gutter' by Alliance citizens.
+
+trait-name-Elyran = Elyran Standard
+trait-description-Elyran =
+    Elyran Standard is the official tongue of the Republic of Elyra.
+    Constructed using elements of Farsi - Arabic - and Turkish - influence from all three of these languages can be seen throughout its grammar and vocabulary.
+
+trait-name-Voracious = Voracious
+trait-description-Voracious =
+    Nothing gets between you and your food.
+    Your endless consumption of food and drinks is twice as fast.
+
+-terrain-example = [color=gray](e.g. plastic flaps, spider webs, slime puddles, kudzu)[/color]
+-slippery-example = [color=gray](e.g. banana peels, water puddles, soap, space lube)[/color]
+
+trait-name-ParkourTraining = Parkour Training
+trait-description-ParkourTraining =
+    Whether as a hobby, lifestyle, or professional training, you are trained in the discipline of parkour.
+    You climb structures like tables [color=yellow]50%[/color] faster.
+    Slipping leaves you stunned for [color=yellow]30%[/color] shorter. { -slippery-example }
+    You gain a [color=yellow]50%[/color] resistance to slows from difficult terrain. { -terrain-example }
+
+trait-name-BadKnees = Bad Knees
+trait-description-BadKnees =
+    Whether due to injury, age, or wear and tear, your knees aren't particularly strong or flexible.
+    You climb structures like tables [color=yellow]50%[/color] slower.
+    Slipping leaves you stunned for [color=yellow]40%[/color] longer. { -slippery-example }
+    Difficult terrain slows you down [color=yellow]35%[/color] more. { -terrain-example }
+
+trait-name-Sluggish = Sluggish
+trait-description-Sluggish =
+    You navigate the world slower than others, perhaps due to a medical condition, inactivity, or age.
+    Your movement speed is decreased by [color=yellow]16%[/color].
+
+trait-name-SnailPaced = Snail-Paced
+trait-description-SnailPaced =
+    You walk at a snail's pace, perhaps due to a medical condition, mobility impairment, or age.
+    Your movement speed is decreased by [color=yellow]32%[/color].
+
+trait-name-LightStep = Light Step
+trait-description-LightStep =
+    You move with a gentle step, which makes your footsteps quieter.
+
+trait-name-Swashbuckler = Swashbuckler
+trait-description-Swashbuckler =
+    You are an expert in swordsmanship, wielding swords, knives, and other blades with unrivaled finesse.
+    Your melee Slash bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+
+trait-name-Spearmaster = Spearmaster
+trait-description-Spearmaster =
+    You have an outstanding proficiency with spears, wielding them as an extension of your body.
+    Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+
+trait-name-WeaponsGeneralist = Weapons Generalist
+trait-description-WeaponsGeneralist =
+    You are a jack of all trades with melee weapons, enabling you to be versatile with your weapon arsenal.
+    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 25%.
+
+trait-name-Singer = Singer
+trait-description-Singer = You are naturally capable of singing simple melodies with your voice.
+
+trait-name-LatentPsychic = Latent Psychic
+trait-description-LatentPsychic =
+    Your mind and soul are open to the noosphere, allowing for use of Telepathy.
+    Thus, you are eligible for potentially receiving psychic powers.
+    It is possible that you may be hunted by otherworldly forces, so consider keeping your powers a secret.
+
+trait-name-PsionicInsulation = χ Waveform Misalignment
+trait-description-PsionicInsulation =
+    You are a flesh automaton animated by neurotransmitters. Within your skull lies a
+    1.5kg sack of meat pretending at sentience. By modern epistemiological theory, you aren't even a sophont.
+    The good news is that you are immune to most positive and negative effects of psychic powers.
+    There may be other consequences to this malady.
+
+trait-name-NaturalTelepath = Natural Telepath
+trait-description-NaturalTelepath =
+    As a naturally occuring Telepath, you are capable of fluent telepathic communication, regardless of
+    whether or not you possess any notable psychic powers. This offers all of the same benefits and
+    drawbacks of Latent Psychic, except that you are guaranteed to start with full Telepathy. You may
+    still gain powers as normal for a Latent Psychic.
+
+trait-name-TrapAvoider = Trap Avoider
+trait-description-TrapAvoider =
+    You possess a preturnatural sense of traps, and will unconsciously avoid them. You will never trigger
+    floor traps, such as land mines, tripwires, mouse traps(If you're small enough), etc.
+
+trait-name-AnomalousPositronics = Anomalous Positronics
+trait-description-AnomalousPositronics =
+    Whether by intentional design from the manufacturer, black market modifications, or accidental omission,
+    your positronic brain lacks its standard psionic insulation. As a being that can be argued to have a soul,
+    this by extension means that it is possible for you to be influenced by the Noosphere.
+
+trait-name-Photophobia = Photophobia
+trait-description-Photophobia =
+    Your eyes are extremely sensitive to bright lights.
+    As a result, you may be blinded for a greater duration than others when exposed to sudden flashes of light.
+    Your eyes are also more likely to be injured by flashes.
+
+trait-name-Clumsy = Clumsy
+trait-description-Clumsy =
+    You have a severe deficiency in hand-eye-coordination, resulting in an inability to do some things that others would take for granted.
+    Any weapons you may try to use are more likely to injure yourself than others. You are unable to climb any objects without injuring yourself.
+
+trait-name-Small = Small
+trait-description-Small =
+    You are much smaller than a typical person, and can climb into spaces others would not normally be able to fit into, such as duffel bags.
+    This trait does not in any way modify your character's size, it merely requires that your character be at most the size of a standard Tajaran.
+
+trait-name-TemperatureTolerance = Temperature Tolerance
+trait-description-TemperatureTolerance =
+    You have a notable tolerance for lower temperatures. You can stand for extended periods of time
+    in conditions just slightly below freezing, such as the inside of a kitchen fridge,
+    or the sunlit mountainside of the famous Glacier station.
+
+trait-name-Talons = Talons
+trait-description-Talons =
+    Your fingertips have been replaced with piercing talons.
+    These could come from gene modifications, vatgrown implants,
+    or even hard plastic retractable talons incorpoated into a prosthetic limb.
+    Your unarmed melee attacks deal Piercing damage instead of the standard damage type for your species.
+    This has no effect on damage dealt with any form of armed melee.
+
+trait-name-Claws = Claws
+trait-description-Claws =
+    Your fingertips have been replaced with sharp claws.
+    These could come from gene modifications, vatgrown implants,
+    or even hard plastic retractable claws incorpoated into a prosthetic limb.
+    Your unarmed melee attacks deal Slashing damage instead of the standard damage type for your species.
+    This has no effect on damage dealt with any form of armed melee.
+
+trait-name-NaturalWeaponRemoval = Natural Weapons Removal
+trait-description-NaturalWeaponRemoval =
+    Whatever "Natural Weapons" your species are normally born with have been surgically removed.
+    This could have been done to better fit in with terran space stations, or as a cosmetic choice.
+    As a result, your unarmed attacks deal Blunt damage instead of the standard damage type for your species.
+    This has no effect on damage dealt with any form of armed melee.
+
+trait-name-StrikingCalluses = Striking Calluses
+trait-description-StrikingCalluses =
+    An iconic enhancement commonly found in the world of cyberenhanced martial arts.
+    Striking Calluses consist of bony dermal deposits grafted into a user's hands, either inside the palm
+    for "Tiger Style" fighting, or just below the knuckles for those who favor traditional boxing.
+    Owners of prosthetic or bionic limbs would instead have a hard plastic shell over their knuckles.
+    These enhancements increase your unarmed strike damage by 2 point base, but do not confer
+    any benefits to any form of armed melee.
+
+trait-name-Spinarette = Bionic Spinarette
+trait-description-Spinarette =
+    This vatgrown organ-- trademarked and patented by the Cybersun Corporation, is marketed as a highly
+    utilitarian enhancement, and sold in clinics all across known space. It consists of a nodule that is traditionally
+    implanted right below the wrist, which absorbs bodily lipids to convert into all natural silk. A small opening
+    in the palm allows the user to 'spin' this thread.
+
+trait-name-AddictionNicotine = Nicotine Addiction
+trait-description-AddictionNicotine =
+    You have an addiction to Nicotine, and will require frequent smoke breaks to keep your mood in check.
+
+trait-name-AnimalFriend = Animal Friend
+trait-description-AnimalFriend =
+    You have a way with animals. You will never be attacked by animals, unless you attack them first.
+
+trait-name-Liar = Pathological liar
+trait-description-Liar = You can hardly bring yourself to tell the truth. Sometimes you lie anyway.
+
+trait-name-ValyrianStandard = Valyrian Standard
+trait-description-ValyrianStandard =
+    A language descended from eastern european languages of old earth - Valyrian Standard is the commonly spoken tongue of Harpies brought up on their homeworld of Valyrian 4b
+    It is rarely spoken outside of the worlds of its native speakers, and has in modern times been supplanted by the 'Conlangs of the Sol Alliance.
+    Its speakers are those who wish to uphold the traditions and beliefs of ancient peoples from before the colonial era.
+
+trait-name-LowPotential = Low Psi-Potential
+trait-description-LowPotential =
+    You possess an unusually weak connection to the noösphere, which makes it more difficult to obtain new psionic powers.
+
+trait-name-HighPotential = High Psi-Potential
+trait-description-HighPotential =
+    Your connection to the noösphere is greater than average, making it easier to obtain new psionic powers.
+
+trait-name-LowAmplification = kα Deficiency
+trait-description-LowAmplification =
+    Your psionic abilities are noticeably weaker than ones used by other psions.
+
+trait-name-HighAmplification = kα Abundance
+trait-description-HighAmplification =
+    Your psionic abilities are stronger than those of other psions.
+
+trait-name-PowerOverwhelming = Power Overwhelming
+trait-description-PowerOverwhelming =
+    WITNESS MY HATE MORTALS, COWER BEFORE MY PSIONIC MIGHT! REALITY IS AS I DEEM IT.
+
+trait-name-LowDampening = kδ Defect
+trait-description-LowDampening =
+    Your skill in manipulating the noösphere is weaker than others. You may experience unintended effects from using your abilities.
+
+trait-name-HighDampening = kδ Proficient
+trait-description-HighDampening =
+    You are skilled in the art of subtly manipulating the noösphere. Your powers are less likely to show unintended effects.
+
+trait-name-Azaziba = Sinta'Azaziba
+trait-description-Azaziba =
+    A language of Moghes consisting of a combination of spoken word and gesticulation.
+    While waning since Moghes entered the galactic stage - it enjoys popular use by Unathi that never fell to the Hegemony's cultural dominance.
+
+trait-name-BionicArm = Bionic Arm
+trait-description-BionicArm =
+    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
+    or a more obvious metal limb. This limb provides enhanced strength to its user, allowing one to pry open barriers with their bare hands.
+
+trait-name-PlateletFactories = Platelet Factories
+trait-description-PlateletFactories =
+    Your body has been augmented with a series of biotailored organs that enhance the owner's long term survivability. These organs will attempt
+    to keep the user alive, even in the face of advanced trauma, all the way up until - but not including - death.
+    Your natural healing is no longer capped, and will now slowly heal any damage type. This includes more exotic injuries like radiation exposure, or cancer.
+
+trait-name-DermalArmor = Dermal Armor
+trait-description-DermalArmor =
+    Your skin has been replaced with a flexible, yet sturdy, hard-polymer shell wrapped in a layer of synthetic flesh.
+    This augmentation provides an innate 10% resistance to physical damage.
+
+trait-name-CyberEyes = Cyber-Eyes Basic System
+trait-description-CyberEyes =
+    One or more of your eyes have been replaced with a highly modular mechanical ocular implant.
+    Their most basic functionality is to provide amelioration for weaknesses of the wearer's natural eyes.
+    The functionality of these implants can be extended by a variety of commercially available modules.
+
+trait-name-FlareShielding = Cyber-Eyes: Eye Damage Resistance
+trait-description-FlareShielding =
+    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+    This provides immunity from most bright flashes of light, such as those from welding arcs.
+
+trait-name-CyberEyesSecurity = Cyber-Eyes: SecHud Module
+trait-description-CyberEyesSecurity =
+    Your Cyber-Eyes have been upgraded to include a built-in Security Hud. Note that this augmentation is considered Contraband
+    for anyone not under the employ of station Security personel, and may be disabled by your employer before dispatch to the station.
+
+trait-name-CyberEyesMedical = Cyber-Eyes: MedHud Module
+trait-description-CyberEyesMedical =
+    Your Cyber-Eyes have been upgraded to include a built-in Medical Hud, allowing you to track the relative health condition of biological organisms.
+
+trait-name-CyberEyesDiagnostic = Cyber-Eyes: Diagnostics Module
+trait-description-CyberEyesDiagnostic =
+    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
+
+trait-name-CyberEyesOmni = Cyber-Eyes: Premium Suite Module
+trait-description-CyberEyesOmni =
+    This expensive implant provides the combined benefits of a SecHud, MedHud, and a Diagnostics Module.
+    Note that this augmentation is considered Contraband for anyone not under the employ of station Security personel,
+    and may be disabled by your employer before dispatch to the station.
+
+trait-name-DispelPower = Normality Projection
+trait-description-DispelPower =
+    Your Mentalic abilities include the power to enforce normality upon Noospheric phenomena.
+    This power, commonly known as "Dispel", allows the user to destroy otherworldly entities with their mind,
+    or to immediately end psychic effects.
+
+trait-name-MetapsionicPower = Metapsion
+trait-description-MetapsionicPower =
+    You are able to intuitively sense the activation of psionic abilities, as well as send out a 'scanning' pulse
+    to detect whether or not psions are nearby. This ability has a wide area of effect, and cannot precisely
+    scan individual entities. Still, it is better than being blind.
+
+trait-name-XenoglossyPower = Xenoglossy
+trait-description-XenoglossyPower =
+    An advanced form of Telepathy, Xenoglossy is the ability to speak using emotional and metaphysical concepts,
+    rather than words, to impart meaning directly into the minds of a listener. When speaking using Xenoglossy, a psion can be
+    universally understood by any entity, who will hear the words as if spoken in one's own native tongue. Additionally,
+    Xenoglossy grants the ability to divine the underlying emotional meaning from the minds of other speakers,
+    allowing its user to understand any spoken language as if it was the user's own native tongue.
+
+trait-name-PsychognomyPower = Psychognomist
+trait-description-PsychognomyPower =
+    A special talent derived from Telepathy, Psychognomy is the ability to read the underlying imprint of telepathic messages.
+    A Psychognomist can glean additional information from their telepathy, seeing vague outlines of what the source of a message
+    might be. This information is not precise, and is largely only useful for narrowing down who the source of a message might be.
+
+trait-name-Redshirt = Redshirt
+trait-description-Redshirt =
+    "They said this air would be breathable.
+    Get in, get out again, and no one gets hurt.
+    Something is pulling me up the hill.
+    I look down in my red shirt.
+    I look down in my red shirt."
+    Reduces your threshold for death by 100 points.
+
+trait-name-BrittleBoneDisease = Osteogenesis Imperfecta
+trait-description-BrittleBoneDisease =
+    Also known as "brittle bone disease", people with this genetic disorder have bones that are easily broken,
+    often simply by moving. This trait reduces your threshold for critical injury by 50 points.
+
+trait-name-LightAmplification = Cyber-Eyes: Light Amplification Module
+trait-description-LightAmplification =
+    Your Cyber-Eyes have been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
+
+trait-name-ThermographicVision = Cyber-Eyes: Thermographic Scanner Module
+trait-description-ThermographicVision =
+    Your Cyber-Eyes have been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
+    biological life forms. It can even detect individuals through the walls of a station.
+
+trait-name-ShadowkinBlackeye = Blackeye
+trait-description-ShadowkinBlackeye =
+    You lose your special Shadowkin powers & respect amongst your peers, in return for some points. Effectively, you are only a Shadowkin in name, not in practice.
+
+trait-name-LyreBird = Lyre Bird
+trait-description-LyreBird =
+    Your natural talent for mimicry vastly exceeds that of other Harpies. You have the ability to perfectly imitate songs in their entirety.
+    Be your own full symphony orchestra, jazz group, or metal band.
+
+trait-name-NaniteAutoRepairBots = Nanite Auto-Repair Bots
+trait-description-NaniteAutoRepairBots =
+    Your chassis has been outfitted with Nanite Repair Drones. Whenever your sensors detect that you've recieved structural damage, the NRDs will activate to bring you back to operational standards.
+
+trait-name-BionicLeg = Bionic Leg
+trait-description-BionicLeg =
+    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
+    or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
+
+trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
+trait-description-FlareShieldingModule =
+    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+    This provides immunity from most bright flashes of light, such as those from welding arcs, exclusive to IPCs because it only needs the module
+    skipping the eye insertion process.
+
+trait-name-SecurityEyesModule = I.P.C Eye Module: Sechud
+trait-description-SecurityEyesModule =
+    A module installed in IPCs that work for the security department and similar, this module is considered contraband and may be removed if the unit isn't working for the security department.
+
+trait-name-MedicalEyesModule = I.P.C Eye Module: Medical
+trait-description-MedicalEyesModule =
+    Your eyes have been upgraded to include a built-in Medical Hud, allowing you to track the relative health condition of biological organisms.
+
+trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
+trait-description-DiagnosticEyesModule =
+    You possess a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
+
+trait-name-OmniEyesModule = I.P.C Eye Module: Premium Model
+trait-description-OmniEyesModule =
+    This upgrade provides the combined benefits of a SecHud, MedHud, and a Diagnostics Module.
+    Note that this module is considered Contraband for anyone not under the employ of station Security personel,
+    and may be disabled by your employer before dispatch to the station.
+
+trait-name-LightAmplificationModule = I.P.C Eye Module: Light Amplification
+trait-description-LightAmplificationModule =
+    Your vision has been enhanced with a light amplifier module, enabling the user to toggle between standard sight and "Night Vision" mode.
+
+trait-name-ThermographicVisionModule = I.P.C Eye Module: Thermographic Scanner
+trait-description-ThermographicVisionModule =
+    Your vision has been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
+    biological life forms. It can even detect individuals through the walls of a station.


### PR DESCRIPTION
# Description

Changes/buffs to Cybernetic Traits.
Some lesser used traits get some love, while some other stuff gets some logical re-balancing.

Feel free to point out if some shitcode is broken or need explaining.

---

# TODO

- [ ] I got ideas cooking that I don't know how to code 

---

# Changelog


:cl:

    tweak: Striking Calluses no longer require you to be one of 3 jobs and Human. I understand you wanted something unique to humans but I'd rather just add 4-5 more perk points to Humans so they're more customizable as a race than punch harder. Also increased the +1 damage to +2.
    tweak: Bionic Spinarette SHOULD no longer have a hunger penalty and costs less. (I don't know if it's still bugged or not.)
    tweak: Platelet Factories heal rate buffed from 0.07 to 0.35 and healing cap increased from 200 to 400. (still drastically worse than the IPC one which got merged and honestly I should buff it even more, but we'll see)
    tweak: Decreased the cost of Thermal Vision to be in line with Night Vision because they're both in the same research tier, costs the same, but one of these just costs twice as much.
    tweak: IPC Platelet Factories healing cap increased from 200 to 250
    fix: Name of Cyber-Eyes Modules for Night Vision and Thermal Vision (It was bothering me)
    remove: Mind over Machine from Cyber-Eyes Modules, what's the point of having Cyber-Eyes if you can't do anything with em.

