### PR TITLE
Fix Various Psionic Bugs

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/AnomalyPowerSystem.EntitySpawn.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/AnomalyPowerSystem.EntitySpawn.cs
@@ -66,7 +66,7 @@ public sealed partial class AnomalyPowerSystem
                         component.CurrentDampening,
                         component.CurrentAmplification,
                         entry.Settings,
-                        _glimmerSystem.GlimmerOutput / 1000,
+                        (float) _glimmerSystem.GlimmerOutput / 1000,
                         component.CurrentAmplification,
                         component.CurrentAmplification);
 

--- a/Content.Server/Nyanotrasen/Objectives/Systems/RaiseGlimmerConditionSystem.cs
+++ b/Content.Server/Nyanotrasen/Objectives/Systems/RaiseGlimmerConditionSystem.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Objectives.Systems
         private float GetProgress(float target)
         {
             var progress = Math.Min(_glimmer.GlimmerOutput / target, 1f);
-            return progress;
+            return (float) progress;
         }
     }
 }

--- a/Content.Server/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -178,7 +178,7 @@ public sealed class GlimmerReactiveSystem : EntitySystem
     private void OnDamageChanged(EntityUid uid, SharedGlimmerReactiveComponent component, DamageChangedEvent args)
     {
         if (args.Origin == null
-            || !_random.Prob(_glimmerSystem.GetGlimmerEquilibriumRatio() / 10))
+            || !_random.Prob((float) _glimmerSystem.GetGlimmerEquilibriumRatio() / 10))
             return;
 
         var tier = _glimmerSystem.GetGlimmerTier();
@@ -195,13 +195,14 @@ public sealed class GlimmerReactiveSystem : EntitySystem
         if (tier < GlimmerTier.High)
             return;
 
-        var totalIntensity = _glimmerSystem.GlimmerOutput * 2;
-        var slope = 11 - _glimmerSystem.GlimmerOutput / 100;
+        var glimmer = (float) _glimmerSystem.GlimmerOutput;
+        var totalIntensity = glimmer * 2;
+        var slope = 11 - glimmer / 100;
         var maxIntensity = 20;
 
-        var removed = _glimmerSystem.GlimmerOutput * _random.NextFloat(0.1f, 0.15f);
+        var removed = glimmer * _random.NextFloat(0.1f, 0.15f);
         _glimmerSystem.DeltaGlimmerInput(-removed);
-        BeamRandomNearProber(uid, (int) _glimmerSystem.GlimmerOutput / 350, _glimmerSystem.GlimmerOutput / 50);
+        BeamRandomNearProber(uid, (int) glimmer / 350, glimmer / 50);
         _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity);
     }
 

--- a/Content.Server/Psionics/Glimmer/PassiveGlimmerReductionSystem.cs
+++ b/Content.Server/Psionics/Glimmer/PassiveGlimmerReductionSystem.cs
@@ -16,11 +16,10 @@ public sealed class PassiveGlimmerReductionSystem : EntitySystem
 
     /// List of glimmer values spaced by minute.
     public List<int> GlimmerValues = new();
-
-    public TimeSpan TargetUpdatePeriod = TimeSpan.FromSeconds(6);
     public TimeSpan NextUpdateTime = default!;
     public TimeSpan LastUpdateTime = default!;
 
+    private TimeSpan _targetUpdatePeriod;
     private float _glimmerLinearDecay;
     private bool _enabled;
 
@@ -28,8 +27,9 @@ public sealed class PassiveGlimmerReductionSystem : EntitySystem
     {
         base.Initialize();
         _enabled = _cfg.GetCVar(CCVars.GlimmerEnabled);
-        _cfg.OnValueChanged(CCVars.GlimmerLinearDecayPerMinute, UpdatePassiveGlimmer, true);
+        _cfg.OnValueChanged(CCVars.GlimmerLinearDecayPerSecond, UpdatePassiveGlimmer, true);
         _cfg.OnValueChanged(CCVars.GlimmerEnabled, value => _enabled = value, true);
+        _cfg.OnValueChanged(CCVars.GlimmerDecayUpdateInterval, value => _targetUpdatePeriod = TimeSpan.FromSeconds(value), true);
     }
 
     public override void Update(float frameTime)
@@ -41,10 +41,10 @@ public sealed class PassiveGlimmerReductionSystem : EntitySystem
         var curTime = _timing.CurTime;
         if (NextUpdateTime > curTime)
             return;
-        NextUpdateTime = curTime + TargetUpdatePeriod;
+        NextUpdateTime = curTime + _targetUpdatePeriod;
         LastUpdateTime = curTime;
 
-        var glimmerDecay = _glimmerLinearDecay / (60 / TargetUpdatePeriod.Seconds);
+        var glimmerDecay = _glimmerLinearDecay * Math.Pow(_targetUpdatePeriod.Seconds, 2) * frameTime;
         _glimmerSystem.DeltaGlimmerOutput(-glimmerDecay);
         GlimmerValues.Add((int) Math.Round(_glimmerSystem.GlimmerOutput));
     }

--- a/Content.Server/Psionics/Glimmer/Structures/GlimmerStructuresSystem.cs
+++ b/Content.Server/Psionics/Glimmer/Structures/GlimmerStructuresSystem.cs
@@ -105,9 +105,9 @@ public sealed class GlimmerStructuresSystem : EntitySystem
                 // As a fun novelty, this means that a highly psionic Epistemics department can essentially "Study" their powers for actual research points!
                 if (source.ResearchPointGeneration != null
                 && TryComp<ResearchPointSourceComponent>(source.Owner, out var research))
-                    research.PointsPerSecond = (int) MathF.Round(
+                    research.PointsPerSecond = (int) Math.Round(
                         source.ResearchPointGeneration.Value
-                        / (MathF.Log(glimmerSources, 4) + 1)
+                        / (Math.Log(glimmerSources, 4) + 1)
                         * _glimmerSystem.GetGlimmerEquilibriumRatio());
 
                 // Shorthand explanation:
@@ -120,14 +120,16 @@ public sealed class GlimmerStructuresSystem : EntitySystem
                 if (source.AddToGlimmer)
                 {
                     _glimmerSystem.DeltaGlimmerInput((_glimmerSystem.GlimmerOutput > glimmerEquilibrium
-                    ? MathF.Pow(_glimmerSystem.GetGlimmerOutputInteger() - source.GlimmerExponentOffset + glimmerSources, 2) : 1f)
-                    * (_glimmerSystem.GlimmerOutput < glimmerEquilibrium ? _glimmerSystem.GetGlimmerEquilibriumRatio() : 1f));
+                    ? Math.Pow(_glimmerSystem.GetGlimmerOutputInteger() - source.GlimmerExponentOffset + glimmerSources, 2) : 1)
+                    * (_glimmerSystem.GlimmerOutput < glimmerEquilibrium ? _glimmerSystem.GetGlimmerEquilibriumRatio() : 1)
+                    * frameTime);
                 }
                 else
                 {
                     _glimmerSystem.DeltaGlimmerInput(-(_glimmerSystem.GlimmerOutput > glimmerEquilibrium
-                    ? MathF.Pow(_glimmerSystem.GetGlimmerOutputInteger() - source.GlimmerExponentOffset + glimmerSources, 2) : 1f)
-                    * (_glimmerSystem.GlimmerOutput > glimmerEquilibrium ? _glimmerSystem.GetGlimmerEquilibriumRatio() : 1f));
+                    ? Math.Pow(_glimmerSystem.GetGlimmerOutputInteger() - source.GlimmerExponentOffset + glimmerSources, 2) : 1)
+                    * (_glimmerSystem.GlimmerOutput > glimmerEquilibrium ? _glimmerSystem.GetGlimmerEquilibriumRatio() : 1)
+                    * frameTime);
                 }
             }
         }

--- a/Content.Server/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Psionics/PsionicsSystem.cs
@@ -225,7 +225,8 @@ public sealed class PsionicsSystem : EntitySystem
         RollAgain:
         component.Potentia -= component.NextPowerCost;
         _psionicAbilitiesSystem.AddPsionics(uid);
-        component.NextPowerCost = component.BaselinePowerCost * MathF.Pow(2, component.PowerSlotsTaken);
+        component.NextPowerCost = Math.Abs( // Taking the absolute value here as a logical guard against this GOTO infinitely looping.
+            component.BaselinePowerCost * MathF.Pow(2, component.PowerSlotsTaken));
         if (component.Potentia > component.NextPowerCost)
             goto RollAgain;
 

--- a/Content.Server/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Psionics/PsionicsSystem.cs
@@ -143,7 +143,7 @@ public sealed class PsionicsSystem : EntitySystem
                 || component.ActivePowers.Contains(power))
                 continue;
 
-            component.AvailablePowers.Add(id.Key, id.Value);
+            component.AvailablePowers.TryAdd(id.Key, id.Value);
         }
     }
 
@@ -269,9 +269,9 @@ public sealed class PsionicsSystem : EntitySystem
             + _random.NextFloat(0, 100);
 
         // Increase the initial odds based on Glimmer.
-        baselineChance += applyGlimmer
+        baselineChance += (float) (applyGlimmer
             ? _glimmerSystem.GetGlimmerEquilibriumRatio() * 25
-            : 0;
+            : 0);
 
         // Certain sources of power rolls provide their own multiplier.
         baselineChance *= rollEventMultiplier;
@@ -280,7 +280,7 @@ public sealed class PsionicsSystem : EntitySystem
         var ev = new OnRollPsionicsEvent(uid, baselineChance);
         RaiseLocalEvent(uid, ref ev);
 
-        if (HandlePotentiaCalculations(uid, component, ev.BaselineChance))
+        if (!HandlePotentiaCalculations(uid, component, ev.BaselineChance))
             return;
 
         HandleRollFeedback(uid);
@@ -297,8 +297,8 @@ public sealed class PsionicsSystem : EntitySystem
             || !psionic.CanReroll)
             return;
 
-        RollPsionics(uid, psionic, true, bonusMuliplier);
         psionic.CanReroll = false;
+        RollPsionics(uid, psionic, true, bonusMuliplier);
     }
 
     private void OnMobstateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)

--- a/Content.Server/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Psionics/PsionicsSystem.cs
@@ -222,9 +222,13 @@ public sealed class PsionicsSystem : EntitySystem
         if (component.Potentia < component.NextPowerCost)
             return false;
 
+        RollAgain:
         component.Potentia -= component.NextPowerCost;
         _psionicAbilitiesSystem.AddPsionics(uid);
         component.NextPowerCost = component.BaselinePowerCost * MathF.Pow(2, component.PowerSlotsTaken);
+        if (component.Potentia > component.NextPowerCost)
+            goto RollAgain;
+
         return true;
     }
 

--- a/Content.Server/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Research/Oracle/OracleSystem.cs
@@ -178,7 +178,7 @@ public sealed class OracleSystem : EntitySystem
             return;
 
         // Why is this hardcoded?
-        var amount = MathF.Round(20 + _random.Next(1, 30) + _glimmer.GlimmerOutput / 10f);
+        var amount = MathF.Round(20 + _random.Next(1, 30) + (float) _glimmer.GlimmerOutput / 10f);
         var temporarySol = new Solution();
         var reagent = _protoMan.Index(oracle.Comp.RewardReagents).Pick(_random);
 

--- a/Content.Shared/CCVar/CCVars.Psionics.cs
+++ b/Content.Shared/CCVar/CCVars.Psionics.cs
@@ -14,8 +14,14 @@ public sealed partial class CCVars
     ///     The rate at which glimmer linearly decays. Since glimmer increases (usually) follow a logistic curve, this means glimmer
     ///     becomes increasingly harder to raise after ~502 points.
     /// </summary>
-    public static readonly CVarDef<float> GlimmerLinearDecayPerMinute =
-        CVarDef.Create("glimmer.linear_decay_per_minute", 6f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> GlimmerLinearDecayPerSecond =
+        CVarDef.Create("glimmer.linear_decay_per_second", 1f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     How many seconds between updates to passive glimmer decay.
+    /// </summary>
+    public static readonly CVarDef<float> GlimmerDecayUpdateInterval =
+        CVarDef.Create("glimmer.decay_update_interval", 6f, CVar.SERVERONLY);
 
     /// <summary>
     ///     Whether random rolls for psionics are allowed.

--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -13,7 +13,7 @@ public sealed class GlimmerSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
-    private float _glimmerInput = 0;
+    private double _glimmerInput = 0;
 
     /// <summary>
     ///     GlimmerInput represents the system-facing value of the station's glimmer, and is given by f(y) for this graph: https://www.desmos.com/calculator/posutiq38e
@@ -22,7 +22,7 @@ public sealed class GlimmerSystem : EntitySystem
     /// <remarks>
     ///     This is private set for a good reason, if you're looking to change it, do so via DeltaGlimmerInput or SetGlimmerInput
     /// </remarks>
-    public float GlimmerInput
+    public double GlimmerInput
     {
         get { return _glimmerInput; }
         private set { _glimmerInput = _enabled ? Math.Max(value, 0) : 0; }
@@ -34,12 +34,12 @@ public sealed class GlimmerSystem : EntitySystem
     /// </summary>
     public string GlimmerInputString => _glimmerInput.ToString("#.##");
 
-    private float _glimmerOutput = 0;
+    private double _glimmerOutput = 0;
 
     /// <summary>
     ///     This constant is equal to the intersection of the Glimmer Equation(https://www.desmos.com/calculator/posutiq38e) and the line Y = X.
     /// </summary>
-    public const float GlimmerEquilibrium = 502.941f;
+    public const double GlimmerEquilibrium = 502.941;
 
 
     /// <summary>
@@ -49,10 +49,10 @@ public sealed class GlimmerSystem : EntitySystem
     /// <remarks>
     ///     This is private set for a good reason, if you're looking to change it, do so via DeltaGlimmerOutput or SetGlimmerOutput
     /// </remarks>
-    public float GlimmerOutput
+    public double GlimmerOutput
     {
         get { return _glimmerOutput; }
-        private set { _glimmerOutput = _enabled ? Math.Clamp(value, 0, 999.999f) : 0; }
+        private set { _glimmerOutput = _enabled ? Math.Clamp(value, 0, 999.999) : 0; }
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public sealed class GlimmerSystem : EntitySystem
     ///     and is the lowest form of abstracted glimmer. It's meant more for sprite states than math.
     /// </summary>
     /// <param name="glimmer">What glimmer count to check. Uses the current glimmer by default.</param>
-    public GlimmerTier GetGlimmerTier(float? glimmer = null)
+    public GlimmerTier GetGlimmerTier(double? glimmer = null)
     {
         if (glimmer == null)
             glimmer = GlimmerOutput;
@@ -105,7 +105,7 @@ public sealed class GlimmerSystem : EntitySystem
     {
         if (!_enabled)
             return 1;
-        else return (int) MathF.Round(GlimmerOutput / 1000);
+        else return (int) Math.Round(GlimmerOutput / 1000);
     }
 
     /// <summary>
@@ -113,12 +113,12 @@ public sealed class GlimmerSystem : EntitySystem
     ///     Go through this if you want glimmer to be modified faster if its below 502.941f, and slower if above said equilibrium
     /// </summary>
     /// <param name="delta"></param>
-    public void DeltaGlimmerInput(float delta)
+    public void DeltaGlimmerInput(double delta)
     {
         if (_enabled && delta != 0)
         {
             GlimmerInput += delta;
-            GlimmerOutput = Math.Clamp(2000 / (1 + MathF.Pow(MathF.E, -.0022f * GlimmerInput)) - 1000, 0, 999.999999f);
+            GlimmerOutput = Math.Clamp(2000 / (1 + Math.Pow(Math.E, -.0022 * GlimmerInput)) - 1000, 0, 999.999999);
         }
     }
 
@@ -127,12 +127,12 @@ public sealed class GlimmerSystem : EntitySystem
     ///     This is primarily intended for load bearing systems such as Probers and Drainers, and should not be called by most things by design.
     /// </summary>
     /// <param name="delta"></param>
-    public void DeltaGlimmerOutput(float delta)
+    public void DeltaGlimmerOutput(double delta)
     {
         if (_enabled && delta != 0)
         {
             GlimmerOutput += delta;
-            GlimmerInput = Math.Max(2000 / (1 + MathF.Pow(MathF.E, -.0022f * GlimmerOutput)) - 1000, 0);
+            GlimmerInput = Math.Max(2000 / (1 + Math.Pow(Math.E, -.0022 * GlimmerOutput)) - 1000, 0);
         }
     }
 
@@ -145,8 +145,8 @@ public sealed class GlimmerSystem : EntitySystem
     {
         if (_enabled && set != 0)
         {
-            GlimmerOutput = Math.Clamp(set, 0, 999.999f);
-            GlimmerInput = 2000 / (1 + MathF.Pow(MathF.E, -.0022f * GlimmerOutput)) - 1000;
+            GlimmerOutput = Math.Clamp(set, 0, 999.999);
+            GlimmerInput = 2000 / (1 + Math.Pow(Math.E, -.0022 * GlimmerOutput)) - 1000;
         }
     }
 
@@ -160,7 +160,7 @@ public sealed class GlimmerSystem : EntitySystem
         if (_enabled && set >= 0)
         {
             GlimmerInput = set;
-            GlimmerOutput = 2000 / (1 + MathF.Pow(MathF.E, -.0022f * GlimmerOutput)) - 1000;
+            GlimmerOutput = 2000 / (1 + Math.Pow(Math.E, -.0022 * GlimmerOutput)) - 1000;
         }
     }
 
@@ -168,7 +168,7 @@ public sealed class GlimmerSystem : EntitySystem
     ///     Outputs the ratio between actual glimmer and glimmer equilibrium(The intersection of the Glimmer Equation and the line y = x).
     ///     This will return 0.01f if glimmer is 0, and 1 if glimmer is disabled.
     /// </summary>
-    public float GetGlimmerEquilibriumRatio()
+    public double GetGlimmerEquilibriumRatio()
     {
         if (!_enabled)
             return 1;


### PR DESCRIPTION
# Description

This isn't fixing all of them by the way, I still need to completely rewrite the equations for the glimmer generating structures so the math there isn't completely terrible. This fixes a few bugs related to the glimmer system, such as linear decay not being consistent regardless of server ping, and also glimmer generating structures also not being consistent based on server ping. Both are now correctly differentiated with respect to time.

Problem though is that the glimmer generator math is still extremely awful, so that's going to need a rewrite.

After deeply analyzing the glimmer equations, I figured out that they were being screwed over by floating point precision limits, so to address this I made Glimmer work on doubles instead. 

I also fixed a bug where generating enough Potentia to gain two or more powers in a single draw caused the user to permanently lose their ability to generate new powers. It's not abundantly clear why this was happening, because nothing changed this code at all since I last touched it. 

# Changelog

:cl:
- fix: Fixed various bugs with psionics.
- fix: Fixed a bug where if you generated enough Potentia during a drug induced psionics roll to gain two powers, you would only gain one power instead, while permanently losing the ability to gain new powers.
- tweak: Glimmer now operates on double precision. Have fun with that breaking change if you made any psionic code downstream. Hint, you can cast doubles into a (float) if you don't wish to convert your system to double. 
