### PR TITLE
More Tolerable Default CVars

### DIFF
--- a/Content.Shared/CCVar/CCVars.Announcer.cs
+++ b/Content.Shared/CCVar/CCVars.Announcer.cs
@@ -14,7 +14,7 @@ public sealed partial class CCVars
     ///     Optionally force set an announcer
     /// </summary>
     public static readonly CVarDef<string> Announcer =
-        CVarDef.Create("announcer.announcer", "", CVar.SERVERONLY);
+        CVarDef.Create("announcer.announcer", "VoxFem", CVar.SERVERONLY);
 
     /// <summary>
     ///     Optionally blacklist announcers

--- a/Content.Shared/CCVar/CCVars.Announcer.cs
+++ b/Content.Shared/CCVar/CCVars.Announcer.cs
@@ -14,7 +14,7 @@ public sealed partial class CCVars
     ///     Optionally force set an announcer
     /// </summary>
     public static readonly CVarDef<string> Announcer =
-        CVarDef.Create("announcer.announcer", "VoxFem", CVar.SERVERONLY);
+        CVarDef.Create("announcer.announcer", "", CVar.SERVERONLY);
 
     /// <summary>
     ///     Optionally blacklist announcers

--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -28,7 +28,7 @@ public sealed partial class CCVars
     ///     Useful to prevent clipping through objects.
     /// </summary>
     public static readonly CVarDef<float> SpaceWindMaxVelocity =
-        CVarDef.Create("atmos.space_wind_max_velocity", 30f, CVar.SERVERONLY);
+        CVarDef.Create("atmos.space_wind_max_velocity", 20f, CVar.SERVERONLY);
 
     /// <summary>
     ///     The maximum angular velocity that space wind can spin objects at while throwing them. This one is mostly for fun.
@@ -63,7 +63,7 @@ public sealed partial class CCVars
     ///     Also looks weird on slow spacing for unrelated reasons. If you do want to enable this, you should probably turn on instaspacing.
     /// </summary>
     public static readonly CVarDef<bool> MonstermosRipTiles =
-        CVarDef.Create("atmos.monstermos_rip_tiles", true, CVar.SERVERONLY);
+        CVarDef.Create("atmos.monstermos_rip_tiles", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     Taken as the cube of a tile's mass, this acts as a minimum threshold of mass for which air pressure calculates whether or not to rip a tile from the floor

--- a/Content.Shared/CCVar/CCVars.Customize.cs
+++ b/Content.Shared/CCVar/CCVars.Customize.cs
@@ -15,11 +15,11 @@ public sealed partial class CCVars
     ///     Allow players to set their own Station AI names.
     /// </summary>
     public static readonly CVarDef<bool> AllowCustomStationAiName =
-        CVarDef.Create("customize.allow_custom_station_ai_name", false, CVar.REPLICATED);
+        CVarDef.Create("customize.allow_custom_station_ai_name", true, CVar.REPLICATED);
 
     /// <summary>
     ///     Allow players to set their own cyborg names. (borgs, mediborgs, etc)
     /// </summary>
     public static readonly CVarDef<bool> AllowCustomCyborgName =
-        CVarDef.Create("customize.allow_custom_cyborg_name", false, CVar.REPLICATED);
+        CVarDef.Create("customize.allow_custom_cyborg_name", true, CVar.REPLICATED);
 }

--- a/Content.Shared/CCVar/CCVars.Events.cs
+++ b/Content.Shared/CCVar/CCVars.Events.cs
@@ -15,12 +15,12 @@ public sealed partial class CCVars
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     public static readonly CVarDef<float>
-        EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 40f, CVar.ARCHIVE | CVar.SERVERONLY);
+        EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 180f, CVar.ARCHIVE | CVar.SERVERONLY);
 
     /// <summary>
     ///     Average ending chaos modifier for the ramping event scheduler.
     ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     public static readonly CVarDef<float>
-        EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
+        EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 0.2f, CVar.ARCHIVE | CVar.SERVERONLY);
 }

--- a/Content.Shared/CCVar/CCVars.Jetpack.cs
+++ b/Content.Shared/CCVar/CCVars.Jetpack.cs
@@ -14,5 +14,5 @@ public sealed partial class CCVars
     ///     When true, jetpacks can be enabled on grids that have zero gravity.
     /// </summary>
     public static readonly CVarDef<bool> JetpackEnableInNoGravity =
-        CVarDef.Create("jetpack.enable_in_no_gravity", true, CVar.REPLICATED);
+        CVarDef.Create("jetpack.enable_in_no_gravity", false, CVar.REPLICATED);
 }

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -134,7 +134,7 @@ public sealed partial class CCVars
     /// Is the emergency shuttle allowed to be early launched.
     /// </summary>
     public static readonly CVarDef<bool> EmergencyEarlyLaunchAllowed =
-        CVarDef.Create("shuttle.emergency_early_launch_allowed", false, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.emergency_early_launch_allowed", true, CVar.SERVERONLY);
 
     /// <summary>
     /// How long the emergency shuttle remains docked with the station, in seconds.

--- a/Content.Shared/CCVar/CCVars.StationGoals.cs
+++ b/Content.Shared/CCVar/CCVars.StationGoals.cs
@@ -14,5 +14,5 @@ public sealed partial class CCVars
     ///     Chance for a station goal to be sent
     /// </summary>
     public static readonly CVarDef<float> StationGoalsChance =
-        CVarDef.Create("game.station_goals_chance", 0.1f, CVar.SERVERONLY);
+        CVarDef.Create("game.station_goals_chance", 1f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
# Description

I can't believe we never cleaned these up. Yea so our codebase made an astoundingly fucking poor first impression on BPL during their huge playtest, and most of these CVars were to blame. In particular is the godawful Ramping Event Scheduler having "Murder the station with ventcritters every 10 seconds at the 30 minute mark" as its settings. 

# Changelog

:cl:
- tweak: Disabled Monstermos Tile Ripping by default.
- tweak: Default settings for Ramping Event Scheduler no longer throws "Ventcritters every 10 seconds, 30 minutes into the round". 
