### PR TITLE
Rename the Medsecglasses to Blueshield Glasses and Add a Diagnostic Hud to Them.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
   id: ClothingEyesGlassesMedSec
-  name: medsecglasses
-  description: Sunglasses with a medical and security hud
+  name: blueshield glasses
+  description: Advanced Sunglasses with a deep blue hue and a built in HUD capable of displaying Security, Medical, and Diagnostics information.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Eyes/Glasses/medglasses.rsi
@@ -15,12 +15,17 @@
     tags:
     - WhitelistChameleon
     - HudMedical
+    - HudSecurity
   - type: IdentityBlocker
     coverage: EYES
   - type: ShowHealthBars
     damageContainers:
     - Biological
+    - Inorganic
+    - Silicon
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - Inorganic
+    - Silicon
     

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -2,7 +2,7 @@
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
   id: ClothingEyesGlassesMedSec
   name: blueshield glasses
-  description: Advanced Sunglasses with a deep blue hue and a built in HUD capable of displaying Security, Medical, and Diagnostics information.
+  description: Advanced Sunglasses with a deep blue hue and a built-in HUD capable of displaying Security, Medical, and Diagnostics information.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Eyes/Glasses/medglasses.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -13,19 +13,19 @@
     protectionTime: 5
   - type: Tag
     tags:
-    - WhitelistChameleon
-    - HudMedical
-    - HudSecurity
+     - WhitelistChameleon
+     - HudMedical
+     - HudSecurity
   - type: IdentityBlocker
     coverage: EYES
   - type: ShowHealthBars
     damageContainers:
-    - Biological
-    - Inorganic
-    - Silicon
+     - Biological
+     - Inorganic
+     - Silicon
   - type: ShowHealthIcons
     damageContainers:
-    - Biological
-    - Inorganic
-    - Silicon
+     - Biological
+     - Inorganic
+     - Silicon
     


### PR DESCRIPTION
# Description

The medsecglasses have been renamed to blueshield glasses, with an updated description.
They also now act as a diagnostic hud, so the status of borgs and IPCs can be monitored.


Firstly, the name looks quite odd next to for example the corpsman glasses, especially if you want to try to fit the word diagnostic in there too, and as these glasses are only used by the BSO, and have the sprite to match, naming them as such seems better.

As for why the diagnostic ability is being added at all, the blueshield is supposed to protect command from threats, and both command AND threats could be IPCs, and borgs can also be threats if their laws are compromised. Being able to identify their integrity at a glance  to decide your priorities, both for who to heal/shield and who to shoot, should be a nice QOL improvement.

---

# Changelog

:cl: BramvanZijp
- tweak: The medsecglasses have been renamed to blueshield glasses, alongside an updated description
- add: Added a diagnostic HUD to the blueshield glasses.
