### PR TITLE
Allow Tricordrazine to Heal Minor Accidental Exposures

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -781,6 +781,7 @@
             Brute: -1
           types:
             Poison: -0.5 ##Should be about what it was when it healed the toxin group
+            Radiation: -0.15 ##Should really only heal minor accidental exposures
             Heat: -0.5
             Shock: -0.5
             Cold: -0.5 # Was .33, Buffed due to limb damage changes


### PR DESCRIPTION

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

As requested in Goob: https://discord.com/channels/1323488536501944350/1323488538750353442/1343047906114011167
this allows Tricordrazine to heal _very minor_ amounts of radiation poisoning. The use case: I walked past a Borg with a micro-RTG and the medibot won't stop bugging me because it doesn't know it can't help. 
With this change it _can_ help, but it's really only viable for small amounts.
Ordinarily, in these small amounts of damage (10-12 tops), it was a hassle to make appropriate radiation medicine for; a lot of effort for only a tiny problem. This apparently caused annoyance, and this change will both make Tricordrazine a tiny bit more useful and lessen the aforementioned problem.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Tricordrazine to heal MINOR amounts of radiation damage. This includes Medibots. If it's more than a teeny tiny amount, go to medical! This also alleviates the issue where the medibot keeps pestering you about the 0.1 rad damage because it thinks it can heal it, while the medicine it'll inject (before this change) didn't actually do anything.
