### PR TITLE
Rev Manifesto Inhand Use Cooldown

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/revolutionary.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/revolutionary.yml
@@ -15,6 +15,8 @@
         color: "#aaaa24"
     - type: RevolutionaryConverter
       conversionDuration: 3
+    - type: UseDelay
+      delay: 2
     - type: Appearance
     - type: EmitSoundOnPickup
       sound: /Audio/SimpleStation14/Items/Handling/book_pickup.ogg


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Add a two second cooldown on the Revolutionary Manifesto's secondary use (the purely cosmetic one) to not make it cause chat spam.
I made this change from web and have NOT tested it yet (unless I checked the checkbox below in the TODO section!

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] TEST IF IT WORKS

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked rev manifesto to not spam chat anymore
