### PR TITLE
Cargo Price Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -39,6 +39,8 @@
     sound: /Audio/SimpleStation14/Items/Handling/book_drop.ogg
   - type: EmitSoundOnLand
     sound: /Audio/SimpleStation14/Items/Handling/book_drop.ogg
+  - type: StackPrice
+    price: 10
 
 - type: entity
   id: BookSpaceEncyclopedia

--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -45,6 +45,8 @@
       - Landmine
     requiredTriggeredSpeed: 0
     stepOn: true
+  - type: StackPrice
+    price: 500
 
 - type: entity
   name: kick mine

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -36,6 +36,8 @@
   - type: HitscanBatteryAmmoProvider
     proto: RedLightLaser
     fireCost: 50
+  - type: StackPrice
+    price: 100
 
 - type: entity
   name: potato battery

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -47,3 +47,5 @@
       state: powersink
     - type: WarpPoint
       location: powersink
+    - type: StackPrice
+      price: 5000

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -69,7 +69,7 @@
   description: A large tower shield. Good for controlling crowds.
   components:
     - type: StaticPrice
-      price: 90
+      price: 300
 
 - type: entity
   name: riot laser shield
@@ -90,6 +90,8 @@
           Heat: 0.7
         flatReductions:
           Heat: 2
+    - type: StackPrice
+      price: 500
 
 - type: entity
   name: riot bullet shield
@@ -113,6 +115,8 @@
         flatReductions:
           Blunt: 1.5
           Piercing: 1.5
+    - type: StackPrice
+      price: 500
 
 #Craftable shields
 
@@ -407,7 +411,7 @@
                   min: 1
                   max: 1
     - type: StaticPrice
-      price: 350
+      price: 3500
 
 - type: entity
   name: broken energy shield

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -87,3 +87,5 @@
     - type: ContainerContainer
       containers:
         AccessOverrider-privilegedId: !type:ContainerSlot
+    - type: StaticPrice
+      price: 350

--- a/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
@@ -27,3 +27,5 @@
   - type: GuideHelp
     guides:
     - Cargo
+  - type: StaticPrice
+    price: 75

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -25,7 +25,7 @@
   - type: StaticPrice
     price: 0
   - type: StackPrice
-    price: 1
+    price: 5
   - type: PhysicalComposition
     materialComposition:
       Steel: 15
@@ -78,6 +78,8 @@
           Quantity: 2
         - ReagentId: Carbon #steel-reinforced
           Quantity: 1
+  - type: StackPrice
+    price: 15
 
 - type: entity
   parent: CableHVStack
@@ -143,6 +145,8 @@
           Quantity: 3
         - ReagentId: Copper
           Quantity: 2
+  - type: StackPrice
+    price: 10
 
 - type: entity
   parent: CableMVStack

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -22,6 +22,8 @@
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: EmbedPassiveDamage
+  - type: StackPrice
+    price: 2000
 
 - type: entity
   parent: EmagUnlimited

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -52,7 +52,7 @@
     materialComposition:
       Steel: 185
   - type: StaticPrice
-    price: 20
+    price: 100
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -36,7 +36,7 @@
       enum.RadarConsoleUiKey.Key:
         type: RadarConsoleBoundUserInterface
   - type: StaticPrice
-    price: 150
+    price: 750
   - type: ReverseEngineering # Delta
     difficulty: 3
     recipes:

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -48,3 +48,5 @@
           Low: {state: jammer_low_charge}
           Medium: {state: jammer_medium_charge}
           High: {state: jammer_high_charge}
+  - type: StackPrice
+    price: 2000

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -66,6 +66,8 @@
     difficulty: 3
     recipes:
       - JawsOfLife
+  - type: StaticPrice
+    price: 3000
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -56,7 +56,7 @@
       moleUsage: 0.00085
     - type: Appearance
     - type: StaticPrice
-      price: 100
+      price: 1000
 #    - type: DynamicPrice
 #      price: 100
     - type: ReverseEngineering # Nyano

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -64,6 +64,8 @@
     - type: Tag
       tags:
       - Flashlight
+    - type: StackPrice
+      price: 50
 
 - type: entity
   parent: Lantern

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -31,4 +31,4 @@
       air: '#03fcd3'
       mix: '#947507'
   - type: StaticPrice
-    price: 40
+    price: 100

--- a/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
@@ -25,4 +25,4 @@
       Glass: 100
       Circuitry: 25
   - type: StaticPrice
-    price: 60
+    price: 500

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -45,6 +45,8 @@
           True: { state: icon-open }
           False: { state: icon }
   - type: Appearance
+  - type: StaticPrice
+    price: 150
 
 - type: entity
   name: emergency toolbox

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -64,7 +64,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 30
+    price: 100
   # Shitmed Change
   - type: Retractor
     speed: 0.35
@@ -146,7 +146,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 30
+    price: 100
   # Shitmed Change
   - type: Retractor
     speed: 0.45
@@ -213,7 +213,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 22
+    price: 100
 
 - type: entity
   name: crowbar
@@ -270,7 +270,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 22
+    price: 100
   - type: Prying
   # Shitmed Change
   - type: Tweezers
@@ -356,7 +356,7 @@
       Plastic: 50
       Circuitry: 25
   - type: StaticPrice
-    price: 56
+    price: 300
 
 - type: entity
   name: network configurator
@@ -404,7 +404,7 @@
         enum.NetworkConfiguratorUiKey.Link:
           type: NetworkConfiguratorBoundUserInterface
     - type: StaticPrice
-      price: 56
+      price: 300
     - type: GuideHelp
       guides:
         - NetworkConfigurator
@@ -458,7 +458,7 @@
 #  - type: DynamicPrice
 #    price: 100
   - type: StaticPrice
-    price: 100
+    price: 500
   - type: MeleeWeapon
     wideAnimationRotation: -90
     attackRate: 1.1
@@ -531,7 +531,7 @@
       Plastic: 100
       Circuitry: 50
   - type: StaticPrice
-    price: 100
+    price: 1000
   - type: UserInterface
     interfaces:
       enum.RcdUiKey.Key:
@@ -715,7 +715,7 @@
       Steel: 100
       Wood: 50
   - type: StaticPrice
-    price: 25
+    price: 100
   # Delta V: Adds tool quality for digging
   - type: Tool
     qualities:
@@ -765,3 +765,5 @@
   - type: Tag
     tags:
     - RollingPin
+  - type: StaticPrice
+    price: 25

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -115,7 +115,7 @@
     materialComposition:
       Steel: 200
   - type: StaticPrice
-    price: 40
+    price: 200
   - type: IgnitionSource
     temperature: 700
   - type: WeldingHealing # Same as Brutepack - Estacao Pirata IPCs
@@ -152,6 +152,8 @@
         - ReagentId: WeldingFuel
           Quantity: 250
         maxVol: 250
+  - type: StaticPrice
+    price: 600
 
 - type: entity
   name: advanced industrial welding tool
@@ -172,6 +174,8 @@
         maxVol: 500
   - type: Tool
     speedModifier: 1.5
+  - type: StaticPrice
+    price: 1000
 
 - type: entity
   name: experimental welding tool
@@ -202,6 +206,8 @@
         Quantity: 0.5
   - type: Tool
     speedModifier: 2
+  - type: StaticPrice
+    price: 3000  # Genuine reason to steal it from the CE.
 
 - type: entity
   name: emergency welding tool
@@ -229,3 +235,5 @@
     enabled: false
     radius: 1.0
     color: orange
+  - type: StaticPrice
+    price: 150

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -33,4 +33,4 @@
       params:
         volume: -1
   - type: StaticPrice
-    price: 1
+    price: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -121,6 +121,8 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/pistol.ogg
     fireOnDropChance: 0.3
+  - type: StackPrice
+    price: 750
 
 - type: entity
   name: viper
@@ -233,6 +235,8 @@
     containers:
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
+  - type: StackPrice
+    price: 1000
 
 - type: entity
   name: cobra
@@ -271,6 +275,8 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg
     fireOnDropChance: 0.5
+  - type: StackPrice
+    price: 350
 
 - type: entity
   name: mk58
@@ -378,6 +384,8 @@
         whitelist:
           tags:
             - CartridgeMagnum
+  - type: StackPrice
+    price: 1000
 
 - type: entity
   name: N1984

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -92,7 +92,6 @@
         type: NukeBoundUserInterface
   - type: StaticPrice
     price: 50000 # YOU STOLE A NUCLEAR FISSION EXPLOSIVE?!
-  - type: CargoSellBlacklist
   - type: ArrivalsBlacklist
   - type: ItemSlots
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -56,6 +56,8 @@
   - type: GuideHelp
     guides:
     - Science
+  - type: StackPrice
+    price: 20000  # Hello there extremely rare and valuable object that the crew can't rebuild. Would you like to steal it?
 
 - type: entity
   id: BaseResearchAndDevelopmentPointSource

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -103,7 +103,7 @@
     flavorKind: station-event-random-sentience-flavor-mechanical
     weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
   - type: StaticPrice
-    price: 100
+    price: 750
   - type: Appearance
   - type: WiresVisuals
   - type: LanguageKnowledge

--- a/Resources/Prototypes/Reagents/Materials/metals.yml
+++ b/Resources/Prototypes/Reagents/Materials/metals.yml
@@ -3,7 +3,7 @@
   stackEntity: SheetSteel1
   name: materials-steel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: steel }
-  price: 0.05
+  price: 0.5
 
 - type: material
   id: Gold
@@ -12,7 +12,7 @@
   unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: gold }
   color: "#FFD700"
-  price: 0.2
+  price: 2
 
 - type: material
   id: Silver
@@ -21,7 +21,7 @@
   unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: silver }
   color: "#C0C0C0"
-  price: 0.15
+  price: 1.5
 
 - type: material
   id: Brass
@@ -29,7 +29,7 @@
   name: materials-brass
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: brass }
   color: "#b18b25"
-  price: 0.1
+  price: 1
 
 - type: material
   id: Plasteel
@@ -37,7 +37,7 @@
   name: materials-plasteel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: plasteel }
   color: "#696969" #Okay, this is epic
-  price: 0.28 # 1-1 mix of plasma and steel.
+  price: 2.8 # 1-1 mix of plasma and steel.
 
 - type: material
   id: Tungsten
@@ -45,4 +45,4 @@
   name: materials-tungsten
   unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: tungsten_1 }
-  price: 0.5
+  price: 5

--- a/Resources/Prototypes/_Nuclear14/Reagents/materials.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/materials.yml
@@ -4,7 +4,7 @@
   name: materials-circuitry # N14TODO: Localise
   icon: { sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi, state: circuits_3 }
   color: "#8A9A5B"
-  price: 0.1
+  price: 1
 
 - type: material
   id: Lead
@@ -13,7 +13,7 @@
   unit: materials-unit-bar
   icon: { sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi, state: ingot_lead }
   color: "#C0C0C0"
-  price: 0.04
+  price: 0.40
 
 - type: material
   id: Aluminum
@@ -22,7 +22,7 @@
   unit: materials-unit-bar
   icon: { sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi, state: ingot_aluminum }
   color: "#C0C0C0"
-  price: 0.01
+  price: 0.10
 
 - type: material
   id: Copper
@@ -31,4 +31,4 @@
   unit: materials-unit-bar
   icon: { sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi, state: ingot_copper }
   color: "#B87333"
-  price: 0.01
+  price: 0.10


### PR DESCRIPTION
# Description

Tweaks the cargo experience by making a large variety of objects have actual values defined for them, so that they're worth selling or fultoning from wrecks. This includes a lot of items previously considered "Worthless" to cargo, but are inherently useful, as well as a variety of traitor items, manufactured goods , and materials. Ostensibly, manufacturing something *should* increase the value of it, you are after all spending machine time and energy to make these goods. 

It also helps provide a useful in-character justification for people to be stealing these items, if for instance the typical traitor steal targets are by a funny coincedence also highly valuable. Someone could conceivably make the IC argument of, "I needed money to bail my brother out of space prison, so I stole the chief engineer's shoes because I heard they were valuable."

Don't merge this yet because it's 100% guaranteed to trip the cargo arbitrage test, so I'll need to adjust the numbers down based on those test results.

# Changelog

:cl:
- tweak: Tweaked the cargo sell prices of a large number of items, manufactured goods, and processed materials. Many items that did not have a sell price before now have a sell price. There's more than a few items that you can profit from manufacturing at an autolathe, and many objects such as vending machines are actually worth the time it takes to fulton them from wreckages and expeditions.
