### PR TITLE
Fixes For High Flow Atmos Components

### DIFF
--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -114,10 +114,18 @@
   suffix: Coolant
   description: "Supermatter coolant, equivalent to a liquid nitrogen canister"
   components:
-  - type: AtmosFixMarker
-    gasMix:
-      volume: 2500
-      moles:
-        - 0 # oxygen
-        - 18710.71051 # nitrogen
-      temperature: 72
+    - type: Sprite
+      layers:
+        - sprite: Markers/atmos.rsi # {
+          state: base
+          shader: unshaded
+        - sprite: Markers/atmos.rsi
+          shader: unshaded # }
+          state: nitrogen
+    - type: AtmosFixMarker
+      gasMix:
+        volume: 2500
+        moles:
+          - 0 # oxygen
+          - 18710.71051 # nitrogen
+        temperature: 72

--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -113,6 +113,7 @@
   id: AtmosFixCoolant
   suffix: Coolant
   description: "Supermatter coolant, equivalent to a liquid nitrogen canister"
+  parent: MarkerBase
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -12,12 +12,17 @@
       maxTransferRate: 3000
 
 - type: entity
-  parent: GasFilterHighFlow
+  parent: GasFilterFlipped
   id: GasFilterFlippedHighFlow
   name: high flow gas filter
   suffix: Flipped
   placement:
     mode: SnapgridCenter
+  components:
+    - type: GasFilter
+      enabled: false
+      transferRate: 3000
+      maxTransferRate: 3000
 
 - type: entity
   parent: GasMixer
@@ -31,12 +36,15 @@
       maxTargetPressure: 13500
 
 - type: entity
-  parent: GasMixerHighFlow
+  parent: GasMixerFlipped
   id: GasMixerFlippedHighFlow
   name: high pressure gas mixer
   suffix: Flipped
   placement:
     mode: SnapgridCenter
+  components:
+    - type: GasMixer
+      maxTargetPressure: 13500
 
 - type: entity
   parent: PressureControlledValve


### PR DESCRIPTION
# Description

Made mistakes on the Flipped Filters & Mixers, also makes it so that the Coolant fix spawner has a sprite.

# Changelog

:cl:
- fix: Fixed High Flow variants of gas filters and mixers being identical to their non-flipped variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced visual displays for coolant elements, providing improved clarity with advanced layered representations.
	- Updated gas system configurations, refining filtering and mixing capabilities for more reliable environmental performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->