### PR TITLE
Shuttle Spawner Airlocks

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
@@ -16,12 +16,28 @@
     tag: DockDart
 
 - type: entity
+  parent: AirlockSyndicateGlass
+  id: AirlockSyndicateGlassShuttleInfiltrator
+  suffix: External, Infiltrator, Glass, Docking
+  components:
+  - type: PriorityDock
+    tag: DockInfiltrator
+
+- type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttlePathfinder
   suffix: External, Salvage, Glass, Docking
   components:
   - type: PriorityDock
     tag: DockPathfinder
+
+- type: entity
+  parent: AirlockSyndicateGlass
+  id: AirlockSyndicateGlassShuttleSANDropship
+  suffix: External, SAN Dropship, Glass, Docking
+  components:
+  - type: PriorityDock
+    tag: DockSANDropship
 
 # 1 per map, these spawn a shuttle.
 - type: entity
@@ -41,9 +57,25 @@
     path: /Maps/Shuttles/dart.yml
 
 - type: entity
+  parent: AirlockSyndicateGlassShuttleInfiltrator
+  id: AirlockSyndicateGlassShuttleInfiltratorFilled
+  suffix: Infiltrator Ship Spawner, MAX ONE PER MAP
+  components:
+  - type: GridFill
+    path: /Maps/Shuttles/infiltrator.yml
+
+- type: entity
   parent: AirlockExternalGlassShuttlePathfinder
   id: AirlockExternalGlassShuttlePathfinderFilled
   suffix: Salvage Ship Spawner, MAX ONE PER MAP
   components:
   - type: GridFill
     path: /Maps/Shuttles/pathfinder.yml
+
+- type: entity
+  parent: AirlockSyndicateGlassShuttleSANDropship
+  id: AirlockSyndicateGlassShuttleSANDropshipFilled
+  suffix: SAN Dropship Spawner, MAX ONE PER MAP
+  components:
+  - type: GridFill
+    path: /Maps/Shuttles/ShuttleEvent/SANDropship.yml

--- a/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
@@ -4,40 +4,40 @@
   id: AirlockExternalGlassShuttleCargoShuttle
   suffix: External, Cargo, Glass, Docking
   components:
-  - type: PriorityDock
-    tag: DockCargoShuttle
+    - type: PriorityDock
+      tag: DockCargoShuttle
 
 - type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleDart
   suffix: External, ERT, Glass, Docking
   components:
-  - type: PriorityDock
-    tag: DockDart
+    - type: PriorityDock
+      tag: DockDart
 
 - type: entity
   parent: AirlockSyndicateGlass
   id: AirlockSyndicateGlassShuttleInfiltrator
   suffix: External, Infiltrator, Glass, Docking
   components:
-  - type: PriorityDock
-    tag: DockInfiltrator
+    - type: PriorityDock
+      tag: DockInfiltrator
 
 - type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttlePathfinder
   suffix: External, Salvage, Glass, Docking
   components:
-  - type: PriorityDock
-    tag: DockPathfinder
+    - type: PriorityDock
+      tag: DockPathfinder
 
 - type: entity
   parent: AirlockSyndicateGlass
   id: AirlockSyndicateGlassShuttleSANDropship
   suffix: External, SAN Dropship, Glass, Docking
   components:
-  - type: PriorityDock
-    tag: DockSANDropship
+    - type: PriorityDock
+      tag: DockSANDropship
 
 # 1 per map, these spawn a shuttle.
 - type: entity
@@ -45,37 +45,37 @@
   id: AirlockExternalGlassShuttleCargoShuttleFilled
   suffix: Cargo Shuttle Spawner, MAX ONE PER MAP
   components:
-  - type: GridFill
-    path: /Maps/Shuttles/cargo.yml
+    - type: GridFill
+      path: /Maps/Shuttles/cargo.yml
 
 - type: entity
   parent: AirlockExternalGlassShuttleDart
   id: AirlockExternalGlassShuttleDartFilled
   suffix: ERT Ship Spawner, MAX ONE PER MAP
   components:
-  - type: GridFill
-    path: /Maps/Shuttles/dart.yml
+    - type: GridFill
+      path: /Maps/Shuttles/dart.yml
 
 - type: entity
   parent: AirlockSyndicateGlassShuttleInfiltrator
   id: AirlockSyndicateGlassShuttleInfiltratorFilled
   suffix: Infiltrator Ship Spawner, MAX ONE PER MAP
   components:
-  - type: GridFill
-    path: /Maps/Shuttles/infiltrator.yml
+    - type: GridFill
+      path: /Maps/Shuttles/infiltrator.yml
 
 - type: entity
   parent: AirlockExternalGlassShuttlePathfinder
   id: AirlockExternalGlassShuttlePathfinderFilled
   suffix: Salvage Ship Spawner, MAX ONE PER MAP
   components:
-  - type: GridFill
-    path: /Maps/Shuttles/pathfinder.yml
+    - type: GridFill
+      path: /Maps/Shuttles/pathfinder.yml
 
 - type: entity
   parent: AirlockSyndicateGlassShuttleSANDropship
   id: AirlockSyndicateGlassShuttleSANDropshipFilled
   suffix: SAN Dropship Spawner, MAX ONE PER MAP
   components:
-  - type: GridFill
-    path: /Maps/Shuttles/ShuttleEvent/SANDropship.yml
+    - type: GridFill
+      path: /Maps/Shuttles/ShuttleEvent/SANDropship.yml

--- a/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Doors/Airlocks/shuttleAirlocks.yml
@@ -1,0 +1,49 @@
+# Unlimited, these are targets for shuttles to dock to.
+- type: entity
+  parent: AirlockGlassShuttle
+  id: AirlockExternalGlassShuttleCargoShuttle
+  suffix: External, Cargo, Glass, Docking
+  components:
+  - type: PriorityDock
+    tag: DockCargoShuttle
+
+- type: entity
+  parent: AirlockGlassShuttle
+  id: AirlockExternalGlassShuttleDart
+  suffix: External, ERT, Glass, Docking
+  components:
+  - type: PriorityDock
+    tag: DockDart
+
+- type: entity
+  parent: AirlockGlassShuttle
+  id: AirlockExternalGlassShuttlePathfinder
+  suffix: External, Salvage, Glass, Docking
+  components:
+  - type: PriorityDock
+    tag: DockPathfinder
+
+# 1 per map, these spawn a shuttle.
+- type: entity
+  parent: AirlockExternalGlassShuttleCargoShuttle
+  id: AirlockExternalGlassShuttleCargoShuttleFilled
+  suffix: Cargo Shuttle Spawner, MAX ONE PER MAP
+  components:
+  - type: GridFill
+    path: /Maps/Shuttles/cargo.yml
+
+- type: entity
+  parent: AirlockExternalGlassShuttleDart
+  id: AirlockExternalGlassShuttleDartFilled
+  suffix: ERT Ship Spawner, MAX ONE PER MAP
+  components:
+  - type: GridFill
+    path: /Maps/Shuttles/dart.yml
+
+- type: entity
+  parent: AirlockExternalGlassShuttlePathfinder
+  id: AirlockExternalGlassShuttlePathfinderFilled
+  suffix: Salvage Ship Spawner, MAX ONE PER MAP
+  components:
+  - type: GridFill
+    path: /Maps/Shuttles/pathfinder.yml

--- a/Resources/Prototypes/_EE/Tags/tags.yml
+++ b/Resources/Prototypes/_EE/Tags/tags.yml
@@ -1,0 +1,8 @@
+- type: Tag
+  id: DockCargoShuttle
+
+- type: Tag
+  id: DockDart
+
+- type: Tag
+  id: DockPathfinder

--- a/Resources/Prototypes/_EE/Tags/tags.yml
+++ b/Resources/Prototypes/_EE/Tags/tags.yml
@@ -5,4 +5,10 @@
   id: DockDart
 
 - type: Tag
+  id: DockInfiltrator
+
+- type: Tag
   id: DockPathfinder
+
+- type: Tag
+  id: DockSANDropship


### PR DESCRIPTION
# Description

This PR adds a variety of "Shuttle Spawning Airlocks" for certain ships in this game that mappers might wish to use. The most important of which are airlocks that cause a Cargo Shuttle and a Pathfinder to spawn already docked to the station. The fact that nobody did this before was fucking astounding to me. 

# Changelog

:cl:
- add: Added a variety of "Shuttle Spawning Airlocks" for mappers to use, which can make it so that shuttles like the Cargo Shuttle, Pathfinder, etc. Spawn already docked to the station. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a refined docking and spawning system for shuttle operations, incorporating multiple shuttle types including cargo, dart, infiltrator, pathfinder, and SANDropship.
  - Added dedicated deployment entities to manage shuttle instantiation effectively.
  - Rolled out a new tagging framework to enhance the categorization and identification of dockable vehicles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->