### PR TITLE
Bug Fix: Fix Roboticist Airlock Sprite Error

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
@@ -14,7 +14,7 @@
     security:    Structures/Doors/Airlocks/Standard/security.rsi
     virology:    Structures/Doors/Airlocks/Standard/virology.rsi
     justice:     DeltaV/Structures/Doors/Airlocks/Standard/justice.rsi # Delta V - Add Justice Dept
-    roboticist:  DeltaV/Structures/Doors/Airlocks/Glass/roboticist.rsi #Added Roboticist Role
+    roboticist:  DeltaV/Structures/Doors/Airlocks/Standard/roboticist.rsi # Added Roboticist Role
 
 - type: AirlockGroup
   id: Glass


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Description.

A fix for [this issue](https://github.com/Simple-Station/Einstein-Engines/issues/1872)

Fixed bug of the painted roboticist airlock displaying the windowed counterpart instead of the standard one.


# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>

https://github.com/user-attachments/assets/fbe4c85f-c876-4e29-9c8d-cf95314e737f

</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed bug of the painted roboticist airlock displaying the windowed counterpart instead of the standard one.



 
