### PR TITLE
Engineering Holoprojectors can be Charged

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/holoprojectors.yml
@@ -14,4 +14,4 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
-        locked: true
+        locked: false


### PR DESCRIPTION
…r right now. im just holoing my shit im helpful as fuck man im an engineer man like for real.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

So there was previously no way to charge the default engineering holoprojector which I've seen like once, but now there is. You can actually take the battery out, like with other holoprojectors.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![holoprojector](https://github.com/user-attachments/assets/a7345fa4-a61b-48f8-81f9-ffb708a71a25)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: you can take the battery out of engineering holoprojectors and charge them.
