### PR TITLE
Add EE Specific Ores To Lavaland

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -496,6 +496,28 @@
           state: rock_asteroid_west
         - state: rock_copper
 
+- type: entity
+  id: AsteroidRockTungsten
+  parent: AsteroidRock
+  description: An ore vein rich with wolframite.
+  suffix: Copper
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
+    - type: Sprite
+      layers:
+        - state: rock_asteroid
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_asteroid_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_asteroid_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_asteroid_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_asteroid_west
+        - state: rock_copper
+
 
 # Rocks and ore veins
 - type: entity
@@ -897,6 +919,28 @@
           state: rock_west
         - state: rock_copper
 
+- type: entity
+  id: WallRockTungsten
+  parent: WallRock
+  description: An ore vein rich with wolframite.
+  suffix: Copper
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
+    - type: Sprite
+      layers:
+        - state: rock
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_west
+        - state: rock_copper
+
 # Basalt variants
 - type: entity
   id: WallRockBasalt
@@ -1259,6 +1303,28 @@
     - type: OreVein
       oreChance: 1.0
       currentOre: OreCopper
+    - type: Sprite
+      layers:
+        - state: rock_wall
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_wall_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_wall_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_wall_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_wall_west
+        - state: rock_copper
+
+- type: entity
+  id: WallRockBasaltTungsten
+  parent: WallRockBasalt
+  description: An ore vein rich with wolframite.
+  suffix: Copper
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
     - type: Sprite
       layers:
         - state: rock_wall
@@ -1647,6 +1713,28 @@
           state: rock_snow_west
         - state: rock_copper
 
+- type: entity
+  id: WallRockSnowTungsten
+  parent: WallRockSnow
+  description: An ore vein rich with wolframite.
+  suffix: Copper
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
+    - type: Sprite
+      layers:
+        - state: rock_snow
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_snow_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_snow_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_snow_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_snow_west
+        - state: rock_copper
+
 # Sand variants
 - type: entity
   id: WallRockSand
@@ -2021,6 +2109,28 @@
           state: rock_sand_west
         - state: rock_copper
 
+- type: entity
+  id: WallRockSandTungsten
+  parent: WallRockSand
+  description: An ore vein rich with wolframite.
+  suffix: Tungsten
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
+    - type: Sprite
+      layers:
+        - state: rock_sand
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_sand_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_sand_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_sand_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_sand_west
+        - state: rock_copper
+
 # Chromite variants
 - type: entity
   id: WallRockChromite
@@ -2375,14 +2485,14 @@
         - state: rock_lead
 
 - type: entity
-  id: WallRockChromiteCopper
+  id: WallRockChromiteTungsten
   parent: WallRockChromite
-  description: An ore vein rich with native copper.
+  description: An ore vein rich with wolframite.
   suffix: Copper
   components:
     - type: OreVein
       oreChance: 1.0
-      currentOre: OreCopper
+      currentOre: OreTungsten
     - type: Sprite
       layers:
         - state: rock_chromite
@@ -2758,6 +2868,28 @@
     - type: OreVein
       oreChance: 1.0
       currentOre: OreCopper
+    - type: Sprite
+      layers:
+        - state: rock_andesite
+        - map: [ "enum.EdgeLayer.South" ]
+          state: rock_andesite_south
+        - map: [ "enum.EdgeLayer.East" ]
+          state: rock_andesite_east
+        - map: [ "enum.EdgeLayer.North" ]
+          state: rock_andesite_north
+        - map: [ "enum.EdgeLayer.West" ]
+          state: rock_andesite_west
+        - state: rock_copper
+
+- type: entity
+  id: WallRockAndesiteTungsten
+  parent: WallRockAndesite
+  description: An ore vein rich with wolframite.
+  suffix: Tungsten
+  components:
+    - type: OreVein
+      oreChance: 1.0
+      currentOre: OreTungsten
     - type: Sprite
       layers:
         - state: rock_andesite

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -186,6 +186,20 @@
   maxGroupSize: 2
   radius: 4
 
+- type: biomeMarkerLayer
+  id: OreTungsten
+  entityMask:
+    AsteroidRock: AsteroidRockTungsten
+    WallRock: WallRockTungsten
+    WallRockBasalt: WallRockBasaltTungsten
+    WallRockChromite: WallRockChromiteTungsten
+    WallRockSand: WallRockSandTungsten
+    WallRockSnow: WallRockSnowTungsten
+  maxCount: 6
+  minGroupSize: 3
+  maxGroupSize: 6
+  radius: 4
+
 # Artifact Fragment
 - type: biomeMarkerLayer
   id: OreArtifactFragment

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -232,3 +232,10 @@
   loots:
     - !type:BiomeMarkerLoot
       proto: OreNormality
+
+- type: salvageLoot
+  id: OreTungsten
+  guaranteed: true
+  loots:
+    - !type:BiomeMarkerLoot
+      proto: OreTungsten

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -27,7 +27,12 @@
   - OreSilver
   - OrePlasma
   - OreUranium
-  #- OreBananium
+  - OreBananium
   - OreArtifactFragment
   - OreDiamond
   - OreBluespace
+  - OreAluminium
+  - OreCopper
+  - OreTungsten
+  - OreLead
+  - OreNormality


### PR DESCRIPTION
# Description

EE Specific ores weren't spawning on Lavaland, also added an ore vein for Tungsten.

# Changelog

:cl:
- add: Added EE-Specific ores to Lavaland, such as Bauxite, Cassiterite, Wolframite, etc. 
- add: Wolframite now spawns in veins just like other ores.
