### PR TITLE
Child of the Noosphere

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -15,6 +15,8 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Player;
 using Content.Shared.CCVar;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Tag;
+
 
 namespace Content.Server.Abilities.Psionics;
 
@@ -33,6 +35,7 @@ public sealed class PsionicAbilitiesSystem : EntitySystem
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly GhostSystem _ghost = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     public override void Initialize()
     {
@@ -205,7 +208,7 @@ public sealed class PsionicAbilitiesSystem : EntitySystem
         var ev = new OnMindbreakEvent();
         RaiseLocalEvent(uid, ref ev);
 
-        if (_config.GetCVar(CCVars.ScarierMindbreaking))
+        if (_config.GetCVar(CCVars.ScarierMindbreaking) || _tag.HasTag(uid,"TraitScaryMindbreaking" ))
             ScarierMindbreak(uid, psionic);
     }
 

--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -3,3 +3,5 @@ examine-dermal-armor-message = {CAPITALIZE(POSS-ADJ($entity))} skin seems to be 
 examine-bionic-arm-message = {CAPITALIZE(POSS-ADJ($entity))} arms emit an ever present faint chirp of servomotors.
 examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever present faint chirp of servomotors.
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
+
+examine-scary-mindbreak-message = {CAPITALIZE(POSS-ADJ($entity))} eyes holds promise to the Omega Point.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -588,3 +588,8 @@ trait-name-ThermographicVisionModule = I.P.C Eye Module: Thermographic Scanner
 trait-description-ThermographicVisionModule =
     Your vision has been enhanced with a Thermographic Scanner. When enabled, it captures a snapshot of the user's surroundings, while highlighting all
     biological life forms. It can even detect individuals through the walls of a station.
+
+trait-name-ScaryMindbreak = Child of the Noosphere
+trait-description-ScaryMindbreak =
+    Your personhood is greatly intertwined with the Noosphere.
+    To be mindbroken is to cease to be.

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -441,3 +441,60 @@
     - !type:TraitAddPsionics
       psionicPowers:
         - PsychognomyPower
+
+// disable this trait if you also have the ccvar for scary mindbreaking on. it just become free points lol
+- type: trait
+  id: ScaryMindbreak
+  category: Mental
+  points: 6
+  requirements:
+  - !type:CharacterLogicOrRequirement
+    requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+      - LatentPsychic
+    - !type:CharacterJobRequirement
+      jobs:
+      - Chaplain
+      - Librarian
+      - ResearchDirector
+      - ForensicMantis
+  - !type:CharacterLogicOrRequirement
+    requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+      - IPC
+    - !type:CharacterTraitRequirement
+      traits:
+      - AnomalousPositronics
+  functions:
+  - !type:TraitAddTag
+    tags:
+    - TraitScaryMindbreaking
+// this doesn't work at all and really should be like a CharacterPsionicRequirement instead of this ungodly mess
+  descriptionExtensions:
+  - description: examine-scary-mindbreak-message
+    fontSize: 12
+    requireDetailRange: true
+    requirements:
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterTraitRequirement
+        traits:
+        - LatentPsychic
+      - !type:CharacterJobRequirement
+        jobs:
+        - Chaplain
+        - Librarian
+        - ResearchDirector
+        - ForensicMantis
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterSpeciesRequirement
+        inverted: true
+        species:
+        - IPC
+      - !type:CharacterTraitRequirement
+        traits:
+        - AnomalousPositronics

--- a/Resources/Prototypes/_EE/Tags/tags.yml
+++ b/Resources/Prototypes/_EE/Tags/tags.yml
@@ -12,3 +12,6 @@
 
 - type: Tag
   id: DockSANDropship
+
+- type: Tag
+  id: TraitScaryMindbreaking


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Adds the "Scarier Mindbreaking" which already existed as a CCvar, as an optional trait. You're effectively round removed if you get mindbroken as a latent with this trait. 




# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add:  Child of the Noosphere", a psionic trait that increases the effect of mindbreaking to an extreme, has been added.
