### PR TITLE
Supermatter Atmos Mapping Assets

### DIFF
--- a/Content.Server/Atmos/Components/AtmosFixMarkerComponent.cs
+++ b/Content.Server/Atmos/Components/AtmosFixMarkerComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Atmos;
+
 namespace Content.Server.Atmos.Components
 {
     /// <summary>
@@ -7,7 +9,10 @@ namespace Content.Server.Atmos.Components
     public sealed partial class AtmosFixMarkerComponent : Component
     {
         // See FixGridAtmos for more details
-        [DataField("mode")]
+        [DataField]
         public int Mode { get; set; } = 0;
+
+        [DataField]
+        public GasMixture? GasMix = default!;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -30,90 +30,94 @@ public sealed partial class AtmosphereSystem
     [AdminCommand(AdminFlags.Debug)]
     private void FixGridAtmosCommand(IConsoleShell shell, string argstr, string[] args)
     {
-       if (args.Length == 0)
-       {
-           shell.WriteError("Not enough arguments.");
-           return;
-       }
+        if (args.Length == 0)
+        {
+            shell.WriteError("Not enough arguments.");
+            return;
+        }
 
-       var mixtures = new GasMixture[8];
-       for (var i = 0; i < mixtures.Length; i++)
-           mixtures[i] = new GasMixture(Atmospherics.CellVolume) { Temperature = Atmospherics.T20C };
+        var mixtures = new GasMixture[8];
+        for (var i = 0; i < mixtures.Length; i++)
+            mixtures[i] = new GasMixture(Atmospherics.CellVolume) { Temperature = Atmospherics.T20C };
 
-       // 0: Air
-       mixtures[0].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
-       mixtures[0].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
+        // 0: Air
+        mixtures[0].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
+        mixtures[0].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
 
-       // 1: Vaccum
+        // 1: Vaccum
 
-       // 2: Oxygen (GM)
-       mixtures[2].AdjustMoles(Gas.Oxygen, Atmospherics.MolesCellGasMiner);
+        // 2: Oxygen (GM)
+        mixtures[2].AdjustMoles(Gas.Oxygen, Atmospherics.MolesCellGasMiner);
 
-       // 3: Nitrogen (GM)
-       mixtures[3].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellGasMiner);
+        // 3: Nitrogen (GM)
+        mixtures[3].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellGasMiner);
 
-       // 4: Plasma (GM)
-       mixtures[4].AdjustMoles(Gas.Plasma, Atmospherics.MolesCellGasMiner);
+        // 4: Plasma (GM)
+        mixtures[4].AdjustMoles(Gas.Plasma, Atmospherics.MolesCellGasMiner);
 
-       // 5: Instant Plasmafire (r)
-       mixtures[5].AdjustMoles(Gas.Oxygen, Atmospherics.MolesCellGasMiner);
-       mixtures[5].AdjustMoles(Gas.Plasma, Atmospherics.MolesCellGasMiner);
-       mixtures[5].Temperature = 5000f;
+        // 5: Instant Plasmafire (r)
+        mixtures[5].AdjustMoles(Gas.Oxygen, Atmospherics.MolesCellGasMiner);
+        mixtures[5].AdjustMoles(Gas.Plasma, Atmospherics.MolesCellGasMiner);
+        mixtures[5].Temperature = 5000f;
 
-       // 6: (Walk-In) Freezer
-       mixtures[6].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
-       mixtures[6].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
-       mixtures[6].Temperature = 235f; // Little colder than an actual freezer but gives a grace period to get e.g. themomachines set up, should keep warm for a few door openings
+        // 6: (Walk-In) Freezer
+        mixtures[6].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
+        mixtures[6].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
+        mixtures[6].Temperature = 235f; // Little colder than an actual freezer but gives a grace period to get e.g. themomachines set up, should keep warm for a few door openings
 
-       // 7: Nitrogen (101kpa) for vox rooms
-       mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
+        // 7: Nitrogen (101kpa) for vox rooms
+        mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
 
-       foreach (var arg in args)
-       {
-           if (!NetEntity.TryParse(arg, out var netEntity) || !TryGetEntity(netEntity, out var euid))
-           {
-               shell.WriteError($"Failed to parse euid '{arg}'.");
-               return;
-           }
+        foreach (var arg in args)
+        {
+            if (!NetEntity.TryParse(arg, out var netEntity) || !TryGetEntity(netEntity, out var euid))
+            {
+                shell.WriteError($"Failed to parse euid '{arg}'.");
+                return;
+            }
 
-           if (!TryComp(euid, out MapGridComponent? gridComp))
-           {
-               shell.WriteError($"Euid '{euid}' does not exist or is not a grid.");
-               return;
-           }
+            if (!TryComp(euid, out MapGridComponent? gridComp))
+            {
+                shell.WriteError($"Euid '{euid}' does not exist or is not a grid.");
+                return;
+            }
 
-           if (!TryComp(euid, out GridAtmosphereComponent? gridAtmosphere))
-           {
-               shell.WriteError($"Grid \"{euid}\" has no atmosphere component, try addatmos.");
-               continue;
-           }
+            if (!TryComp(euid, out GridAtmosphereComponent? gridAtmosphere))
+            {
+                shell.WriteError($"Grid \"{euid}\" has no atmosphere component, try addatmos.");
+                continue;
+            }
 
-           // Force Invalidate & update air on all tiles
-           Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> grid =
-               new(euid.Value, gridAtmosphere, Comp<GasTileOverlayComponent>(euid.Value), gridComp, Transform(euid.Value));
+            // Force Invalidate & update air on all tiles
+            Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> grid =
+                new(euid.Value, gridAtmosphere, Comp<GasTileOverlayComponent>(euid.Value), gridComp, Transform(euid.Value));
 
-           RebuildGridTiles(grid);
+            RebuildGridTiles(grid);
 
-           var query = GetEntityQuery<AtmosFixMarkerComponent>();
-           foreach (var (indices, tile) in gridAtmosphere.Tiles.ToArray())
-           {
-               if (tile.Air is not {Immutable: false} air)
-                   continue;
+            var query = GetEntityQuery<AtmosFixMarkerComponent>();
+            foreach (var (indices, tile) in gridAtmosphere.Tiles.ToArray())
+            {
+                if (tile.Air is not {Immutable: false} air)
+                    continue;
 
-               air.Clear();
-               var mixtureId = 0;
-               var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, indices);
-               while (enumerator.MoveNext(out var entUid))
-               {
-                   if (query.TryComp(entUid, out var marker))
-                       mixtureId = marker.Mode;
-               }
+                air.Clear();
+                var mixtureId = 0;
+                GasMixture? gasMix = null;
+                var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, indices);
+                while (enumerator.MoveNext(out var entUid))
+                {
+                    if (!query.TryComp(entUid, out var marker))
+                        continue;
 
-               var mixture = mixtures[mixtureId];
-               Merge(air, mixture);
-               air.Temperature = mixture.Temperature;
-           }
-       }
+                    mixtureId = marker.Mode;
+                    gasMix = marker.GasMix;
+                }
+
+                var mixture = mixtures[mixtureId];
+                Merge(air, gasMix is not null ? gasMix : mixture);
+                air.Temperature = mixture.Temperature;
+            }
+        }
     }
 
     /// <summary>

--- a/Content.Server/Atmos/Piping/Unary/Components/GasOutletInjectorComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasOutletInjectorComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// <summary>
         ///     Target volume to transfer. If <see cref="WideNet"/> is enabled, actual transfer rate will be much higher.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float TransferRate
         {
             get => _transferRate;

--- a/Resources/Maps/lighthouse.yml
+++ b/Resources/Maps/lighthouse.yml
@@ -95024,26 +95024,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 20.5,-64.5
       parent: 2
-- proto: HighSecDoor
+- proto: HighSecEngineeringLocked
   entities:
   - uid: 13819
     components:
     - type: MetaData
-      name: replace me with engineering high sec locked
+      name: Supermatter Engine access
     - type: Transform
       pos: 13.5,-71.5
       parent: 2
   - uid: 13820
     components:
     - type: MetaData
-      name: replace me with engineering high sec locked
+      name: Supermatter Engine access
     - type: Transform
       pos: 11.5,-71.5
       parent: 2
   - uid: 13821
     components:
     - type: MetaData
-      name: replace me with engineering high sec locked
+      name: Supermatter Engine access
     - type: Transform
       pos: 11.5,-73.5
       parent: 2

--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -108,3 +108,16 @@
   components:
   - type: AtmosFixMarker
     mode: 7
+
+- type: entity
+  id: AtmosFixCoolant
+  suffix: Coolant
+  description: "Supermatter coolant, equivalent to a liquid nitrogen canister"
+  components:
+  - type: AtmosFixMarker
+    gasMixture:
+      volume: 2500
+      moles:
+        - 0 # oxygen
+        - 18710.71051 # nitrogen
+      temperature: 72

--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -115,7 +115,7 @@
   description: "Supermatter coolant, equivalent to a liquid nitrogen canister"
   components:
   - type: AtmosFixMarker
-    gasMixture:
+    gasMix:
       volume: 2500
       moles:
         - 0 # oxygen

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1240,6 +1240,15 @@
     containers:
       board: [ DoorElectronicsArmory ]
 
+- type: entity
+  parent: HighSecDoor
+  id: HighSecEngineeringLocked
+  suffix: Engineering, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsEngineering ]
+
 #Airtight hatch
 
 - type: entity

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -31,4 +31,4 @@
   components:
     - type: GasVentPump
       maxPressure: 13500
-      pumpPower: 6
+      PumpPower: 6

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -1,0 +1,34 @@
+﻿- type: entity
+  parent: GasPressurePump
+  id: GasPressurePumpHighFlow
+  name: high flow gas pump
+  description: A pump that moves gas by pressure. It pumps air at three times the pressure of a standard pump.
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: GasPressurePump
+    enabled: false
+    maxTargetPressure: 13500
+
+- type: entity
+  parent: GasVolumePump
+  id: GasVolumePumpHighFlow
+  name: high flow volumetric gas pump. It pumps air at three times the volume of a standard pump
+  description: A pump that moves gas by volume.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasVolumePump
+      maxTransferRate: 600
+
+- type: entity
+  parent: GasDualPortVentPump
+  id: GasDualPortVentPumpHighFlow
+  name: high flow dual-port air vent
+  description: Has a valve and a pump attached to it. There are two ports, one is an input for releasing air, the other is an output when siphoning. It can handle three times the pressure of a standard vent.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasVentPump
+      maxPressure: 13500
+      pumpPower: 6

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -1,0 +1,50 @@
+- type: entity
+  parent: GasFilter
+  id: GasFilterHighFlow
+  name: high flow gas filter
+  description: Very useful for filtering gases. It can handle three times the volume of a standard filter, which makes it suitable for use in Supermatter engines.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasFilter
+      enabled: false
+      transferRate: 3000
+      maxTransferRate: 3000
+
+- type: entity
+  parent: GasFilterHighFlow
+  id: GasFilterFlippedHighFlow
+  name: high flow gas filter
+  suffix: Flipped
+  placement:
+    mode: SnapgridCenter
+
+- type: entity
+  parent: GasMixer
+  id: GasMixerHighFlow
+  name: high pressure gas mixer
+  description: Used for mixing gasses at the extreme pressures required by Supermatter engines.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasMixer
+      maxTargetPressure: 13500
+
+- type: entity
+  parent: GasMixerHighFlow
+  id: GasMixerFlippedHighFlow
+  name: high pressure gas mixer
+  suffix: Flipped
+  placement:
+    mode: SnapgridCenter
+
+- type: entity
+  parent: PressureControlledValve
+  id: PressureControlledValveHighFlow
+  name: blow-off valve
+  description: A variant on a pneumatic valve designed for fire suppression of Supermatter engines. When the pressure in its flow direction exceeds the "reference" pressure on its side, the valve opens.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: PressureControlledValve
+      maxTransferRate: 3000

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -8,7 +8,7 @@
   components:
     - type: GasVentPump
       maxPressure: 13500
-      pumpPower: 6
+      PumpPower: 6
 
 - type: entity
   parent: GasVentScrubber

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -31,6 +31,5 @@
     mode: SnapgridCenter
   components:
     - type: GasOutletInjector
-      transferRate: 600
       maxTransferRate: 600
       maxPressure: 13500

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -1,0 +1,36 @@
+- type: entity
+  parent: GasVentPump
+  id: GasVentPumpHighFlow
+  name: high pressure air vent
+  description: A pipe with an attached high-flow pump. It can handle three times the pressure of a standard vent.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasVentPump
+      maxPressure: 13500
+      pumpPower: 6
+
+- type: entity
+  parent: GasVentScrubber
+  id: GasVentScrubberHighFlow
+  name: high pressure air scrubber
+  description: A pipe with an attached air scrubber. It can handle three times the pressure of a standard scrubber.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasVentScrubber
+      maxPressure: 13500
+      maxTransferRate: 600
+
+- type: entity
+  parent: GasOutletInjector
+  id: GasOutletInjectorHighFlow
+  name: high pressure air injector
+  description: An air injector designed to handle three times the pressure of a standard injector.
+  placement:
+    mode: SnapgridCenter
+  components:
+    - type: GasOutletInjector
+      transferRate: 600
+      maxTransferRate: 600
+      maxPressure: 13500


### PR DESCRIPTION
# Description

This adds "High Flow" variants of all existing atmos devices, which are useful for supermatter engines. I also added the ability for FixAtmosMarkers to optionally accept a gas mixture directly, as opposed to the stupid hardcoded gas mixes that they were limited to using previously.

# Changelog

:cl:
- add: Added high pressure variants of atmos devices intended for supermatter engines.
- add: Added engineering locked high security doors, also for use in supermatter engines.
- add: Fix Atmos markers can now accept a gas mixture directly for modifying their tile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced atmospheric commands now dynamically use specific gas mixtures for more flexible performance.
  - Introduced a new supermatter coolant entity, offering an alternative liquid nitrogen-like option.
  - Added several high-pressure and high-flow gas components, including pumps, filters, mixers, vents, and injectors.
  - Updated map elements by refining door access prototypes and labels for improved in-game clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->