### PR TITLE
Tweak Footprints

### DIFF
--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -88,7 +88,7 @@ public sealed class FootPrintsSystem : EntitySystem
 
         stepTransform.LocalRotation = dragging
             ? (newPos - component.LastStepPos).ToAngle() + Angle.FromDegrees(-90f)
-            : args.Component.LocalRotation + Angle.FromDegrees(180f);
+            : args.Component.LocalRotation + Math.PI;
 
         if (!TryComp<SolutionContainerManagerComponent>(footprintUid, out var solutionContainer)
             || !_solution.ResolveSolution((footprintUid, solutionContainer), footPrintComponent.SolutionName, ref footPrintComponent.Solution, out var solution))
@@ -108,7 +108,7 @@ public sealed class FootPrintsSystem : EntitySystem
             return new(uid, transform.LocalPosition);
 
         var offset = component.RightStep
-            ? new Angle(Angle.FromDegrees(180f) + transform.LocalRotation).RotateVec(component.OffsetPrint)
+            ? new Angle(Math.PI + transform.LocalRotation).RotateVec(component.OffsetPrint)
             : new Angle(transform.LocalRotation).RotateVec(component.OffsetPrint);
 
         return new(uid, transform.LocalPosition + offset);

--- a/Content.Shared/Footprint/FootPrintsComponent.cs
+++ b/Content.Shared/Footprint/FootPrintsComponent.cs
@@ -67,11 +67,11 @@ public sealed partial class FootPrintsComponent : Component
     ///     Reagent volume used for footprints.
     /// </summary>
     [DataField]
-    public Solution ContainedSolution = new(3) { CanReact = true, MaxVolume = 5f, };
+    public Solution ContainedSolution = new(3) { CanReact = true, MaxVolume = 25f, };
 
     /// <summary>
     ///     Amount of reagents used per footprint.
     /// </summary>
     [DataField]
-    public FixedPoint2 FootprintVolume = 1f;
+    public FixedPoint2 FootprintVolume = 5f;
 }

--- a/Content.Shared/Footprint/PuddleFootPrintsComponent.cs
+++ b/Content.Shared/Footprint/PuddleFootPrintsComponent.cs
@@ -10,5 +10,5 @@ public sealed partial class PuddleFootPrintsComponent : Component
     ///     Ratio between puddle volume and the amount of reagents that can be transferred from it.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 SizeRatio = 0.15f;
+    public FixedPoint2 SizeRatio = 0.75f;
 }


### PR DESCRIPTION
# Description

This PR reduces the number of footprints generated per puddle by a factor of 5, primarily by significantly increasing the amount of fluid reagents "Consumed" from puddles in order to create the footprints. A single puddle shouldn't be creating thousands of footprints. While there are better solutions to footprint lag, I'm on a time constraint, and need to fix MANY issues, I simply don't have the time available to dedicate to rewriting the entire footprint system.

# Changelog

:cl:
- tweak: Significantly increased the amount of reagents "Consumed" by walking over puddles. This should result in substantially less footprint spam, since puddles are more rapidly consumed by people walking over them and making footprints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted footprint orientation calculations to ensure consistent directional behavior.
- **New Features**
  - Increased the reagent capacity for footprint entities, allowing for more substantial chemical interactions.
  - Enhanced the balance between footprint amounts and puddle transfer ratios for improved reaction dynamics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->