### PR TITLE
BSO Energy shotgun

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/blueshield_officer.yml
@@ -29,6 +29,8 @@
       id: LoadoutBSOEnergyShield
     - type: loadout
       id: LoadoutBSORifleBRDIR25
+    - type: loadout
+      id: LoadoutBSOEnergyShotgun
 
 #- type: characterItemGroup
 #  id: LoadoutJOBEyes

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -102,6 +102,23 @@
     - WeaponSubMachineGunBRDIR25
 
 - type: loadout
+  id: LoadoutBSOEnergyShotgun
+  category: JobsCommandBlueshieldOfficer
+  cost: 0
+  canBeHeirloom: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBlueshieldOfficerPrimary
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+    - !type:CharacterAgeRequirement
+      min: 21
+  items:
+    - WeaponEnergyShotgun
+
+
+- type: loadout
   id: LoadoutBSOEnergyShield
   category: JobsCommandBlueshieldOfficer
   cost: 0


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Brings EE up to date with goob MRP, where BSO has the energy shotgun. This will make future merges easier for Goob MRP, and will give BSO on EE another option. It is still significantly weaker then the rifle given to them by TCJ, which is why it'll match everything else in point cost.

---


<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Gave BSO energy shotgun as a loadout gun.
