### PR TITLE
Miscellaneous Fixes From White Dream

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -91,7 +91,8 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (a.IsPinned != b.IsPinned)
                     return a.IsPinned ? -1 : 1;
 
-                // First, sort by unread. Any chat with unread messages appears first.
+                // First, sort by unread. Any chat with unread messages appears first. We just sort based on unread
+                // status, not number of unread messages, so that more recent unread messages take priority.
                 var aUnread = ach.Unread > 0;
                 var bUnread = bch.Unread > 0;
                 if (aUnread != bUnread)

--- a/Content.Client/Flight/FlyingVisualizerSystem.cs
+++ b/Content.Client/Flight/FlyingVisualizerSystem.cs
@@ -37,8 +37,7 @@ public sealed class FlyingVisualizerSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return;
 
-        if (!animateLayer)
-            entity.Comp.PostShader = shader;
+        entity.Comp.PostShader = shader;
 
         if (animateLayer && layer is not null)
             entity.Comp.LayerSetShader(layer.Value, shader);

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -48,7 +48,7 @@ public sealed class BodySystem : SharedBodySystem
 
         if (_mobState.IsDead(ent) && _mindSystem.TryGetMind(ent, out var mindId, out var mind))
         {
-            mind.TimeOfDeath ??= _gameTiming.RealTime;
+            mind.TimeOfDeath ??= _gameTiming.CurTime; // WD EDIT
             _ticker.OnGhostAttempt(mindId, canReturnGlobal: true, mind: mind);
         }
     }

--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -22,7 +22,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
         SubscribeLocalEvent<AirlockComponent, SignalReceivedEvent>(OnSignalReceived);
 
         SubscribeLocalEvent<AirlockComponent, PowerChangedEvent>(OnPowerChanged);
-        SubscribeLocalEvent<AirlockComponent, ActivateInWorldEvent>(OnActivate, before: new[] { typeof(DoorSystem) });
+        SubscribeLocalEvent<AirlockComponent, ActivateInWorldEvent>(OnActivate, after: new[] { typeof(DoorSystem) });
     }
 
     private void OnAirlockInit(EntityUid uid, AirlockComponent component, ComponentInit args)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -202,7 +202,7 @@ namespace Content.Server.Ghost
 
         private void OnGhostExamine(EntityUid uid, GhostComponent component, ExaminedEvent args)
         {
-            var timeSinceDeath = _gameTiming.RealTime.Subtract(component.TimeOfDeath);
+            var timeSinceDeath = _gameTiming.CurTime.Subtract(component.TimeOfDeath); // WD EDIT
             var deathTimeInfo = timeSinceDeath.Minutes > 0
                 ? Loc.GetString("comp-ghost-examine-time-minutes", ("minutes", timeSinceDeath.Minutes))
                 : Loc.GetString("comp-ghost-examine-time-seconds", ("seconds", timeSinceDeath.Seconds));

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -482,7 +482,7 @@ namespace Content.Shared.Cuffs
         }
 
         /// <returns>False if the target entity isn't cuffable.</returns>
-        public bool TryCuffing(EntityUid user, EntityUid target, EntityUid handcuff, HandcuffComponent? handcuffComponent = null, CuffableComponent? cuffable = null, float distanceThreshold = 0.3f)
+        public bool TryCuffing(EntityUid user, EntityUid target, EntityUid handcuff, HandcuffComponent? handcuffComponent = null, CuffableComponent? cuffable = null, float distanceThreshold = SharedInteractionSystem.InteractionRange)
         {
             if (!Resolve(handcuff, ref handcuffComponent) || !Resolve(target, ref cuffable, false))
                 return false;

--- a/Resources/Locale/en-US/ghost/ghost-respawn.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-respawn.ftl
@@ -1,6 +1,10 @@
-ghost-respawn-time-left = Please wait {$time} {$time ->
+ghost-respawn-minutes-left = Please wait {$time} {$time ->
     [one] minute
    *[other] minutes
+} before trying to respawn.
+ghost-respawn-seconds-left = Please wait {$time} {$time ->
+    [one] second
+   *[other] seconds
 } before trying to respawn.
 
 ghost-respawn-max-players = Cannot respawn right now. There should be fewer than {$players} players.

--- a/Resources/Locale/ru-RU/ghost/ghost-respawn.ftl
+++ b/Resources/Locale/ru-RU/ghost/ghost-respawn.ftl
@@ -1,8 +1,14 @@
-ghost-respawn-time-left = До возможности вернуться в раунд { $time } 
+ghost-respawn-minutes-left = До возможности вернуться в раунд { $time } 
     { $time ->
         [one] минута
         [few] минуты
        *[other] минут
+    }
+ghost-respawn-seconds-left = До возможности вернуться в раунд { $time } 
+    { $time ->
+        [one] секунда
+        [few] секунды
+       *[other] секунд
     }
 ghost-respawn-max-players = Функция недоступна, игроков на сервере должно быть меньше { $players }.
 ghost-respawn-window-title = Правила возвращения в раунд

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -401,7 +401,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 100
+        damage: 10
       behaviors:
       - !type:GibBehavior
         gibContents: Skip

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -401,10 +401,11 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 10
+        damage: 100
       behaviors:
       - !type:GibBehavior
         gibContents: Skip
+        recursive: false
   - type: NonSpreaderZombie
   - type: LanguageKnowledge
     speaks: [Hissing]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -246,8 +246,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - Opaque # WWDP allow shooting through windows
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
@@ -329,8 +328,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - Opaque # WWDP allow shooting through windows
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
@@ -997,8 +995,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - Opaque # WWDP allow shooting through windows
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
@@ -1117,8 +1114,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - Opaque # WWDP allow shooting through windows
       fly-by: *flybyfixture
   - type: Ammo
   - type: Projectile

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -12,7 +12,7 @@
     - type: RCDDeconstructable
       cost: 6
       delay: 4
-      fx: EffectRCDDeconstruct4  
+      fx: EffectRCDDeconstruct4
     - type: CanBuildWindowOnTop
     - type: Sprite
       drawdepth: Walls
@@ -194,7 +194,7 @@
           mask:
           - FullTileMask
           layer:
-          - WallLayer
+          - GlassLayer # WWDP fix
     - type: Construction
       graph: GrilleDiagonal
       node: grilleDiagonal
@@ -229,8 +229,8 @@
           mask:
           - FullTileMask
           layer:
-          - WallLayer
+          - GlassLayer # WWDP fix
     - type: Construction
       graph: GrilleDiagonal
       node: clockworkGrilleDiagonal
-      
+

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -41,7 +41,9 @@
   - type: Appearance
   - type: Tag
     tags:
-      - WeldbotFixableStructure
+    - ForceFixRotations # WWDP fix missing tags
+    - Window # WWDP fix missing tags
+    - WeldbotFixableStructure
   - type: DamageVisuals
     thresholds: [4, 8, 12]
     damageDivisor: 28

--- a/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
@@ -175,3 +175,6 @@
   result: VimHarness
   category: MechEquipment
   completetime: 5
+  materials:
+    Steel: 400
+    Plastic: 100

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -324,14 +324,14 @@
   - type: SurgeryStep
     tool:
     - type: Tending
-    duration: 1
+    duration: 2
   - type: Sprite
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
     state: hemostat
   - type: SurgeryTendWoundsEffect
     damage:
       groups:
-        Brute: -5
+        Brute: -10
   - type: SurgeryRepeatableStep
 
 - type: entity
@@ -343,7 +343,7 @@
   - type: SurgeryStep
     tool:
     - type: Tending
-    duration: 1
+    duration: 2
   - type: Sprite
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
     state: hemostat
@@ -351,7 +351,7 @@
     mainGroup: Burn
     damage:
       groups:
-        Burn: -5
+        Burn: -10
   - type: SurgeryRepeatableStep
 
 - type: entity


### PR DESCRIPTION
# Description

Ports the following PRs:
https://github.com/WWhiteDreamProject/wwdpublic/pull/271
https://github.com/WWhiteDreamProject/wwdpublic/pull/282
https://github.com/WWhiteDreamProject/wwdpublic/pull/255
https://github.com/WWhiteDreamProject/wwdpublic/pull/254
https://github.com/WWhiteDreamProject/wwdpublic/pull/246
https://github.com/WWhiteDreamProject/wwdpublic/pull/223
https://github.com/WWhiteDreamProject/wwdpublic/pull/220
https://github.com/WWhiteDreamProject/wwdpublic/pull/219
https://github.com/WWhiteDreamProject/wwdpublic/pull/213

This is a rather huge variety of fixes to be honest.

# Changelog

:cl: White Dream
- fix: Fixed airlock opening and closing visuals
- fix: Fixed Weather spamming infinite sounds.
- fix: Cockroaches no longer spam organs when stepped on.
- fix: Fixed the timer on the Return To Round button
- fix: Fixed Return to Round not remembering how long it's been since you died if you re-enter your body.
- fix: Fixed harpy flight visuals not showing for other people.
- fix: Fixed disabler bolts not going through windows like other kinds of lasers.
- fix: Fixed Vim Harness being free
- fix: Fixed handcuffs not respecting your arm length.
- fix: Made tending wounds not as message spammy.
- fix: Fixed shuttle windows not preventing you from being electrocuted by grills under them.
