### PR TITLE
R25 Rifle Tweaks

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -83,8 +83,8 @@
   - type: Gun
     minAngle: 21
     maxAngle: 32
-    fireRate: 5 # 300rpm in Semi & Full Auto
-    burstFireRate: 20 # 1200rpm in Burst mode.
+    fireRate: 5  # 300rpm in Semi & Full Auto
+    burstFireRate: 20  # 1200rpm in Burst mode.
     shotsPerBurst: 5
     burstCooldown: 1.1
     cameraRecoilScalar: 0.5

--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -78,15 +78,15 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -19
-    maxAngle: -16
+    minAngle: -17
+    maxAngle: -22
   - type: Gun
     minAngle: 21
     maxAngle: 32
     fireRate: 5 # 300rpm in Semi & Full Auto
     burstFireRate: 20 # 1200rpm in Burst mode.
     shotsPerBurst: 5
-    burstCooldown: 0.8
+    burstCooldown: 1.1
     cameraRecoilScalar: 0.5
     selectedMode: Burst
     soundGunshot:


### PR DESCRIPTION
# Description

This PR tweaks the stats of the R25 rifle so that it isn't completely useless. Its accuracy when wielded has been improved so that it can more consistently hit targets at between half and a full screen length away. As a tradeoff, its cooldown between bursts has been increased so that its DPS isn't comically overtuned. 

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/7b862f2a-09c3-450b-9482-a6ce69b4c971

</p>
</details>

# Changelog

:cl:
- tweak: Increased the accuracy-when-wielded of the BRDI-R25 rifle. As a tradeoff, it has a longer cooldown between hyperbursts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Gameplay Adjustments**
	- Updated the weapon's handling by refining its firing angles.
	- Adjusted the burst cooldown period to alter the firing rhythm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->