### PR TITLE
Nerf .45

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 25
 
 - type: entity
   id: BulletMagnumPractice
@@ -43,8 +43,8 @@
     damage:
       types:
         Blunt: 3
-        Heat: 32
-        
+        Heat: 22
+
 - type: entity
   id: BulletMagnumAP
   name: bullet (.45 magnum armor-piercing)
@@ -54,7 +54,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26 # 20% decrease
+        Piercing: 20 # 20% decrease
     ignoreResistances: true
 
 - type: entity
@@ -67,4 +67,4 @@
     damage:
       types:
         Radiation: 15
-        Piercing: 20
+        Piercing: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -54,7 +54,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20 # 20% decrease
+        Piercing: 25
     ignoreResistances: true
 
 - type: entity


### PR DESCRIPTION
# Description

Somehow I didn't realize that .45 magnum, despite being a common ammo type available to a lot of people, deals literally double the damage of all other comparable smallarms. No wonder people were complaining about the Universals being comically overpowered. This PR normalizes their damage so that it's still "More than other equivalent small arms calibers", but not ".45 is more than double the damage of 9mm". 

# Changelog

:cl:
- tweak: Nerfed universals and other .45 auto guns. I get the meme that .45 is better than 9mm, but not "More than double" the damage of 9mm. 
