### PR TITLE
Revert "NT Poster Censorship" (#1880)

### DIFF
--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -316,9 +316,6 @@ ImprovisedExplosiveFuel: FireBombFuel
 WeaponSubMachineGunVectorRubber: null
 WeaponSubMachineGunVector: null
 
-# 2025-03-10
-PosterLegitNoERP: null
-
 # Lavaland EE stuff
 TreasureDatadiskEncrypted: null
 VendingMachineBoozeSyndicate: VendingMachineBooze

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -316,6 +316,9 @@ ImprovisedExplosiveFuel: FireBombFuel
 WeaponSubMachineGunVectorRubber: null
 WeaponSubMachineGunVector: null
 
+# 2025-03-10
+PosterLegitNoERP: null
+
 # Lavaland EE stuff
 TreasureDatadiskEncrypted: null
 VendingMachineBoozeSyndicate: VendingMachineBooze

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -316,11 +316,6 @@ ImprovisedExplosiveFuel: FireBombFuel
 WeaponSubMachineGunVectorRubber: null
 WeaponSubMachineGunVector: null
 
-# 2025-03-05
-PosterLegitEnlist: null
-PosterLegitNoErp: null
-PosterContrabandEnlistGorlex: null
-
 # Lavaland EE stuff
 TreasureDatadiskEncrypted: null
 VendingMachineBoozeSyndicate: VendingMachineBooze

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -88,6 +88,7 @@
       - PosterContrabandMoth
       - PosterContrabandCybersun600
       - PosterContrabandDonk
+      - PosterContrabandEnlistGorlex
       - PosterContrabandInterdyne
       - PosterContrabandWaffleCorp
       - PosterContrabandSaucerNumberOne # Nyanotrasen Poster, see Resources/Prototypes/Nyanotrasen/Entities/Structures/Wallmount/Signs/posters.yml
@@ -138,10 +139,12 @@
       - PosterLegit50thAnniversaryVintageReprint
       - PosterLegitFruitBowl
       - PosterLegitPDAAd
+      - PosterLegitEnlist
       - PosterLegitNanomichiAd
       - PosterLegit12Gauge
       - PosterLegitHighClassMartini
       - PosterLegitTheOwl
+      - PosterLegitNoERP
       - PosterLegitCarbonDioxide
       - PosterLegitDickGumshue
       - PosterLegitThereIsNoGasGiant
@@ -166,6 +169,6 @@
       - PosterLegitShoukou # Nyanotrasen Poster, see Resources/Prototypes/Nyanotrasen/Entities/Structures/Wallmount/Signs/posters.yml
       - PosterLegitCornzza # Nyanotrasen Poster, see Resources/Prototypes/Nyanotrasen/Entities/Structures/Wallmount/Signs/posters.yml
       - PosterLegitFuckAround # DeltaV Poster, see Resources/Prototypes/DeltaV/Entities/Structures/Wallmount/Signs/posters.yml
-      - PosterLegitSafetyMothSSD
       - PosterLegitOppenhopper
+      - PosterLegitSafetyMothSSD
     chance: 1

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -144,7 +144,7 @@
       - PosterLegit12Gauge
       - PosterLegitHighClassMartini
       - PosterLegitTheOwl
-      - PosterLegitNoERP
+      #- PosterLegitNoERP # Einstein Engines: breaks literal 4th wall
       - PosterLegitCarbonDioxide
       - PosterLegitDickGumshue
       - PosterLegitThereIsNoGasGiant

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -1294,6 +1294,7 @@
   - type: Sprite
     state: poster53_legit
 
+
 #maps
 
 - type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

This PR re-adds the Enlist, and EnlistGorlex posters. Why:
- The Enlist poster has been replaced from a Death Squad operative to ERT ***ages ago*** in Delta-V code. Regardless of whatever the final codebase using this poster, I don't think this warrants a complete migration removal, since ERT are a known substance almost universally, and the closest example, like the Sec ERT, looks as distinct from a DS as both from a blood-red.
- The EnlistGorlex poster doesn't actually make mention of any nuclear operatives. It is a task Gorlex sends agents on, yes, but from a PR point of view blatantly advertising nuclear capabilities would ruin the balance of power.
  "Oh, but the hardsuit! That's a nukie hardsuit!" Wrong.
  
  Traitors - even non-Gorlex traitors - can buy those hardsuits. The hardsuit alone wouldn't imply nuclear operatives exist. It's scary, but not THAT scary, even as a contraband poster.

In absolutely no circumstance would I put them in migrations unless the lore SPECIFICALLY removes both nuclear operatives (which are still in fact a gamemode) and ERTs (which are still an IC superforce). I can see a situation where you'd want an Enlist poster upstream but not in the marker spawn list, for example.

---

# TODO

This PR is complete, I do not need help completing it.  

---

# Changelog

:cl: router
- add: Re-added ERT and Gorlex enlist posters to the default roster, and removed them from the mapping migration list.
- remove: Removed No ERP posters from rotation. This does not affect specifically placed posters.