### PR TITLE
Crafting Curtains and Tables No Longer Consumes Entire Stack

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
@@ -1,9 +1,9 @@
 # TODO once tiles can be smoothed and carpets ported over to that, add them to the FloorTile outputs
 - type: entity
-  name: carpet
   parent: FloorTileItemBase
   id: FloorCarpetItemRed
-  suffix: Red
+  name: red carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-red
@@ -21,11 +21,13 @@
     prototype: Carpet
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemBlack
-  suffix: Black
+  name: black carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-black
@@ -40,11 +42,13 @@
     prototype: CarpetBlack
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemBlue
-  suffix: Blue
+  name: blue carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-blue
@@ -59,11 +63,13 @@
     prototype: CarpetBlue
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemGreen
-  suffix: Green
+  name: green carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-green
@@ -78,11 +84,13 @@
     prototype: CarpetGreen
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemOrange
-  suffix: Orange
+  name: orange carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-orange
@@ -97,11 +105,13 @@
     prototype: CarpetOrange
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemSkyBlue
-  suffix: Sky Blue
+  name: sky blue carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-skyblue
@@ -116,11 +126,13 @@
     prototype: CarpetSBlue
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemPurple
-  suffix: Purple
+  name: purple carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-purple
@@ -135,11 +147,13 @@
     prototype: CarpetPurple
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemPink
-  suffix: Pink
+  name: pink carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-pink
@@ -154,11 +168,13 @@
     prototype: CarpetPink
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemCyan
-  suffix: Cyan
+  name: cyan carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-cyan
@@ -173,11 +189,13 @@
     prototype: CarpetCyan
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material
 
 - type: entity
   parent: FloorCarpetItemRed
   id: FloorCarpetItemWhite
-  suffix: White
+  name: white carpet
+  suffix: Item
   components:
   - type: Sprite
     state: carpet-white
@@ -192,3 +210,4 @@
     prototype: CarpetWhite
     doAfter: 0.5
     removeOnInteract: true
+  - type: Material

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/curtains.yml
@@ -17,92 +17,65 @@
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetBlack
+            - material: FloorCarpetBlack
+              amount: 1
               doAfter: 1
-              name: black carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-black
         - to: CurtainsBlue
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetBlue
+            - material: FloorCarpetBlue
+              amount: 1
               doAfter: 1
-              name: blue carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-blue
         - to: CurtainsCyan
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetCyan
+            - material: FloorCarpetCyan
+              amount: 1
               doAfter: 1
-              name: cyan carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-cyan
         - to: CurtainsGreen
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetGreen
+            - material: FloorCarpetGreen
+              amount: 1
               doAfter: 1
-              name: green carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-green
         - to: CurtainsOrange
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetOrange
+            - material: FloorCarpetOrange
+              amount: 1
               doAfter: 1
-              name: orange carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-orange
         - to: CurtainsPink
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetPink
+            - material: FloorCarpetPink
+              amount: 1
               doAfter: 1
-              name: pink carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-pink
         - to: CurtainsPurple
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetPurple
+            - material: FloorCarpetPurple
+              amount: 1
               doAfter: 1
-              name: purple carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-purple
         - to: CurtainsRed
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetRed
+            - material: FloorCarpetRed
+              amount: 1
               doAfter: 1
-              name: red carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-red
         - to: CurtainsWhite
           completed:
             - !type:SnapToGrid { }
           steps:
-            - tag: CarpetWhite
+            - material: FloorCarpetWhite
+              amount: 1
               doAfter: 1
-              name: white carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-white
               
     - node: Curtains
       entity: HospitalCurtains

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
@@ -1,4 +1,4 @@
-﻿- type: constructionGraph
+- type: constructionGraph
   id: Table
   start: start
   graph:
@@ -214,75 +214,57 @@
               
         - to: TableFancyBlack
           steps: 
-            - tag: CarpetBlack
-              name: black carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-black
+            - material: FloorCarpetBlack
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyBlue
           steps: 
-            - tag: CarpetBlue
-              name: blue carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-blue
+            - material: FloorCarpetBlue
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyCyan
           steps: 
-            - tag: CarpetCyan
-              name: cyan carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-cyan
+            - material: FloorCarpetCyan
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyGreen
           steps: 
-            - tag: CarpetGreen
-              name: green carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-green
+            - material: FloorCarpetGreen
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyOrange
           steps: 
-            - tag: CarpetOrange
-              name: orange carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-orange
+            - material: FloorCarpetOrange
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyPurple
           steps: 
-            - tag: CarpetPurple
-              name: purple carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-purple
+            - material: FloorCarpetPurple
+              amount: 1
+              doAfter: 1
                 
         - to: TableFancyPink
           steps: 
-            - tag: CarpetPink
-              name: pink carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-pink
+            - material: FloorCarpetPink
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyRed
           steps: 
-            - tag: CarpetRed
-              name: red carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-red
+            - material: FloorCarpetRed
+              amount: 1
+              doAfter: 1
               
         - to: TableFancyWhite
           steps: 
-            - tag: CarpetWhite
-              name: white carpet
-              icon:
-                sprite: Objects/Tiles/tile.rsi
-                state: carpet-white
+            - material: FloorCarpetWhite
+              amount: 1
+              doAfter: 1
 
         - to: TableWoodReinforced #Nyano - See Resources/Prototypes/Nyanotrasen/Entities/Furniture/Tables/tables.yml
           steps:

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -422,6 +422,13 @@
   itemSize: 5
 
 - type: stack
+  id: FloorTileRCircuit
+  name: red-circuit floor
+  spawn: FloorTileItemRCircuit
+  maxCount: 30
+  itemSize: 5
+
+- type: stack
   id: FloorTileGrass
   name: grass floor tile
   spawn: FloorTileItemGrass

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -1,4 +1,4 @@
-﻿- type: stack
+- type: stack
   id: FloorTileSteel
   name: steel tile
   spawn: FloorTileItemSteel
@@ -88,7 +88,7 @@
   spawn: FloorTileItemBrassFilled
   maxCount: 30
   itemSize: 5
-
+  
 - type: stack
   id: FloorTileBrassReebe
   name: smooth brass plate
@@ -203,70 +203,80 @@
 
 - type: stack
   id: FloorCarpetRed
-  name: red carpet tile
+  name: red carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-red }
   spawn: FloorCarpetItemRed
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetBlack
-  name: block carpet tile
+  name: black carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-black }
   spawn: FloorCarpetItemBlack
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetBlue
-  name: blue carpet tile
+  name: blue carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-blue }
   spawn: FloorCarpetItemBlue
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetGreen
-  name: green carpet tile
+  name: green carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-green }
   spawn: FloorCarpetItemGreen
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetOrange
-  name: orange carpet tile
+  name: orange carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-orange }
   spawn: FloorCarpetItemOrange
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetSkyBlue
-  name: skyblue carpet tile
+  name: skyblue carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-skyblue }
   spawn: FloorCarpetItemSkyBlue
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetPurple
-  name: purple carpet tile
+  name: purple carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-purple }
   spawn: FloorCarpetItemPurple
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetPink
-  name: pink carpet tile
+  name: pink carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-pink }
   spawn: FloorCarpetItemPink
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetCyan
-  name: cyan carpet tile
+  name: cyan carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-cyan }
   spawn: FloorCarpetItemCyan
   maxCount: 30
   itemSize: 5
 
 - type: stack
   id: FloorCarpetWhite
-  name: white carpet tile
+  name: white carpet
+  icon: { sprite: Objects/Tiles/tile.rsi, state: carpet-white }
   spawn: FloorCarpetItemWhite
   maxCount: 30
   itemSize: 5
@@ -408,13 +418,6 @@
   id: FloorTileBCircuit
   name: bcircuit floor tile
   spawn: FloorTileItemBCircuit
-  maxCount: 30
-  itemSize: 5
-
-- type: stack
-  id: FloorTileRCircuit
-  name: red-circuit floor
-  spawn: FloorTileItemRCircuit
   maxCount: 30
   itemSize: 5
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Stolen from https://github.com/Fansana/floofstation1/pull/152, courtesy of cynical24. When you craft a curtain or make a table into a _fancy_ table, it doesn't take the entire stack of carpet. This should hopefully stop me from having to return to the HoP to ask for another 10 carpet.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] general thievery of text (with permission)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![curtains](https://github.com/user-attachments/assets/0c960653-311a-40e7-bcbe-53e50d771c63)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: you don't use the entire stack of carpet now when crafting colored curtains or fancy tables.
