### PR TITLE
Shadeskip Changes

### DIFF
--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -243,17 +243,17 @@
               - settings:
                   spawnOnPulse: true
                   spawnOnSuperCritical: true
-                  minAmount: 5
-                  maxAmount: 8
-                  maxRange: 1.5
+                  minAmount: 18
+                  maxAmount: 28
+                  maxRange: 2.5
                 spawns:
-                - ShadowKudzuWeak
+                - ShadowKudzuTemp
               - settings:
                   spawnOnPulse: true
                   spawnOnSuperCritical: true
                   minAmount: 1
                   maxAmount: 1
-                  maxRange: 0.5
+                  maxRange: 2
                 spawns:
                 - EffectFlashShadeskip
 

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -313,3 +313,11 @@
         - ShadowBasaltRandom
     - type: TimedDespawn
       lifetime: 30
+
+- type: entity
+  name: Temporary haze
+  id: ShadowKudzuTemp
+  parent: ShadowKudzuWeak
+  components:
+    - type: TimedDespawn
+      lifetime: 30


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description


Changes Shadeskip fog to only last 30 seconds, and increases its area of effect to 2.5 tiles.still occasionally spawns Trees, Crystals and Portals (the only thing that needs flashes for removal now).

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Make shadeskip fog Temporary
- [x] Increase shadeskip area
---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->
Single use of Shadeskip with new area centered on Aghost Andy
![image](https://github.com/user-attachments/assets/e02dac84-1c5c-4c77-81d9-f3866ca1c918)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:

- tweak: Shadeskip fog now lasts 30 seconds, and has an increased area of effect.
