### PR TITLE
Tweak R25 Again

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -78,8 +78,8 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -12
-    maxAngle: -24
+    minAngle: -17
+    maxAngle: -22
   - type: Gun
     minAngle: 21
     maxAngle: 32
@@ -94,7 +94,6 @@
       params:
         volume: -3
         maxDistance: 8
-        rolloffFactor: 1
     availableModes:
     - SemiAuto
     - Burst

--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -78,15 +78,15 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -17
-    maxAngle: -22
+    minAngle: -12
+    maxAngle: -24
   - type: Gun
     minAngle: 21
     maxAngle: 32
     fireRate: 5  # 300rpm in Semi & Full Auto
     burstFireRate: 20  # 1200rpm in Burst mode.
-    shotsPerBurst: 5
-    burstCooldown: 1.1
+    shotsPerBurst: 3
+    burstCooldown: 0.9
     cameraRecoilScalar: 0.5
     selectedMode: Burst
     soundGunshot:
@@ -94,7 +94,7 @@
       params:
         volume: -3
         maxDistance: 8
-        rolloffFactor: 1.2
+        rolloffFactor: 1
     availableModes:
     - SemiAuto
     - Burst


### PR DESCRIPTION
# Description

Some more tweaks to the R25 stats after getting more feedback about it. (Shoutout to all the forks that decided to comment it out instead of actually giving feedback to their upstream?...)

# Changelog

:cl:
- tweak: Tweaked the R25's stats, it now has a 3 round burst instead of a 5 round burst.
- fix: Fixed an issue where the R25 was inaudible unless you were the one firing it. 
