### PR TITLE
Allow Weldbot to Fix Specific Structures

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/WeldbotWeldOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/WeldbotWeldOperator.cs
@@ -25,6 +25,11 @@ public sealed partial class WeldbotWeldOperator : HTNOperator
     private TagSystem _tagSystem = default!;
 
     public const string SiliconTag = "SiliconMob";
+    public const string WeldotFixableStructureTag = "WeldbotFixableStructure";
+
+    public const float EmaggedBurnDamage = 10;
+    public const float SiliconRepairAmount = 30;
+    public const float StructureRepairAmount = 5;
 
     /// <summary>
     /// Target entity to inject.
@@ -57,33 +62,58 @@ public sealed partial class WeldbotWeldOperator : HTNOperator
         if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entMan) || _entMan.Deleted(target))
             return HTNOperatorStatus.Failed;
 
-        var tagPrototype = _prototypeManager.Index<TagPrototype>(SiliconTag);
+        var tagSiliconMobPrototype = _prototypeManager.Index<TagPrototype>(SiliconTag);
+        var tagWeldFixableStructurePrototype = _prototypeManager.Index<TagPrototype>(WeldotFixableStructureTag);
 
-        if (!_entMan.TryGetComponent<TagComponent>(target, out var tagComponent) || !_tagSystem.HasTag(tagComponent, tagPrototype)
+        if(!_entMan.TryGetComponent<TagComponent>(target, out var tagComponent))
+            return HTNOperatorStatus.Failed;
+
+        var weldableIsSilicon = _tagSystem.HasTag(tagComponent, tagSiliconMobPrototype);
+        var weldableIsStructure = _tagSystem.HasTag(tagComponent, tagWeldFixableStructurePrototype);
+
+        if ((!weldableIsSilicon && !weldableIsStructure)
             || !_entMan.TryGetComponent<WeldbotComponent>(owner, out var botComp)
             || !_entMan.TryGetComponent<DamageableComponent>(target, out var damage)
-            || !_interaction.InRangeUnobstructed(owner, target)
-            || (damage.DamagePerGroup["Brute"].Value == 0 && !_entMan.HasComponent<EmaggedComponent>(owner)))
+            || !_interaction.InRangeUnobstructed(owner, target))
+            return HTNOperatorStatus.Failed;
+
+        var canWeldSilicon = damage.DamagePerGroup["Brute"].Value > 0  || _entMan.HasComponent<EmaggedComponent>(owner);
+        var canWeldStructure = damage.TotalDamage.Value > 0;
+
+        if ((!canWeldSilicon && weldableIsSilicon) || (!canWeldStructure && weldableIsStructure))
             return HTNOperatorStatus.Failed;
 
         if (botComp.IsEmagged)
         {
-            if (!_prototypeManager.TryIndex<DamageGroupPrototype>("Burn", out var prototype))
+            if (!_prototypeManager.TryIndex<DamageGroupPrototype>("Burn", out var prototype) || weldableIsStructure)
                 return HTNOperatorStatus.Failed;
 
-            _damageableSystem.TryChangeDamage(target, new DamageSpecifier(prototype, 10), true, false, damage);
+            _damageableSystem.TryChangeDamage(target, new DamageSpecifier(prototype, EmaggedBurnDamage), true, false, damage);
         }
         else
         {
-            if (!_prototypeManager.TryIndex<DamageGroupPrototype>("Brute", out var prototype))
-                return HTNOperatorStatus.Failed;
+            if (weldableIsSilicon)
+            {
+                if (!_prototypeManager.TryIndex<DamageGroupPrototype>("Brute", out var prototype))
+                    return HTNOperatorStatus.Failed;
 
-            _damageableSystem.TryChangeDamage(target, new DamageSpecifier(prototype, -50), true, false, damage);
+                _damageableSystem.TryChangeDamage(target, new DamageSpecifier(prototype, -SiliconRepairAmount), true, false, damage);
+            }
+            else if (weldableIsStructure)
+            {
+                //If a structure explicitly has a tag to allow a Weldbot to fix it, trust that we can just do so no matter what the damage actually is.
+                _damageableSystem.ChangeAllDamage(target, damage, -StructureRepairAmount);
+            }
+            else
+            {
+                return HTNOperatorStatus.Failed;
+            }
         }
 
         _audio.PlayPvs(botComp.WeldSound, target);
 
-        if(damage.DamagePerGroup["Brute"].Value == 0) //only say "all done if we're actually done!"
+        if((weldableIsSilicon && damage.DamagePerGroup["Brute"].Value == 0)
+            || (weldableIsStructure && damage.TotalDamage.Value == 0)) //only say "all done if we're actually done!"
             _chat.TrySendInGameICMessage(owner, Loc.GetString("weldbot-finish-weld"), InGameICChatType.Speak, hideChat: true, hideLog: true);
 
         return HTNOperatorStatus.Finished;

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -256,6 +256,39 @@ namespace Content.Shared.Damage
             // Shitmed Change End
         }
 
+        /// <summary>
+        ///     Changes all damage types supported by a <see cref="DamageableComponent"/> by the specified value.
+        /// </summary>
+        /// <remakrs>
+        ///     Will not lower damage to a negative value.
+        /// </remakrs>
+        public void ChangeAllDamage(EntityUid uid, DamageableComponent component, FixedPoint2 addedValue)
+        {
+            foreach (var type in component.Damage.DamageDict.Keys)
+            {
+                component.Damage.DamageDict[type] += addedValue;
+                if (component.Damage.DamageDict[type] < 0)
+                    component.Damage.DamageDict[type] = 0;
+            }
+
+            // Changing damage does not count as 'dealing' damage, even if it is set to a larger value, so we pass an
+            // empty damage delta.
+            DamageChanged(uid, component, new DamageSpecifier());
+
+            // Shitmed Change Start
+            if (HasComp<TargetingComponent>(uid))
+            {
+                foreach (var (part, _) in _body.GetBodyChildren(uid))
+                {
+                    if (!TryComp(part, out DamageableComponent? damageComp))
+                        continue;
+
+                    ChangeAllDamage(part, damageComp, addedValue);
+                }
+            }
+            // Shitmed Change End
+        }
+
         public void SetDamageModifierSetId(EntityUid uid, string damageModifierSetId, DamageableComponent? comp = null)
         {
             if (!_damageableQuery.Resolve(uid, ref comp))

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -277,8 +277,8 @@ namespace Content.Shared.Damage
 
             // Shitmed Change Start
             if (!HasComp<TargetingComponent>(uid))
-                continue;
-                
+                return;
+
             foreach (var (part, _) in _body.GetBodyChildren(uid))
             {
                 if (!TryComp(part, out DamageableComponent? damageComp))

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -276,15 +276,15 @@ namespace Content.Shared.Damage
             DamageChanged(uid, component, new DamageSpecifier());
 
             // Shitmed Change Start
-            if (HasComp<TargetingComponent>(uid))
+            if (!HasComp<TargetingComponent>(uid))
+                continue;
+                
+            foreach (var (part, _) in _body.GetBodyChildren(uid))
             {
-                foreach (var (part, _) in _body.GetBodyChildren(uid))
-                {
-                    if (!TryComp(part, out DamageableComponent? damageComp))
-                        continue;
+                if (!TryComp(part, out DamageableComponent? damageComp))
+                    continue;
 
-                    ChangeAllDamage(part, damageComp, addedValue);
-                }
+                ChangeAllDamage(part, damageComp, addedValue);
             }
             // Shitmed Change End
         }

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Windows/tinted_windows.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Windows/tinted_windows.yml
@@ -14,6 +14,7 @@
   - type: Tag
     tags:
       - ForceNoFixRotations
+      - WeldbotFixableStructure
   - type: Icon
     sprite: Structures/Windows/directional.rsi
     state: tinted_window

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -43,6 +43,9 @@
     - state: panel_open
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AnimationPlayer
+  - type: Tag
+    tags:
+      - WeldbotFixableStructure
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: DoorSignalControl

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -77,6 +77,9 @@
   - type: InteractionOutline
   - type: Damageable
     damageContainer: StructuralInorganic
+  - type: Tag
+    tags:
+      - WeldbotFixableStructure
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
@@ -164,6 +167,9 @@
   - type: Repairable
   - type: Damageable
     damageContainer: StructuralInorganic
+  - type: Tag
+    tags:
+      - WeldbotFixableStructure
   - type: DamageVisuals
     thresholds: [8, 16, 25]
     damageDivisor: 3.333

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -39,6 +39,9 @@
   - type: IconSmooth
     base: swindow
   - type: Appearance
+  - type: Tag
+    tags:
+      - WeldbotFixableStructure
   - type: DamageVisuals
     thresholds: [4, 8, 12]
     damageDivisor: 28

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -18,6 +18,7 @@
     tags:
       - ForceFixRotations
       - Window
+      - WeldbotFixableStructure
   - type: Sprite
     drawdepth: WallTops
     sprite: Structures/Windows/window.rsi
@@ -115,6 +116,7 @@
     tags:
       - Window
       - Directional #Delta V - Summary: Allows the tilewindow mapping command to work.
+      - WeldbotFixableStructure
   - type: MeleeSound
     soundGroups:
       Brute:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windows.yml
@@ -19,6 +19,7 @@
     tags:
       - ForceFixRotations
       - Window
+      - WeldbotFixableStructure
   - type: Physics
     bodyType: Static
   - type: Fixtures

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1095,6 +1095,9 @@
   id: SiliconMob
 
 - type: Tag
+  id: WeldbotFixableStructure
+
+- type: Tag
   id: PlushieSharkBlue
 
 - type: Tag


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->
As requested in Goobstation MRP;

This update allows the weldbot to, _very slowly_, fix specific structures.
To allow a structure to be repaired by a weldbot, apply the "WeldbotFixableStructure" tag to it.
So far, this has been applied to:
- Windows
- Directional Windows
- Grounding Rods
- Tesla Coils
The robot will repair 5 damage per step to structures. In addition, repair speeds of silicon mobs, borgs and IPC's has been lowered a bit.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Weldbots can now fix specific structures, like windows and grounding rods.
