### PR TITLE
Fixes For Deserters

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/SANDropship.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/SANDropship.yml
@@ -28,7 +28,7 @@ entities:
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: /QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAoAAAAAAA/QAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAoAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAAWQAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAbAAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAbAAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAoAAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: oAAAAAAAoAAAAAAA1wAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAA/QAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAA/QAAAAAA1wAAAAAAoAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAAWQAAAAAAWQAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbgAAAAAAbgAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAbAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAbAAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAoAAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
@@ -36,7 +36,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAA1wAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAA/QAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAWQAAAAAAoAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAAWQAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAoAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA1wAAAAAAAAAAAAAA1wAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA1wAAAAAA/QAAAAAAbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAWQAAAAAAoAAAAAAA1wAAAAAA/QAAAAAAbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAWQAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA1wAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAWQAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAA/QAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAA/QAAAAAA/QAAAAAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAA/QAAAAAAoAAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -69,34 +69,35 @@ entities:
           0,-1:
             1: 33584
           0,-4:
-            1: 4867
-            0: 4
+            1: 4912
+            0: 2180
           -1,-4:
-            1: 2056
-            0: 5
+            1: 2176
+            0: 549
           0,-3:
             1: 15355
           -1,-3:
-            1: 35562
+            1: 35578
           0,-2:
             1: 13075
           -1,-2:
             1: 34824
-            0: 273
+            0: 17
           -1,-1:
             1: 10368
-            0: 16
+            0: 256
+          1,-3:
+            1: 16
+            0: 9216
           1,-2:
-            0: 435
+            0: 179
             1: 16448
           1,-1:
-            0: 176
+            0: 384
             1: 64
           1,-4:
             0: 9
             1: 41478
-          1,-3:
-            0: 9216
           -2,-4:
             0: 2
             1: 43020
@@ -104,7 +105,7 @@ entities:
             0: 168
             1: 16448
           -2,-1:
-            0: 160
+            0: 32
             1: 64
           -2,-3:
             0: 33792
@@ -225,33 +226,33 @@ entities:
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 195
+  - uid: 55
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-14.5
+      pos: -0.5,-15.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 214
-  - uid: 196
+      - 188
+  - uid: 56
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-14.5
+      pos: 0.5,-15.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 214
-  - uid: 197
+      - 188
+  - uid: 64
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-14.5
+      pos: 1.5,-15.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 214
+      - 188
 - proto: BlastDoorOpen
   entities:
   - uid: 88
@@ -277,7 +278,7 @@ entities:
   - uid: 406
     components:
     - type: Transform
-      pos: 3.6820488,-10.727015
+      pos: 4.627112,-10.6256695
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -886,14 +887,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-- proto: ComputerComms
-  entities:
-  - uid: 136
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
 - proto: ComputerIFF
   entities:
   - uid: 131
@@ -901,6 +894,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-2.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
       parent: 1
 - proto: ComputerShuttle
   entities:
@@ -946,67 +947,6 @@ entities:
     - type: Transform
       pos: 3.5337243,-9.2386
       parent: 1
-- proto: FireAlarm
-  entities:
-  - uid: 227
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 211
-      - 210
-      - 209
-      - 140
-      - 139
-- proto: Firelock
-  entities:
-  - uid: 210
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 227
-  - uid: 211
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 227
-- proto: FirelockEdge
-  entities:
-  - uid: 139
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 227
-  - uid: 140
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 227
-  - uid: 209
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 227
 - proto: FoodPacketCheesieTrash
   entities:
   - uid: 103
@@ -1371,6 +1311,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
 - proto: GrilleDiagonal
   entities:
   - uid: 39
@@ -1395,6 +1355,17 @@ entities:
     components:
     - type: Transform
       pos: 1.5,0.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
       parent: 1
 - proto: Gyroscope
   entities:
@@ -1433,6 +1404,26 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-4.5
+      parent: 1
+- proto: JetpackBlackFilled
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.6463256,-10.3912945
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.2713256,-10.4381695
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5057006,-10.6725445
       parent: 1
 - proto: MagazineBoxPistol
   entities:
@@ -1494,6 +1485,26 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
 - proto: PlastitaniumWindowDiagonal
   entities:
   - uid: 2
@@ -1518,6 +1529,17 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
@@ -1574,18 +1596,6 @@ entities:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 291
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-10.5
-      parent: 1
-  - uid: 292
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-10.5
-      parent: 1
   - uid: 293
     components:
     - type: Transform
@@ -1604,8 +1614,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
 - proto: Rack
   entities:
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 1
   - uid: 200
     components:
     - type: Transform
@@ -1616,8 +1644,29 @@ entities:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
 - proto: SignalButton
   entities:
+  - uid: 188
+    components:
+    - type: MetaData
+      name: blast doors
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        55:
+        - Pressed: Toggle
+        56:
+        - Pressed: Toggle
+        64:
+        - Pressed: Toggle
   - uid: 213
     components:
     - type: MetaData
@@ -1626,21 +1675,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 214
-    components:
-    - type: MetaData
-      name: external blast doors
-    - type: Transform
-      pos: 1.5,-12.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        195:
-        - Pressed: Toggle
-        196:
-        - Pressed: Toggle
-        197:
-        - Pressed: Toggle
   - uid: 215
     components:
     - type: MetaData
@@ -1796,7 +1830,7 @@ entities:
   - uid: 403
     components:
     - type: Transform
-      pos: 3.561351,-10.418608
+      pos: 4.4630494,-10.414732
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -1965,29 +1999,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-7.5
-      parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-7.5
-      parent: 1
   - uid: 62
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-5.5
-      parent: 1
-  - uid: 68
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-7.5
       parent: 1
   - uid: 69
     components:
@@ -2065,12 +2081,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
-      parent: 1
-  - uid: 114
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-7.5
       parent: 1
   - uid: 115
     components:
@@ -2196,12 +2206,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-10.5
-      parent: 1
   - uid: 156
     components:
     - type: Transform
@@ -2326,12 +2330,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-10.5
-      parent: 1
   - uid: 189
     components:
     - type: Transform
@@ -2365,6 +2363,12 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-10.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
       parent: 1
   - uid: 216
     components:
@@ -2419,11 +2423,29 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
   - uid: 366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-5.5
       parent: 1
   - uid: 372
     components:
@@ -2455,6 +2477,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 7.5,-13.5
       parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
   - uid: 15
@@ -2479,23 +2513,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
-      parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 108
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 120
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-7.5
       parent: 1
   - uid: 165
     components:
@@ -2538,6 +2555,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
   - uid: 296
     components:
     - type: Transform
@@ -2546,41 +2568,19 @@ entities:
   - uid: 308
     components:
     - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 364
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 367
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-2.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 368
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 369
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
   - uid: 370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-6.5
-      parent: 1
-  - uid: 371
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
       parent: 1
   - uid: 373
     components:
@@ -2608,12 +2608,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 74
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-10.5
-      parent: 1
 - proto: WeaponDisablerSMG
   entities:
   - uid: 59
@@ -2639,5 +2633,41 @@ entities:
     components:
     - type: Transform
       pos: 0.5,0.5
+      parent: 1
+- proto: WindoorPlasma
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
       parent: 1
 ...

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -12,16 +12,18 @@
     - GladiabotGreen
     - GladiabotBlue
     - GladiabotYellow
+    - SAN
 
 - type: npcFaction
   id: NanoTrasen
   hostile:
-  - SimpleHostile
-  - Syndicate
-  - Xeno
-  - Zombie
-  - Revolutionary
-  - Dragon
+    - SimpleHostile
+    - Syndicate
+    - Xeno
+    - Zombie
+    - Revolutionary
+    - Dragon
+    - SAN
 
 - type: npcFaction
   id: Mouse
@@ -34,28 +36,29 @@
 - type: npcFaction
   id: PetsNT
   hostile:
-  - Mouse
-  - SimpleHostile
-  - Zombie
-  - Xeno
+    - Mouse
+    - SimpleHostile
+    - Zombie
+    - Xeno
 
 - type: npcFaction
   id: SimpleHostile
   friendly:
   - AnimalFriend
   hostile:
-  - NanoTrasen
-  - Syndicate
-  - Passive
-  - PetsNT
-  - Zombie
-  - Revolutionary
-  - GeometerOfBlood
-  - GladiabotFFA
-  - GladiabotRed
-  - GladiabotGreen
-  - GladiabotBlue
-  - GladiabotYellow
+    - NanoTrasen
+    - Syndicate
+    - Passive
+    - PetsNT
+    - Zombie
+    - Revolutionary
+    - GeometerOfBlood
+    - GladiabotFFA
+    - GladiabotRed
+    - GladiabotGreen
+    - GladiabotBlue
+    - GladiabotYellow
+    - SAN
 
 - type: npcFaction
   id: SimpleNeutral
@@ -63,59 +66,62 @@
 - type: npcFaction
   id: Syndicate
   hostile:
-  - NanoTrasen
-  - SimpleHostile
-  - Xeno
-  - PetsNT
-  - Zombie
+    - NanoTrasen
+    - SimpleHostile
+    - Xeno
+    - PetsNT
+    - Zombie
+    - SAN
 
 - type: npcFaction
   id: Xeno
   hostile:
-  - NanoTrasen
-  - Syndicate
-  - Passive
-  - PetsNT
-  - Zombie
-  - Revolutionary
-  - GladiabotFFA
-  - GladiabotRed
-  - GladiabotGreen
-  - GladiabotBlue
-  - GladiabotYellow
+    - NanoTrasen
+    - Syndicate
+    - Passive
+    - PetsNT
+    - Zombie
+    - Revolutionary
+    - GladiabotFFA
+    - GladiabotRed
+    - GladiabotGreen
+    - GladiabotBlue
+    - GladiabotYellow
+    - SAN
 
 - type: npcFaction
   id: Zombie
   hostile:
-  - NanoTrasen
-  - SimpleNeutral
-  - SimpleHostile
-  - Syndicate
-  - Passive
-  - PetsNT
-  - Revolutionary
-  - GladiabotFFA
-  - GladiabotRed
-  - GladiabotGreen
-  - GladiabotBlue
-  - GladiabotYellow
+    - NanoTrasen
+    - SimpleNeutral
+    - SimpleHostile
+    - Syndicate
+    - Passive
+    - PetsNT
+    - Revolutionary
+    - GladiabotFFA
+    - GladiabotRed
+    - GladiabotGreen
+    - GladiabotBlue
+    - GladiabotYellow
+    - SAN
 
 - type: npcFaction
   id: Revolutionary
   hostile:
-  - NanoTrasen
-  - Zombie
-  - SimpleHostile
-  - Dragon
+    - NanoTrasen
+    - Zombie
+    - SimpleHostile
+    - Dragon
 
 - type: npcFaction
   id: Pibble
   friendly:
   - AnimalFriend
   hostile:
-  - Cat
-  - Birb
-  - Mailman
+    - Cat
+    - Birb
+    - Mailman
 
 - type: npcFaction
   id: Mailman
@@ -123,8 +129,8 @@
 - type: npcFaction
   id: Cat
   hostile:
-  - Mouse
-  - SimpleHostile
+    - Mouse
+    - SimpleHostile
 
 - type: npcFaction
   id: Birb

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -113,6 +113,7 @@
     - Zombie
     - SimpleHostile
     - Dragon
+    - SAN
 
 - type: npcFaction
   id: Pibble


### PR DESCRIPTION
# Description

Other factions weren't hostile towards members of SAN, so this PR corrects that issue. It was a little weird that other factions would be shot at by the dropship turret, but SAN members weren't fired upon by other factions turrets, or attacked by space fauna.

Also tweaked the dropship's design a little.

![image](https://github.com/user-attachments/assets/777635fb-8bf4-41b6-8201-b87958509721)

![image](https://github.com/user-attachments/assets/58d9e659-4721-4ab4-a82c-24326b306357)


# Changelog

:cl:
- fix: Fixed an issue where SAN members(currently just Deserters) weren't attacked by other hostile NPCs.
- tweak: Tweaked the design of the SAN Dropship. It also now comes with some jetpacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Revamped shuttle event environments with updated spatial layouts and reconfigured interactive elements.
  - Introduced new gameplay components that enhance onboard dynamics.
  - Expanded adversary interactions by adding a new hostile faction recognized across multiple enemy groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->