### PR TITLE
Saltern Fixes

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -30,6 +30,8 @@ tilemap:
   62: FloorLino
   64: FloorMetalDiamond
   65: FloorMime
+  10: FloorMining
+  9: FloorMiningDark
   69: FloorMono
   2: FloorPlastic
   76: FloorRGlass
@@ -270,11 +272,11 @@ entities:
           version: 6
         1,2:
           ind: 1,2
-          tiles: eAAAAAAAeQAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: eAAAAAAAeQAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACgAAAAAACQAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeQAAAAAAHQAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAIgAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeQAAAAAAHQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAACQAAAAAACQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAACgAAAAAACQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         2,2:
           ind: 2,2
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: HQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -4585,9 +4587,6 @@ entities:
     - type: DeviceList
       devices:
       - 283
-      - 7940
-      - 7941
-      - 7942
       - 8044
       - 8042
       - 8043
@@ -4772,7 +4771,7 @@ entities:
       pos: 3.5,22.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -43530.066
+      secondsUntilStateChange: -44402.203
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -4913,42 +4912,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -32.5,8.5
       parent: 2
-  - uid: 93
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 70.5,4.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 2
-      links:
-      - 106
-      - 95
-    - type: DeviceLinkSource
-      linkedPorts:
-        95:
-        - DoorStatus: DoorBolt
-        106:
-        - DoorStatus: DoorBolt
   - uid: 94
     components:
     - type: Transform
       pos: -29.5,-10.5
       parent: 2
-  - uid: 95
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 71.5,2.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
-      links:
-      - 93
-    - type: DeviceLinkSource
-      linkedPorts:
-        93:
-        - DoorStatus: DoorBolt
   - uid: 96
     components:
     - type: Transform
@@ -5008,20 +4976,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 45.5,-24.5
       parent: 2
-  - uid: 106
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 69.5,2.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
-      links:
-      - 93
-    - type: DeviceLinkSource
-      linkedPorts:
-        93:
-        - DoorStatus: DoorBolt
   - uid: 107
     components:
     - type: Transform
@@ -5373,6 +5327,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,30.5
+      parent: 2
+- proto: AirlockExternalGlassShuttlePathfinderFilled
+  entities:
+  - uid: 13255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,42.5
       parent: 2
 - proto: AirlockFreezer
   entities:
@@ -5833,6 +5795,13 @@ entities:
       name: Morgue
     - type: Transform
       pos: 16.5,-15.5
+      parent: 2
+- proto: AirlockMiningLocked
+  entities:
+  - uid: 13286
+    components:
+    - type: Transform
+      pos: 31.5,32.5
       parent: 2
 - proto: AirlockQuartermasterGlassLocked
   entities:
@@ -6762,6 +6731,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -54.5,10.5
+      parent: 2
+  - uid: 13282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,42.5
+      parent: 2
+  - uid: 13283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 34.5,30.5
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
@@ -17548,6 +17529,61 @@ entities:
     components:
     - type: Transform
       pos: 24.5,30.5
+      parent: 2
+  - uid: 13271
+    components:
+    - type: Transform
+      pos: 31.5,32.5
+      parent: 2
+  - uid: 13272
+    components:
+    - type: Transform
+      pos: 31.5,33.5
+      parent: 2
+  - uid: 13273
+    components:
+    - type: Transform
+      pos: 31.5,34.5
+      parent: 2
+  - uid: 13274
+    components:
+    - type: Transform
+      pos: 31.5,35.5
+      parent: 2
+  - uid: 13275
+    components:
+    - type: Transform
+      pos: 31.5,36.5
+      parent: 2
+  - uid: 13276
+    components:
+    - type: Transform
+      pos: 31.5,37.5
+      parent: 2
+  - uid: 13277
+    components:
+    - type: Transform
+      pos: 31.5,38.5
+      parent: 2
+  - uid: 13278
+    components:
+    - type: Transform
+      pos: 31.5,39.5
+      parent: 2
+  - uid: 13279
+    components:
+    - type: Transform
+      pos: 31.5,40.5
+      parent: 2
+  - uid: 13280
+    components:
+    - type: Transform
+      pos: 31.5,41.5
+      parent: 2
+  - uid: 13281
+    components:
+    - type: Transform
+      pos: 31.5,42.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -30058,6 +30094,18 @@ entities:
     - type: Transform
       pos: 15.5,-12.5
       parent: 2
+- proto: ClothingBackpackDuffelSalvageConscription
+  entities:
+  - uid: 13298
+    components:
+    - type: Transform
+      pos: 32.519737,36.56386
+      parent: 2
+  - uid: 13299
+    components:
+    - type: Transform
+      pos: 32.543175,36.915424
+      parent: 2
 - proto: ClothingBeltChampion
   entities:
   - uid: 4848
@@ -30638,6 +30686,13 @@ entities:
     - type: Transform
       pos: -8.46747,33.763454
       parent: 2
+- proto: CombatKnife
+  entities:
+  - uid: 13295
+    components:
+    - type: Transform
+      pos: 32.476448,35.775322
+      parent: 2
 - proto: ComfyChair
   entities:
   - uid: 4933
@@ -31018,6 +31073,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 33.5,27.5
       parent: 2
+- proto: ComputerShuttleSalvage
+  entities:
+  - uid: 13294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,37.5
+      parent: 2
 - proto: ComputerSolarControl
   entities:
   - uid: 4991
@@ -31036,12 +31099,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 14.5,-27.5
       parent: 2
-  - uid: 4994
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 60.5,1.5
-      parent: 2
 - proto: ComputerStationRecords
   entities:
   - uid: 4995
@@ -31059,6 +31116,14 @@ entities:
     components:
     - type: Transform
       pos: -2.5,11.5
+      parent: 2
+- proto: ComputerSupermatter
+  entities:
+  - uid: 4994
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 60.5,1.5
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
@@ -31739,6 +31804,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -24.5,15.5
       parent: 2
+  - uid: 13304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,38.5
+      parent: 2
 - proto: DecorFloorBoard10
   entities:
   - uid: 5105
@@ -32236,6 +32307,15 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: DecorFloorFood1
+  entities:
+  - uid: 13288
+    components:
+    - type: Transform
+      pos: 32.5,35.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: DecorFloorGlass3
   entities:
   - uid: 5165
@@ -32472,6 +32552,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,12.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 13306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,40.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -38313,37 +38401,6 @@ entities:
       color: '#730000C6'
 - proto: GasFilterFlipped
   entities:
-  - uid: 6146
-    components:
-    - type: Transform
-      pos: 71.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 6147
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 6148
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 69.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 6149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 67.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 6150
     components:
     - type: Transform
@@ -38356,13 +38413,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 51.5,23.5
       parent: 2
-  - uid: 6152
-    components:
-    - type: Transform
-      pos: 71.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 6153
     components:
     - type: Transform
@@ -38427,6 +38477,36 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#A01E16FF'
+- proto: GasFilterFlippedHighFlow
+  entities:
+  - uid: 6146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,6.5
+      parent: 2
+  - uid: 6147
+    components:
+    - type: Transform
+      pos: 71.5,7.5
+      parent: 2
+  - uid: 6148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,6.5
+      parent: 2
+  - uid: 6149
+    components:
+    - type: Transform
+      pos: 71.5,9.5
+      parent: 2
+  - uid: 6152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,6.5
+      parent: 2
 - proto: GasMinerAmmonia
   entities:
   - uid: 6161
@@ -38576,6 +38656,23 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,12.5
+      parent: 2
+- proto: GasOutletInjectorHighFlow
+  entities:
+  - uid: 7940
+    components:
+    - type: Transform
+      pos: 68.5,1.5
+      parent: 2
+  - uid: 7941
+    components:
+    - type: Transform
+      pos: 67.5,1.5
+      parent: 2
+  - uid: 7942
+    components:
+    - type: Transform
+      pos: 66.5,1.5
       parent: 2
 - proto: GasPassiveVent
   entities:
@@ -51056,27 +51153,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#ADD8E6FF'
-  - uid: 7825
-    components:
-    - type: MetaData
-      name: atmos to active coolant
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 63.5,-1.5
-      parent: 2
-    - type: GasPressurePump
-      targetPressure: 1000
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 7826
-    components:
-    - type: MetaData
-      name: passive coolant removal
-    - type: Transform
-      pos: 63.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7827
     components:
     - type: MetaData
@@ -51130,17 +51206,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#A01E16FF'
-  - uid: 7833
-    components:
-    - type: MetaData
-      name: passive coolant input
-    - type: Transform
-      pos: 63.5,3.5
-      parent: 2
-    - type: GasPressurePump
-      targetPressure: 1000
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7834
     components:
     - type: MetaData
@@ -51151,25 +51216,6 @@ entities:
       parent: 2
     - type: GasPressurePump
       targetPressure: 4500
-  - uid: 7835
-    components:
-    - type: MetaData
-      name: active coolant removal
-    - type: Transform
-      pos: 67.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 7836
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 68.5,-2.5
-      parent: 2
-    - type: GasPressurePump
-      targetPressure: 1000
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7837
     components:
     - type: Transform
@@ -51178,6 +51224,35 @@ entities:
       parent: 2
     - type: GasPressurePump
       targetPressure: 1500
+- proto: GasPressurePumpHighFlow
+  entities:
+  - uid: 7825
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 63.5,-1.5
+      parent: 2
+  - uid: 7826
+    components:
+    - type: Transform
+      pos: 67.5,-2.5
+      parent: 2
+  - uid: 7833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 68.5,-2.5
+      parent: 2
+  - uid: 8049
+    components:
+    - type: Transform
+      pos: 63.5,3.5
+      parent: 2
+  - uid: 8051
+    components:
+    - type: Transform
+      pos: 63.5,6.5
+      parent: 2
 - proto: GasThermoMachineFreezer
   entities:
   - uid: 7838
@@ -51265,6 +51340,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 66.5,9.5
       parent: 2
+    - type: GasValve
+      open: False
   - uid: 7848
     components:
     - type: MetaData
@@ -52026,32 +52103,6 @@ entities:
       - 5879
     - type: AtmosPipeColor
       color: '#000099C6'
-- proto: GasVentPumpHighFlow
-  entities:
-  - uid: 7940
-    components:
-    - type: Transform
-      pos: 66.5,1.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 45
-  - uid: 7941
-    components:
-    - type: Transform
-      pos: 67.5,1.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 45
-  - uid: 7942
-    components:
-    - type: Transform
-      pos: 68.5,1.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 45
 - proto: GasVentScrubber
   entities:
   - uid: 7943
@@ -53014,16 +53065,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FF00FF'
-  - uid: 8049
-    components:
-    - type: MetaData
-      name: passive coolant volumetric pump
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#A01E16FF'
   - uid: 8050
     components:
     - type: Transform
@@ -53032,10 +53073,24 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#ADD8E6FF'
-  - uid: 8051
+  - uid: 8056
     components:
-    - type: MetaData
-      name: passive coolant volumetric pump
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 48.5,25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#ADD8E6FF'
+- proto: GasVolumePumpHighFlow
+  entities:
+  - uid: 7835
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,8.5
+      parent: 2
+  - uid: 7836
+    components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,8.5
@@ -53045,65 +53100,41 @@ entities:
     - type: Transform
       pos: 76.5,4.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 8053
     components:
     - type: Transform
       pos: 75.5,4.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 8054
     components:
     - type: Transform
       pos: 74.5,4.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 8055
     components:
     - type: Transform
       pos: 73.5,4.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 8056
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 48.5,25.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#ADD8E6FF'
   - uid: 8057
     components:
     - type: Transform
       pos: 73.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 8058
     components:
     - type: Transform
       pos: 74.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 8059
     components:
     - type: Transform
       pos: 75.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 8060
     components:
     - type: Transform
       pos: 76.5,7.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
 - proto: Gauze
   entities:
   - uid: 8061
@@ -56264,26 +56295,6 @@ entities:
     - type: Transform
       pos: 13.5,36.5
       parent: 2
-  - uid: 8640
-    components:
-    - type: Transform
-      pos: 29.5,40.5
-      parent: 2
-  - uid: 8641
-    components:
-    - type: Transform
-      pos: 29.5,38.5
-      parent: 2
-  - uid: 8642
-    components:
-    - type: Transform
-      pos: 29.5,33.5
-      parent: 2
-  - uid: 8643
-    components:
-    - type: Transform
-      pos: 29.5,36.5
-      parent: 2
   - uid: 8644
     components:
     - type: Transform
@@ -56298,6 +56309,36 @@ entities:
     components:
     - type: Transform
       pos: -20.5,26.5
+      parent: 2
+  - uid: 13265
+    components:
+    - type: Transform
+      pos: 30.5,42.5
+      parent: 2
+  - uid: 13266
+    components:
+    - type: Transform
+      pos: 32.5,42.5
+      parent: 2
+  - uid: 13267
+    components:
+    - type: Transform
+      pos: 33.5,40.5
+      parent: 2
+  - uid: 13268
+    components:
+    - type: Transform
+      pos: 33.5,39.5
+      parent: 2
+  - uid: 13269
+    components:
+    - type: Transform
+      pos: 33.5,36.5
+      parent: 2
+  - uid: 13270
+    components:
+    - type: Transform
+      pos: 33.5,35.5
       parent: 2
 - proto: GrilleBroken
   entities:
@@ -56662,39 +56703,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 27.5,42.5
       parent: 2
-  - uid: 8709
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,39.5
-      parent: 2
-  - uid: 8710
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,37.5
-      parent: 2
-  - uid: 8711
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,35.5
-      parent: 2
-  - uid: 8712
-    components:
-    - type: Transform
-      pos: 29.5,34.5
-      parent: 2
-  - uid: 8713
-    components:
-    - type: Transform
-      pos: 29.5,37.5
-      parent: 2
-  - uid: 8714
-    components:
-    - type: Transform
-      pos: 29.5,39.5
-      parent: 2
 - proto: GrilleDiagonal
   entities:
   - uid: 8715
@@ -56967,6 +56975,26 @@ entities:
     components:
     - type: Transform
       pos: 54.5,-9.5
+      parent: 2
+- proto: HighSecEngineeringLocked
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 69.5,2.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 70.5,4.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 71.5,2.5
       parent: 2
 - proto: HospitalCurtains
   entities:
@@ -57587,6 +57615,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.395765,1.2312138
+      parent: 2
+- proto: KukriKnife
+  entities:
+  - uid: 13296
+    components:
+    - type: Transform
+      pos: 32.58731,35.66901
       parent: 2
 - proto: Lamp
   entities:
@@ -58787,6 +58822,13 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 13287
+    components:
+    - type: Transform
+      pos: 31.5,40.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: N14DecorFloorBoard23
   entities:
   - uid: 9027
@@ -58844,6 +58886,16 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,34.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: N14DecorFloorGlass5
+  entities:
+  - uid: 13305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -58935,6 +58987,16 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: N14DecorFloorScrapwood
+  entities:
+  - uid: 13309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,33.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: N14DecorFloorTrashbags2
   entities:
   - uid: 9043
@@ -58986,12 +59048,48 @@ entities:
     - type: Transform
       pos: 25.622877,37.9276
       parent: 2
+- proto: N14TableMetalGrate
+  entities:
+  - uid: 13289
+    components:
+    - type: Transform
+      pos: 32.5,35.5
+      parent: 2
+  - uid: 13290
+    components:
+    - type: Transform
+      pos: 32.5,36.5
+      parent: 2
+  - uid: 13291
+    components:
+    - type: Transform
+      pos: 32.5,39.5
+      parent: 2
+  - uid: 13292
+    components:
+    - type: Transform
+      pos: 32.5,40.5
+      parent: 2
 - proto: N14Trashbin
   entities:
   - uid: 9050
     components:
     - type: Transform
       pos: 24.59658,29.502493
+      parent: 2
+- proto: N14WallDecorWallscreen
+  entities:
+  - uid: 13307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,37.5
+      parent: 2
+  - uid: 13308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,38.5
       parent: 2
 - proto: NetworkConfigurator
   entities:
@@ -59194,6 +59292,20 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-19.5
+      parent: 2
+- proto: OreBag
+  entities:
+  - uid: 13302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.329716,39.723698
+      parent: 2
+  - uid: 13303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.65784,39.747135
       parent: 2
 - proto: OreBox
   entities:
@@ -59653,6 +59765,19 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-23.5
+      parent: 2
+- proto: Pickaxe
+  entities:
+  - uid: 13300
+    components:
+    - type: Transform
+      pos: 32.58753,40.661198
+      parent: 2
+  - uid: 13301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.540653,40.45026
       parent: 2
 - proto: PillCanister
   entities:
@@ -60335,6 +60460,11 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-28.5
+      parent: 2
+  - uid: 13293
+    components:
+    - type: Transform
+      pos: 32.5,34.5
       parent: 2
 - proto: PottedPlantRD
   entities:
@@ -61504,11 +61634,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 33.5,25.5
       parent: 2
-  - uid: 9449
-    components:
-    - type: Transform
-      pos: 31.5,31.5
-      parent: 2
 - proto: PoweredLightColoredBlack
   entities:
   - uid: 9450
@@ -61545,6 +61670,12 @@ entities:
       - 10340
 - proto: PoweredSmallLight
   entities:
+  - uid: 9449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,40.5
+      parent: 2
   - uid: 9455
     components:
     - type: Transform
@@ -62154,6 +62285,12 @@ entities:
     components:
     - type: Transform
       pos: 21.5,38.5
+      parent: 2
+  - uid: 13264
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,33.5
       parent: 2
 - proto: PoweredSmallLightMaintenance
   entities:
@@ -64248,6 +64385,16 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
+  - uid: 8640
+    components:
+    - type: Transform
+      pos: 32.5,42.5
+      parent: 2
+  - uid: 8641
+    components:
+    - type: Transform
+      pos: 30.5,42.5
+      parent: 2
   - uid: 9920
     components:
     - type: Transform
@@ -65874,6 +66021,26 @@ entities:
     components:
     - type: Transform
       pos: -53.5,11.5
+      parent: 2
+  - uid: 13260
+    components:
+    - type: Transform
+      pos: 33.5,36.5
+      parent: 2
+  - uid: 13261
+    components:
+    - type: Transform
+      pos: 33.5,35.5
+      parent: 2
+  - uid: 13262
+    components:
+    - type: Transform
+      pos: 33.5,39.5
+      parent: 2
+  - uid: 13263
+    components:
+    - type: Transform
+      pos: 33.5,40.5
       parent: 2
 - proto: ReinforcedWindowDiagonal
   entities:
@@ -69961,6 +70128,16 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmos Tech Lockers
+  - uid: 13310
+    components:
+    - type: Transform
+      pos: 72.5,12.5
+      parent: 2
+  - uid: 13311
+    components:
+    - type: Transform
+      pos: 41.5,25.5
+      parent: 2
 - proto: SurveillanceCameraGeneral
   entities:
   - uid: 10834
@@ -70571,17 +70748,6 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Logistics pallets area
-  - uid: 10893
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,28.5
-      parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSupply
-      nameSet: True
-      id: Salvage equipment room
 - proto: Syringe
   entities:
   - uid: 10894
@@ -72222,6 +72388,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 68.5,4.5
       parent: 2
+- proto: ThrowingKnife
+  entities:
+  - uid: 13297
+    components:
+    - type: Transform
+      pos: 32.382698,35.962822
+      parent: 2
 - proto: TintedWindow
   entities:
   - uid: 11169
@@ -73009,6 +73182,51 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
+  - uid: 8642
+    components:
+    - type: Transform
+      pos: 33.5,41.5
+      parent: 2
+  - uid: 8643
+    components:
+    - type: Transform
+      pos: 33.5,42.5
+      parent: 2
+  - uid: 8709
+    components:
+    - type: Transform
+      pos: 29.5,36.5
+      parent: 2
+  - uid: 8710
+    components:
+    - type: Transform
+      pos: 29.5,38.5
+      parent: 2
+  - uid: 8711
+    components:
+    - type: Transform
+      pos: 29.5,41.5
+      parent: 2
+  - uid: 8712
+    components:
+    - type: Transform
+      pos: 29.5,42.5
+      parent: 2
+  - uid: 8713
+    components:
+    - type: Transform
+      pos: 29.5,39.5
+      parent: 2
+  - uid: 8714
+    components:
+    - type: Transform
+      pos: 29.5,37.5
+      parent: 2
+  - uid: 10893
+    components:
+    - type: Transform
+      pos: 29.5,40.5
+      parent: 2
   - uid: 11287
     components:
     - type: Transform
@@ -79027,17 +79245,17 @@ entities:
   - uid: 12424
     components:
     - type: Transform
-      pos: 30.5,32.5
+      pos: 29.5,35.5
       parent: 2
   - uid: 12425
     components:
     - type: Transform
-      pos: 31.5,32.5
+      pos: 29.5,34.5
       parent: 2
   - uid: 12426
     components:
     - type: Transform
-      pos: 32.5,32.5
+      pos: 29.5,33.5
       parent: 2
   - uid: 12427
     components:
@@ -79068,6 +79286,36 @@ entities:
     components:
     - type: Transform
       pos: 34.5,25.5
+      parent: 2
+  - uid: 13256
+    components:
+    - type: Transform
+      pos: 33.5,38.5
+      parent: 2
+  - uid: 13257
+    components:
+    - type: Transform
+      pos: 33.5,33.5
+      parent: 2
+  - uid: 13258
+    components:
+    - type: Transform
+      pos: 33.5,34.5
+      parent: 2
+  - uid: 13259
+    components:
+    - type: Transform
+      pos: 33.5,37.5
+      parent: 2
+  - uid: 13284
+    components:
+    - type: Transform
+      pos: 32.5,32.5
+      parent: 2
+  - uid: 13285
+    components:
+    - type: Transform
+      pos: 30.5,32.5
       parent: 2
 - proto: WallSolid
   entities:


### PR DESCRIPTION
# Description

My mappers somehow all at once decided that removing all shuttles was a good idea. This caused problems because the mining shuttle sometimes doesn't dock to the station correctly, and when it happens a shuttle is needed to go retrieve it. Making it so that cargo doesn't have either cargo shuttle or pathfinder makes this impossible. @Ichaie 
@Mike32oz @OldDanceJacket make sure that in future map updates, that your maps have at least one pilotable shuttle, either the cargo shuttle or the Pathfinder. Ideally, you should be using the new Shuttle Spawning Airlocks, such as AirlockExternalGlassShuttlePathfinderFilled

These airlocks spawn a ship already docked to the station, similar to how the escape pods work. 

Also make sure that the doors to Supermatter cores are using High Security Engineering Locked doors, these airlocks are special in that they don't allow smallmobs like mice to crawl underneath, and are harder to hack. That first point is extremely vital because shitters will take mouse ghostroles and sprint into the supermatter to try and detonate it. 

Anyways this PR adds a dock for the Pathfinder to Saltern, as well as fixes some issues with Saltern's Supermatter. 

# Changelog

:cl:
- add: Saltern now has a dock for the Pathfinder, which will now start the round already docked to the station if nothing goes wrong.
- tweak: Made Saltern's supermatter much less "Explodey"
