### PR TITLE
Fairer Turrets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -73,51 +73,80 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 600
+            damage: 200 # Was 600, most players were under the impression these were indestructible. It having an Inorganic damage container did not help.
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                WeaponTurretSyndicateBroken: # Make a broken turret when destroyed.
+                  min: 1
+                  max: 1
         - trigger:
             !type:DamageTrigger
-            damage: 300
+            damage: 90 # Rather than fully smash the turret at half health, make an indication that its taking damage.
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+        - trigger:
+            !type:DamageTrigger
+            damage: 50 # Helps indicate that the turrets arent indestructible.
+          # TODO: Construction graph
+          behaviors:
+            - !type:PlaySoundBehavior
+              sound:
+                collection: MetalGlassBreak
     - type: Gun
       fireRate: 6
       selectedMode: FullAuto
       availableModes:
         - FullAuto
       soundGunshot: /Audio/Weapons/Guns/Gunshots/gun_sentry.ogg
+      currentAngle: 25 # Fires first shot at min accuracy.
+      minAngle: 25 # Not guaranteed to hit their shots anymore.
+      maxAngle: 45 # Continuous fire makes their accuracy unreliable.
     # TODO: Power ammo provider?
     - type: BallisticAmmoProvider
-      proto: CartridgeCaselessRifle
-      capacity: 500
+      proto: CartridgeLightRifle # This way it drops spent casings.
+      capacity: 200 # Not infinite ammo, it should run out of ammo in a more reasonable timeframe.
     - type: HTN
       rootTask:
         task: TurretCompound
       blackboard:
         RotateSpeed: !type:Single
-          3.141
+          1.571 # At most 1 second to react to a target directly behind it, instead of instantaneous tracking  
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/Effects/double_beep.ogg
     - type: MouseRotator
       angleTolerance: 5
-      rotationSpeed: 180
+      rotationSpeed: 90
       simple4DirMode: false
     - type: NoRotateOnInteract
     - type: NoRotateOnMove
     - type: Input
       context: "human"
+
+- type: entity
+  parent: BaseWeaponTurret
+  id: BaseWeaponTurretMinigun
+  name: minigun turret
+  abstract: true
+  components:
+    - type: Gun
+      fireRate: 15
+      selectedMode: FullAuto
+      availableModes:
+        - FullAuto
+      soundGunshot: /Audio/Weapons/Guns/Gunshots/minigun.ogg
+      currentAngle: 45 # Fires first shot at min accuracy.
+      minAngle: 45 # Always cover the screen in bullets.
+      maxAngle: 45 
+    # TODO: Power ammo provider?
+    - type: BallisticAmmoProvider
+      proto: CartridgeMinigun # BRRT FOOD
+      capacity: 1000 # Not infinite ammo, it should run out of ammo in a more reasonable timeframe.
 
 - type: entity
   parent: BaseWeaponTurret
@@ -139,6 +168,7 @@
         - SAN
     - type: Gun
       fireRate: 10  # Guaranteed to spook the shit out of people.
+      currentAngle: 40 # Fires first shot at min accuracy.
       minAngle: 40
       maxAngle: 45  # Not guaranteed to do a whole lot of damage unless they stand there and let it hit them.
       soundGunshot:
@@ -146,29 +176,7 @@
     - type: BallisticAmmoProvider
       proto: CartridgePistol
       capacity: 200
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 200
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          # TODO: Construction graph
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-            - !type:PlaySoundBehavior
-              sound:
-                collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+
 - type: entity
   parent: BaseWeaponTurret
   name: disposable ballistic turret
@@ -178,21 +186,6 @@
     - type: NpcFactionMember
       factions:
         - Syndicate
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-            - !type:TriggerBehavior
     - type: Gun
       fireRate: 2
       selectedMode: FullAuto


### PR DESCRIPTION
# Description

It had basically always bothered me, and evidently a lot of other people that turrets were previously "Unfair enemies". They had perfect aimbot accuracy, tracked targets instantly at any angle, and were nigh-indestructible. It was telling that players were pretty much only ever killed by turrets once or twice, and then they figure out that the turrets are outright impossible to beat in a fair fight, so they end up resorting to underhanded tactics like using an RCD to wall the turret off. Or use a pickaxe to go around them.

I previously added a new turret for the SAN dropship, and with it had tried out a very different approach for "Fairer Turret" balancing. A more reasonable healthbar, no instant tracking, and no perfect accuracy, The players enjoyed these a lot more than the original turrets. Plus they were more visually interesting firing an inaccurate spray at their targets.

<details><summary><h1>Media</h1></summary>
<p>

I'm on my lunch break at college right now, so no media.

</p>
</details>

# Changelog

:cl:
- tweak: Adjusted turrets to be a more "Fair" fight. They no longer have perfect aimbot accuracy, they don't track targets instantly, and they also have a "More fair" healthbar that can reasonably be shot through by someone with good enough weapons and armor, 