### PR TITLE
BSO Gear Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -982,10 +982,10 @@
     - HighRiskItem
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 1200
-    startingCharge: 1200
+    maxCharge: 1210
+    startingCharge: 1210
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 24
+    autoRechargeRate: 48
     autoRechargePause: true
-    autoRechargePauseTime: 10
+    autoRechargePauseTime: 5

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -2,7 +2,7 @@
   parent: ClothingOuterHardsuitSecurity
   id: ClothingOuterHardsuitBlueshield
   name: blueshield's hardsuit
-  description: A special hardsuit made for the Blueshield, contains extra armor.
+  description: A special security hardsuit made for the Blueshield Officer, has extra armor yet somehow feels lighter.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/Combat/blueshield.rsi
@@ -20,6 +20,7 @@
         Slash: 0.5
         Piercing: 0.5
         Radiation: 0.5
+        Heat: 0.5
         Caustic: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 0.85

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Lever/lever.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Lever/lever.yml
@@ -31,7 +31,7 @@
           tags:
           - CartridgeMagnum
   - type: Gun
-    fireRate: 0.55
+    fireRate: 0.8
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
   - type: ChamberMagazineAmmoProvider
@@ -57,5 +57,5 @@
     zeroVisible: true
   - type: Appearance
   - type: UseDelay
-    delay: 0.2
+    delay: 0.1
   - type: UseDelayBlockShoot


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Small tweaks to various equipment belonging to the BSO, to even things out.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Added 50% heat resist to BSO hardsuit (unsure why it didn't have it)
- tweak: Slightly changed the energy shotguns recharge properties to avoid a bug and give it less downtime
- tweak: Buffed the fire rate/use time of the chester, to hopefully allow it to keep up with other weapons again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced battery performance on weapons with increased charge capacity and faster recharge mechanics.
	- Revamped security hardsuit design with a refined description and added heat protection for improved defense.
	- Improved weapon responsiveness by increasing firing speed and reducing action delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->