### PR TITLE
Trait Add Tag

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -695,9 +695,7 @@ public sealed partial class TraitAddTag : TraitFunction
         IEntityManager entityManager,
         ISerializationManager serializationManager)
     {
-        // DO STUFF between these two brackets
         var tagSystem = entityManager.System<TagSystem>();
-        // tagSystem now contains a massive library of functions, but the relevant one we want is AddTags(), which takes a "target" in the form of uid, and a list of tags, which we just declared in our DataField
         tagSystem.AddTags(uid, Tags);
     }
 }

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -677,3 +677,26 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
         entityManager.Dirty(uid, melee);
     }
 }
+
+
+    // <summary>
+    // Adds a Tag to something
+    // </summary>
+    [UsedImplicitly]
+public sealed partial class TraitAddTag : TraitFunction
+{
+    // Your datafields go here
+    [DataField]
+    public List<ProtoId<TagPrototype>> Tags { get; private set; } = new();
+    // The "Override" goes here
+    public override void OnPlayerSpawn(EntityUid uid,
+        IComponentFactory factory,
+        IEntityManager entityManager,
+        ISerializationManager serializationManager)
+    {
+        // DO STUFF between these two brackets
+        var tagSystem = entityManager.System<TagSystem>();
+        // tagSystem now contains a massive library of functions, but the relevant one we want is AddTags(), which takes a "target" in the form of uid, and a list of tags, which we just declared in our DataField
+        tagSystem.AddTags(uid, Tags);
+    }
+}

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -680,10 +680,10 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
 }
 
 
-    // <summary>
-    // Adds a Tag to something
-    // </summary>
-    [UsedImplicitly]
+// <summary>
+// Adds a Tag to something
+// </summary>
+[UsedImplicitly]
 public sealed partial class TraitAddTag : TraitFunction
 {
     // Your datafields go here

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -686,7 +686,6 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
 [UsedImplicitly]
 public sealed partial class TraitAddTag : TraitFunction
 {
-    // Your datafields go here
     [DataField]
     public List<ProtoId<TagPrototype>> Tags { get; private set; } = new();
     public override void OnPlayerSpawn(EntityUid uid,

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -22,6 +22,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Weapons.Melee;
 using Robust.Shared.Audio;
+using Content.Shared.Tag;
 
 namespace Content.Server.Traits;
 

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -686,7 +686,7 @@ public sealed partial class TraitModifyUnarmed : TraitFunction
 [UsedImplicitly]
 public sealed partial class TraitAddTag : TraitFunction
 {
-    [DataField]
+    [DataField, AlwaysPushInheritance]
     public List<ProtoId<TagPrototype>> Tags { get; private set; } = new();
     
     public override void OnPlayerSpawn(EntityUid uid,

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -688,6 +688,7 @@ public sealed partial class TraitAddTag : TraitFunction
 {
     [DataField]
     public List<ProtoId<TagPrototype>> Tags { get; private set; } = new();
+    
     public override void OnPlayerSpawn(EntityUid uid,
         IComponentFactory factory,
         IEntityManager entityManager,

--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -689,7 +689,6 @@ public sealed partial class TraitAddTag : TraitFunction
     // Your datafields go here
     [DataField]
     public List<ProtoId<TagPrototype>> Tags { get; private set; } = new();
-    // The "Override" goes here
     public override void OnPlayerSpawn(EntityUid uid,
         IComponentFactory factory,
         IEntityManager entityManager,


### PR DESCRIPTION


# Description

Added TraitAddTag Function, which for example can be used to add Spidercraft to the Spinerette trait.

# Changelog

:cl:
- add: TraitAddTag Function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Entities now receive automatic tag assignments at spawn, enhancing the system's trait interaction and overall categorization capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->