### PR TITLE
Make Shoving Great Again

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -18,7 +18,7 @@ public sealed partial class MeleeWeaponSystem
     /// <summary>
     /// Does all of the melee effects for a player that are predicted, i.e. character lunge and weapon animation.
     /// </summary>
-    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
+    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, Angle spriteRotation, bool predicted = true)
     {
         if (!Timing.IsFirstTimePredicted)
             return;
@@ -43,15 +43,12 @@ public sealed partial class MeleeWeaponSystem
             return;
         }
 
-        var spriteRotation = Angle.Zero;
         if (arcComponent.Animation != WeaponArcAnimation.None
             && TryComp(weapon, out MeleeWeaponComponent? meleeWeaponComponent))
         {
             if (user != weapon
                 && TryComp(weapon, out SpriteComponent? weaponSpriteComponent))
                 sprite.CopyFrom(weaponSpriteComponent);
-
-            spriteRotation = meleeWeaponComponent.WideAnimationRotation;
 
             if (meleeWeaponComponent.SwingLeft)
                 angle *= -1;

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -257,6 +257,6 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         // Entity might not have been sent by PVS.
         if (Exists(ent) && Exists(entWeapon))
-            DoLunge(ent, entWeapon, ev.Angle, ev.LocalPos, ev.Animation);
+            DoLunge(ent, entWeapon, ev.Angle, ev.LocalPos, ev.Animation, ev.SpriteRotation);
     }
 }

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -322,7 +322,7 @@ public sealed partial class AbsorbentSystem : SharedAbsorbentSystem
         var localPos = Vector2.Transform(targetPos, _transform.GetInvWorldMatrix(userXform));
         localPos = userXform.LocalRotation.RotateVec(localPos);
 
-        _melee.DoLunge(user, used, Angle.Zero, localPos, null, false);
+        _melee.DoLunge(user, used, Angle.Zero, localPos, null, Angle.Zero, false);
 
         return true;
     }

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -93,6 +93,9 @@ namespace Content.Server.Hands.Systems
             if (args.Handled)
                 return;
 
+            if (!_random.Prob(args.DisarmProbability)) // WWDP shove
+                return;
+
             // Break any pulls
             if (TryComp(uid, out PullerComponent? puller) && TryComp(puller.Pulling, out PullableComponent? pullable))
                 _pullingSystem.TryStopPull(puller.Pulling.Value, pullable, ignoreGrab: true); // Goobstation edit added check for grab
@@ -102,7 +105,7 @@ namespace Content.Server.Hands.Systems
                 return;
 
 
-            args.Handled = true; // no shove/stun.
+            args.Handled = true; // Successful disarm.
         }
 
         // Shitmed Change Start

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -150,45 +150,50 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             return false;
 
         var chance = CalculateDisarmChance(user, target, inTargetHand, combatMode);
-        if (!_random.Prob(chance))
-        {
-            // Don't play a sound as the swing is already predicted.
-            // Also don't play popups because most disarms will miss.
-            return false;
-        }
 
-        var filterOther = Filter.PvsExcept(user, entityManager: EntityManager);
-        var msgPrefix = "disarm-action-";
-
-        if (inTargetHand == null)
-            msgPrefix = "disarm-action-shove-";
-
-        var msgOther = Loc.GetString(
-                msgPrefix + "popup-message-other-clients",
-                ("performerName", Identity.Entity(user, EntityManager)),
-                ("targetName", Identity.Entity(target, EntityManager)));
-
-        var msgUser = Loc.GetString(msgPrefix + "popup-message-cursor", ("targetName", Identity.Entity(target, EntityManager)));
-
-        PopupSystem.PopupEntity(msgOther, user, filterOther, true);
-        PopupSystem.PopupEntity(msgUser, target, user);
+        // WWDP shove is guaranteed now, disarm chance is rolled on top
 
         _audio.PlayPvs(combatMode.DisarmSuccessSound, user, AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
         AdminLogger.Add(LogType.DisarmedAction, $"{ToPrettyString(user):user} used disarm on {ToPrettyString(target):target}");
 
-        var staminaDamage = (TryComp<ShovingComponent>(user, out var shoving) ? shoving.StaminaDamage : ShovingComponent.DefaultStaminaDamage)
-            * Math.Clamp(chance, 0f, 1f);
+        var staminaDamage = CalculateShoveStaminaDamage(user, target); // WWDP shoving
 
-        var eventArgs = new DisarmedEvent { Target = target, Source = user, PushProbability = chance, StaminaDamage = staminaDamage };
+        var eventArgs = new DisarmedEvent { Target = target, Source = user, DisarmProbability = chance, StaminaDamage = staminaDamage }; // WWDP shoving
         RaiseLocalEvent(target, eventArgs);
 
         if (!eventArgs.Handled)
+        {
+            ShoveOrDisarmPopup(disarm: false); // WWDP
             return false;
+        }
+
+        ShoveOrDisarmPopup(disarm: true); // WWDP
 
         _audio.PlayPvs(combatMode.DisarmSuccessSound, user, AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
         AdminLogger.Add(LogType.DisarmedAction, $"{ToPrettyString(user):user} used disarm on {ToPrettyString(target):target}");
 
         return true;
+
+        // WWDP edit (moved to function)
+        void ShoveOrDisarmPopup(bool disarm)
+        {
+            var filterOther = Filter.PvsExcept(user, entityManager: EntityManager);
+            var msgPrefix = "disarm-action-";
+
+            if (!disarm)
+                msgPrefix = "disarm-action-shove-";
+
+            var msgOther = Loc.GetString(
+                msgPrefix + "popup-message-other-clients",
+                ("performerName", Identity.Entity(user, EntityManager)),
+                ("targetName", Identity.Entity(target, EntityManager)));
+
+            var msgUser = Loc.GetString(msgPrefix + "popup-message-cursor", ("targetName", Identity.Entity(target, EntityManager)));
+
+            PopupSystem.PopupEntity(msgOther, user, filterOther, true);
+            PopupSystem.PopupEntity(msgUser, target, user);
+        }
+        // WWDP edit end
     }
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
@@ -227,14 +232,22 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (TryComp<ShovingComponent>(disarmer, out var shoving))
             chance += shoving.DisarmBonus;
 
-        return Math.Clamp(chance
-                        * _contests.MassContest(disarmer, disarmed, false, 2f)
-                        * _contests.StaminaContest(disarmer, disarmed, false, 0.5f)
-                        * _contests.HealthContest(disarmer, disarmed, false, 1f),
+        return Math.Clamp(chance // WWDP disarm based on health & stamina
+                        * _contests.StaminaContest(disarmer, disarmed)
+                        * _contests.HealthContest(disarmer, disarmed),
                         0f, 1f);
     }
 
-    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
+    private float CalculateShoveStaminaDamage(EntityUid disarmer, EntityUid disarmed)
+    {
+        var baseStaminaDamage = TryComp<ShovingComponent>(disarmer, out var shoving) ? shoving.StaminaDamage : ShovingComponent.DefaultStaminaDamage;
+
+        return
+            baseStaminaDamage
+            * _contests.MassContest(disarmer, disarmed, false, 4f);
+    }
+
+    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, Angle spriteRotation, bool predicted = true)
     {
         Filter filter;
 

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -260,7 +260,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             filter = Filter.Pvs(user, entityManager: EntityManager);
         }
 
-        RaiseNetworkEvent(new MeleeLungeEvent(GetNetEntity(user), GetNetEntity(weapon), angle, localPos, animation), filter);
+        RaiseNetworkEvent(new MeleeLungeEvent(GetNetEntity(user), GetNetEntity(weapon), angle, localPos, animation, spriteRotation), filter);
     }
 
     private void OnSpeechHit(EntityUid owner, MeleeSpeechComponent comp, MeleeHitEvent args)

--- a/Content.Server/Weapons/Melee/ShovingComponent.cs
+++ b/Content.Server/Weapons/Melee/ShovingComponent.cs
@@ -6,7 +6,7 @@ public sealed partial class ShovingComponent : Component
     /// <summary>
     ///     Default shoving stamina damage used if the shoving entity has no ShovingComponent. See <see cref="StaminaDamage"/>.
     /// </summary>
-    public const float DefaultStaminaDamage = 50f;
+    public const float DefaultStaminaDamage = 10f; // WWDP shoving
 
     /// <summary>
     ///     Amount of stamina damage dealt on successful shove if the attacker has a 100% chance to shove the target.

--- a/Content.Shared/CCVar/CCVars.Melee.cs
+++ b/Content.Shared/CCVar/CCVars.Melee.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// Shove range multiplier.
+    /// </summary>
+    public static readonly CVarDef<float> ShoveRange =
+        CVarDef.Create("game.shove_range", 0.5f, CVar.SERVER | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Shove speed multiplier, does not affect range.
+    /// </summary>
+    public static readonly CVarDef<float> ShoveSpeed =
+        CVarDef.Create("game.shove_speed", 5f, CVar.SERVER | CVar.ARCHIVE);
+
+    /// <summary>
+    /// How much should the mass difference affect shove range & speed.
+    /// </summary>
+    public static readonly CVarDef<float> ShoveMassFactor =
+        CVarDef.Create("game.shove_mass_factor", 5f, CVar.SERVER | CVar.ARCHIVE);
+}
+
+

--- a/Content.Shared/CombatMode/DisarmedEvent.cs
+++ b/Content.Shared/CombatMode/DisarmedEvent.cs
@@ -13,9 +13,9 @@ namespace Content.Shared.CombatMode
         public EntityUid Source { get; init; }
 
         /// <summary>
-        ///     Probability for push/knockdown.
+        ///    WWDP - Probability to disarm in addition to shoving.
         /// </summary>
-        public float PushProbability { get; init; }
+        public float DisarmProbability { get; init; }
 
         /// <summary>
         ///     Potential stamina damage if this disarm results in a shove.

--- a/Content.Shared/Weapons/Melee/Events/MeleeLungeEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/MeleeLungeEvent.cs
@@ -31,12 +31,18 @@ public sealed class MeleeLungeEvent : EntityEventArgs
     /// </summary>
     public string? Animation;
 
-    public MeleeLungeEvent(NetEntity entity, NetEntity weapon, Angle angle, Vector2 localPos, string? animation)
+    /// <summary>
+    /// WWDP / The rotation of the sprite for the animation
+    /// </summary>
+    public Angle SpriteRotation;
+
+    public MeleeLungeEvent(NetEntity entity, NetEntity weapon, Angle angle, Vector2 localPos, string? animation, Angle spriteRotation)
     {
         Entity = entity;
         Weapon = weapon;
         Angle = angle;
         LocalPos = localPos;
         Animation = animation;
+        SpriteRotation = spriteRotation;
     }
 }

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -157,10 +157,23 @@ public sealed partial class MeleeWeaponComponent : Component
     public Angle Angle = Angle.FromDegrees(60);
 
     [DataField, AutoNetworkedField]
-    public EntProtoId Animation = "WeaponArcPunch";
+    public EntProtoId Animation = "WeaponArcThrust";
 
     [DataField, AutoNetworkedField]
     public EntProtoId WideAnimation = "WeaponArcSlash";
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId DisarmAnimation = "WeaponArcDisarm";
+
+    [DataField, AutoNetworkedField]
+    public bool CanHeavyAttack = true;
+
+    /// <summary>
+    /// Rotation of the animation.
+    /// 0 degrees means the top faces the attacker.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Angle AnimationRotation = Angle.Zero;
 
     /// <summary>
     /// Rotation of the animation.

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -406,7 +406,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         // Attack confirmed
         for (var i = 0; i < swings; i++)
         {
-            string animation;
+            string animation = weapon.Animation;
+            Angle spriteRotation = weapon.AnimationRotation;
 
             switch (attack)
             {
@@ -425,12 +426,13 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                         return false;
 
                     animation = weapon.WideAnimation;
+                    spriteRotation = weapon.WideAnimationRotation;
                     break;
                 default:
                     throw new NotImplementedException();
             }
 
-            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range, animation);
+            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range, animation, spriteRotation);
         }
 
         var attackEv = new MeleeAttackEvent(weaponUid);
@@ -827,7 +829,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return true;
     }
 
-    private void DoLungeAnimation(EntityUid user, EntityUid weapon, Angle angle, MapCoordinates coordinates, float length, string? animation)
+    private void DoLungeAnimation(EntityUid user, EntityUid weapon, Angle angle, MapCoordinates coordinates, float length, string? animation, Angle spriteRotation)
     {
         // TODO: Assert that offset eyes are still okay.
         if (!TryComp(user, out TransformComponent? userXform))
@@ -848,10 +850,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (localPos.Length() > visualLength)
             localPos = localPos.Normalized() * visualLength;
 
-        DoLunge(user, weapon, angle, localPos, animation);
+        DoLunge(user, weapon, angle, localPos, animation, spriteRotation);
     }
 
-    public abstract void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true);
+    public abstract void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, Angle spriteRotation, bool predicted = true);
 
     /// <summary>
     /// Used to update the MeleeWeapon component on item toggle.

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Justice/gavel.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Justice/gavel.yml
@@ -9,7 +9,8 @@
       layers:
         - state: icon
     - type: MeleeWeapon
-      wideAnimationRotation: -90
+      animationRotation: 45 # WWDP
+      wideAnimationRotation: 135 # WWDP
       damage:
         types:
           Blunt: 2

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -106,6 +106,7 @@
       path: /Audio/Nyanotrasen/Weapons/electricguitarhit.ogg
     range: 1.85
     attackRate: .8
+    animationRotation: -45
     wideAnimationRotation: 45
     damage:
       types:
@@ -114,8 +115,8 @@
     bluntStaminaDamageFactor: 1.5
     heavyRateModifier: 0.75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 10
-    angle: 160
+    heavyStaminaCost: 15
+    angle: 90
   - type: DamageOtherOnHit
     staminaCost: 8
   - type: Wieldable
@@ -191,6 +192,7 @@
         Blunt: 20
   - type: MeleeWeapon
     range: 1.5
+    animationRotation: -45 # WWDP
     wideAnimationRotation: 45
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
@@ -31,6 +31,7 @@
     - Payload # yes, you can make re-usable prank grenades
     - BikeHorn
   - type: MeleeWeapon
+    animationRotation: 135 # WWDP
     wideAnimationRotation: 135
     soundHit:
       collection: BikeHorn
@@ -78,6 +79,7 @@
       params:
         variation: 0.246
   - type: MeleeWeapon
+    animationRotation: 135 # WWDP
     wideAnimationRotation: 135
     soundHit:
       collection: CluwneHorn

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -29,6 +29,7 @@
     sprite: Objects/Fun/Darts/dart_red.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -45
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1970,7 +1970,6 @@
     - type: StaminaDamageOnHit
       damage: 0.8
     - type: MeleeWeapon
-      canBeBlocked: false # WD EDIT
       animationRotation: -45 # WWDP
       wideAnimationRotation: -135
       attackRate: .1

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1970,6 +1970,8 @@
     - type: StaminaDamageOnHit
       damage: 0.8
     - type: MeleeWeapon
+      canBeBlocked: false # WD EDIT
+      animationRotation: -45 # WWDP
       wideAnimationRotation: -135
       attackRate: .1
       damage:
@@ -2030,7 +2032,7 @@
       params:
         variation: 0.05
   - type: EmitSoundOnLand
-    sound: 
+    sound:
       path: /Audio/DeltaV/Voice/Harpy/caw1.ogg
       params:
         variation: 0.05

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -37,7 +37,8 @@
   - type: FireExtinguisher
     hasSafety: true
   - type: MeleeWeapon
-    wideAnimationRotation: 180
+    animationRotation: -90 # WWDP
+    wideAnimationRotation: 0 # WWDP
     attackRate: 1.25
     bluntStaminaDamageFactor: 2.5
     range: 1.75

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -19,7 +19,7 @@
   - type: MeleeWeapon
     wideAnimationRotation: 90
     resetOnHandSelected: false
-    animation: WeaponArcDisarm
+    # animation: WeaponArcDisarm # WWDP replaced with animation
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -395,6 +395,7 @@
     sprite: Objects/Misc/bureaucracy.rsi
     state: overpriced_pen
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -45
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -31,6 +31,7 @@
     - Plastic
     - Trash
   - type: MeleeWeapon
+    animationRotation: 180 # WWDP
     wideAnimationRotation: 180
     attackRate: .6666
     damage:
@@ -53,6 +54,7 @@
     types:
     - Fork
   - type: MeleeWeapon
+    animationRotation: 180 # WWDP
     wideAnimationRotation: 180
     attackRate: .6666
     damage:
@@ -102,6 +104,7 @@
     types:
     - Spoon
   - type: MeleeWeapon
+    animationRotation: 180 # WWDP
     wideAnimationRotation: 180
     attackRate: .6666
     damage:
@@ -178,6 +181,7 @@
     reactionTypes:
     - Stir
   - type: MeleeWeapon
+    animationRotation: 180 # WWDP
     wideAnimationRotation: 180
     attackRate: .5
     damage:

--- a/Resources/Prototypes/Entities/Objects/Tools/EmpFlashlight.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/EmpFlashlight.yml
@@ -11,7 +11,7 @@
           name: power-cell-clot-component-spot-name-default
           startingItem: PowerCellHigh
     - type: MeleeWeapon
-      wideAnimationRotation: -135
+      wideAnimationRotation: 90 # WWDP
       damage:
         types:
           Blunt: 12

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -119,7 +119,7 @@
         visible: false
         map: [ "light" ]
   - type: MeleeWeapon
-    wideAnimationRotation: 90
+    wideAnimationRotation: -90
     attackRate: 1.25
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -32,6 +32,7 @@
     explosionType: Default
     maxIntensity: 20
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: 45
     attackRate: 1.25
     range: 1.75
@@ -43,7 +44,7 @@
     heavyDamageBaseModifier: 1.5
     heavyStaminaCost: 10
     maxTargets: 3
-    angle: 100
+    angle: 60 # WWDP
     soundHit:
       path: /Audio/Weapons/smash.ogg
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -85,6 +85,8 @@
           Quantity: 8
         maxVol: 8 #uses less fuel than a welder, so this isnt as bad as it looks
   - type: MeleeWeapon
+    canBeBlocked: false
+    animationRotation: 180
     wideAnimationRotation: 180
     damage:
       types:
@@ -228,6 +230,8 @@
       - state: zippo-inhand-right-flame
         shader: unshaded
   - type: MeleeWeapon
+    canBeBlocked: false
+    animationRotation: 180
     wideAnimationRotation: 180
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -85,7 +85,6 @@
           Quantity: 8
         maxVol: 8 #uses less fuel than a welder, so this isnt as bad as it looks
   - type: MeleeWeapon
-    canBeBlocked: false
     animationRotation: 180
     wideAnimationRotation: 180
     damage:
@@ -230,7 +229,6 @@
       - state: zippo-inhand-right-flame
         shader: unshaded
   - type: MeleeWeapon
-    canBeBlocked: false
     animationRotation: 180
     wideAnimationRotation: 180
     damage:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -30,6 +30,7 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
     - state: cutters-cutty-thingy
   - type: MeleeWeapon
+    animationRotation: -90 # WWDP
     wideAnimationRotation: -90
     attackRate: 1.1
     range: 1.6
@@ -114,6 +115,7 @@
     sprite: Objects/Tools/screwdriver.rsi
     storedRotation: -90
   - type: MeleeWeapon
+    animationRotation: -90 # WWDP
     wideAnimationRotation: -90
     attackRate: .74
     damage:
@@ -191,6 +193,7 @@
       sprite: Objects/Tools/wrench.rsi
       state: storage
   - type: MeleeWeapon
+    animationRotation: 225 # WWDP
     wideAnimationRotation: 135
     attackRate: 1.1
     range: 1.6
@@ -249,6 +252,7 @@
       sprite: Objects/Tools/crowbar.rsi
       state: storage
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: .8
     damage:
@@ -460,7 +464,8 @@
   - type: StaticPrice
     price: 100
   - type: MeleeWeapon
-    wideAnimationRotation: -90
+    animationRotation: 90 # WWDP
+    wideAnimationRotation: 90 # WWDP
     attackRate: 1.1
     range: 1.4
     damage:
@@ -690,6 +695,7 @@
     sprite: Objects/Tools/shovel.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: 45
     attackRate: 1.25
     range: 1.75
@@ -743,6 +749,7 @@
     slots:
     - Belt
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: 1.1
     damage:

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -82,6 +82,7 @@
         shader: unshaded
   - type: UseDelay
   - type: MeleeWeapon
+    animationRotation: -90 # WWDP
     wideAnimationRotation: -90
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -81,6 +81,7 @@
       types:
         Piercing: 5
         Slash: 3.5
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
@@ -181,6 +182,7 @@
       types:
         Piercing: 5
         Slash: 3.5
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Weapons/Melee/baseball_bat.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     range: 1.6
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -12,6 +12,7 @@
     sprite: Objects/Weapons/Melee/cane.rsi
   - type: Appearance
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: 45
     damage:
       types:
@@ -38,7 +39,8 @@
     sprite: Objects/Weapons/Melee/cane_blade.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: 65
+    animationRotation: 45 # WWDP
+    wideAnimationRotation: 45 # WWDP
     attackRate: .6666
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -56,6 +56,7 @@
         shader: unshaded
         map: [ "blade" ]
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: .8
     damage:
@@ -159,7 +160,8 @@
         shader: unshaded
         map: [ "blade" ]
   - type: MeleeWeapon
-    wideAnimationRotation: -135
+    animationRotation: 135 # WWDP
+    wideAnimationRotation: 135 # WWDP
     attackRate: 1
     hidden: true
     damage:
@@ -280,8 +282,8 @@
             Slash: 6
             Heat: 12
             Structural: 20 # "expertly contained to cut through nearly any material" yet it had no structural damage
-  - type: GuideHelp  
-    guides: [ SecurityWeapons ]  
+  - type: GuideHelp
+    guides: [ SecurityWeapons ]
 
 - type: entity
   name: double-bladed energy sword

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Weapons/Melee/gohei.rsi
     state: gohei
   - type: MeleeWeapon
+    animationRotation: -60 # WWDP
     wideAnimationRotation: -150
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -13,6 +13,7 @@
     types:
       - Knife
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     attackRate: .8
     range: 1.5
@@ -168,6 +169,7 @@
     sprite: Objects/Weapons/Melee/kukri_knife.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     attackRate: 1.0
     range: 1.75
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -13,6 +13,7 @@
   - type: MeleeWeapon
     attackRate: 0.85
     range: 1.5
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -61,6 +62,7 @@
   - type: MeleeWeapon
     autoAttack: true
     angle: 0
+    animationRotation: -90 # WWDP
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
@@ -94,6 +96,7 @@
   - type: MeleeWeapon
     autoAttack: true
     angle: 0
+    animationRotation: -90 # WWDP
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
@@ -154,6 +157,7 @@
   - type: MeleeWeapon
     attackRate: 0.65 # Lavaland/Eris Change
     range: 1.65
+    animationRotation: -45
     wideAnimationRotation: -135
     damage:
       types:
@@ -201,6 +205,7 @@
     state: icon
   - type: MeleeWeapon
     autoAttack: true
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: 1.25
     range: 1.4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/needle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/needle.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Weapons/Melee/needle.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Weapons/Melee/sledgehammer.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: 1.3333
     range: 1.75
@@ -20,7 +21,7 @@
     heavyDamageBaseModifier: 1.75
     heavyStaminaCost: 7.5
     maxTargets: 10
-    angle: 120
+    angle: 90 # WWDP
     soundHit:
       collection: MetalThud
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -36,6 +36,7 @@
       map: ["enum.SolutionContainerLayers.Fill"]
       visible: false
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     range: 1.75
     damage:
@@ -128,6 +129,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/reinforced_spear.rsi
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     damage:
       types:
@@ -149,6 +151,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/plasma_spear.rsi
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     damage:
       types:
@@ -170,6 +173,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/uranium_spear.rsi
   - type: MeleeWeapon
+    animationRotation: -135 # WWDP
     wideAnimationRotation: -135
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -9,6 +9,7 @@
   - type: Execution
     doAfterDuration: 4.0
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
   - type: Sprite
     state: icon
@@ -28,6 +29,7 @@
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: .8
     range: 1.75

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
@@ -11,6 +11,7 @@
     size: Normal
     sprite: Objects/Weapons/Melee/white_cane.rsi
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: 45
     attackRate: 1.1
     range: 1.6

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -105,6 +105,7 @@
     sprite: Objects/Weapons/Melee/truncheon.rsi
     state: icon
   - type: MeleeWeapon
+    animationRotation: -45 # WWDP
     wideAnimationRotation: -135
     attackRate: 0.8
     damage:


### PR DESCRIPTION
# Description

This is a port of both 
https://github.com/WWhiteDreamProject/wwdpublic/pull/264
and https://github.com/WWhiteDreamProject/wwdpublic/pull/280

Which handily fixes shoving being completely worthless, by reworking it into an actual physical shove that moves the target, with a chance based on your mass contest interactions to disarm them. It had a dependency in the form of melee lunge visuals, so I ported that as well. I also did general code cleanups to make these fixes not depend on calls to Deprecated functions.

# Changelog

:cl: Vaankas
- add: Reworked Shoving. It now actually moves your target by shoving them away from you!
- add: Added visuals for weapon lunges.
