### PR TITLE
Fix Cult Doors

### DIFF
--- a/Resources/Prototypes/WhiteDream/Entities/Objects/Structures/Cult/airlock.yml
+++ b/Resources/Prototypes/WhiteDream/Entities/Objects/Structures/Cult/airlock.yml
@@ -46,6 +46,7 @@
     deconstructable: false
   - type: RunedDoor
   - type: Repulse
+    forceMultiplier: 300 # This datafield has an awful name, it's actually the amount of force in Newtons.
   - type: RepulseOnTouch
   - type: PlacementReplacement
     key: walls


### PR DESCRIPTION
# Description

Cult doors would launch people at FTL speed, they exerted 13,000 Newtons of force on non-cultists who touched them. Which while sometimes hilarious, is enough to send people through walls. This PR sets it to a more reasonable number of 300 Newtons, which is enough to throw a standard human about 2 tiles from the door.

# Changelog

:cl:
- tweak: Tweaked cult doors so that they don't launch people at luminal speeds.
