### PR TITLE
Trait Cost Balancing

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -57,7 +57,7 @@
 - type: trait
   id: Narcolepsy
   category: Mental
-  points: 2
+  points: 6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -78,7 +78,7 @@
 - type: trait
   id: Pacifist
   category: Mental
-  points: 6
+  points: 8
   functions:
     - !type:TraitAddComponent
       components:
@@ -101,7 +101,7 @@
 - type: trait
   id: Muted
   category: Mental
-  points: 4
+  points: 6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -199,7 +199,7 @@
 - type: trait
   id: Sluggish
   category: Physical
-  points: 3
+  points: 5
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -221,7 +221,7 @@
 - type: trait
   id: SnailPaced
   category: Physical
-  points: 5
+  points: 8
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -243,7 +243,7 @@
 - type: trait
   id: BloodDeficiency
   category: Physical
-  points: 5
+  points: 6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -265,7 +265,7 @@
 - type: trait
   id: Hemophilia
   category: Physical
-  points: 2
+  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -320,7 +320,7 @@
 - type: trait
   id: Clumsy
   category: Physical
-  points: 1
+  points: 4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -175,7 +175,7 @@
 - type: trait
   id: BadKnees
   category: Physical
-  points: 3
+  points: 5
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: WillToLive
   category: Physical
-  points: -1
+  points: -3
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -50,7 +50,7 @@
 - type: trait
   id: Tenacity
   category: Physical
-  points: -3
+  points: -4
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -239,7 +239,7 @@
 - type: trait
   id: Steadfast
   category: Physical
-  points: -4
+  points: -6
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -512,7 +512,7 @@
 - type: trait
   id: BionicArm
   category: Physical
-  points: -8
+  points: -10
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -871,7 +871,7 @@
 - type: trait
   id: BionicLeg
   category: Physical
-  points: -6
+  points: -8
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->


Makes a lot of disabilities give more points (based off community and personal opinions), and makes some very strong traits cost more points.


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Narcolepsy gives 6 points instead of 2
- tweak: Pacifist gives 8 points instead of 6
- tweak: Muted gives 6 points instead of 4
- tweak: Sluggish gives 5 points instead of 3
- tweak: Snail Paced gives 8 points instead of 5
- tweak: Blood Deficiency gives 6 points instead of 5
- tweak: Hemophilia gives 4 points instead of 2
- tweak: Clumsy gives 4 points instead of 1
- tweak: Bad knees gives 5 points instead of 3
- tweak: Will to live costs 3 points instead of 1
- tweak: Tenacity costs 4 points instead of 3
- tweak: Steadfast costs 6 points instead of 4
- tweak: Bionic Arm costs 10 points instead of 8
- tweak: Bionic leg costs 8 points instead of 6 
