### PR TITLE
Experimental Welder Rework

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -177,7 +177,7 @@
   name: experimental welding tool
   parent: Welder
   id: WelderExperimental
-  Description: "An experimental welder that is less harmful to the eyes while having a hotter flame and slowly regenerating fuel."
+  description: "An experimental welder that is less harmful to the eyes while having a hotter flame and slowly regenerating fuel."
   components:
   - type: Sprite
     sprite: Objects/Tools/welder_experimental.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -157,7 +157,7 @@
   name: advanced industrial welding tool
   parent: WelderIndustrial
   id: WelderIndustrialAdvanced
-  description: "An advanced industrial welder with over double the fuel capacity and hotter flame."
+  description: "An advanced industrial welder with over five times the fuel capacity and hotter flame."
   components:
   - type: Sprite
     sprite: Objects/Tools/welder_industrialadv.rsi
@@ -168,16 +168,16 @@
       Welder:
         reagents:
         - ReagentId: WeldingFuel
-          Quantity: 250
-        maxVol: 250
+          Quantity: 500
+        maxVol: 500
   - type: Tool
-    speedModifier: 1.3
+    speedModifier: 1.5
 
 - type: entity
   name: experimental welding tool
   parent: Welder
   id: WelderExperimental
-  description: "An experimental welder capable of self-fuel generation and less harmful to the eyes."
+  description: "An experimental welder capable of self-fuel generation, an extremely hot flame, and is less harmful to eyes."
   components:
   - type: Sprite
     sprite: Objects/Tools/welder_experimental.rsi
@@ -188,8 +188,8 @@
       Welder:
         reagents:
         - ReagentId: WeldingFuel
-          Quantity: 1000
-        maxVol: 1000
+          Quantity: 200
+        maxVol: 200
   - type: PointLight
     enabled: false
     radius: 1.5
@@ -199,7 +199,9 @@
     generated:
       reagents:
       - ReagentId: WeldingFuel
-        Quantity: 1
+        Quantity: 0.5
+  - type: Tool
+    speedModifier: 2
 
 - type: entity
   name: emergency welding tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -177,7 +177,7 @@
   name: experimental welding tool
   parent: Welder
   id: WelderExperimental
-  description: "An experimental welder capable of self-fuel generation, an extremely hot flame, and is less harmful to eyes."
+  Description: "An experimental welder that is less harmful to the eyes while having a hotter flame and slowly regenerating fuel."
   components:
   - type: Sprite
     sprite: Objects/Tools/welder_experimental.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -157,7 +157,7 @@
   name: advanced industrial welding tool
   parent: WelderIndustrial
   id: WelderIndustrialAdvanced
-  description: "An advanced industrial welder with over five times the fuel capacity and hotter flame."
+  description: "An advanced industrial welder with over five times the fuel capacity and a hotter flame."
   components:
   - type: Sprite
     sprite: Objects/Tools/welder_industrialadv.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Changes the experimental welder a decent amount. Rather than being practically a normal welder with nigh unlimited fuel, it is now a super fast welder with slower self-fueling, and a much lower fuel capacity. Changes advanced industrial welder to make it still a worthwhile item.

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Advanced Industrial welder from 250 capacity to 500
- tweak: Advanced Industrial welder from 1.3x speed to 1.5x speed
- tweak: Experimental welder from 1000 capacity to 200
- tweak: Experimental welder from 1u of welder fuel generated to 0.5u
- tweak: Experimental welder from 1x speed to 2x speed
