### PR TITLE
Mindswap Removal.

### DIFF
--- a/Resources/Prototypes/Psionics/PsionicPowerPool.yml
+++ b/Resources/Prototypes/Psionics/PsionicPowerPool.yml
@@ -7,7 +7,7 @@
     PsionicRegenerationPower: 1
     MassSleepPower: 0.3
 #    PsionicInvisibilityPower: 0.15
-    MindSwapPower: 0.15
+#    MindSwapPower: 0.15
     TelepathyPower: 1
     HealingWordPower: 0.85
     ShadeskipPower: 0.15

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -57,35 +57,35 @@
     - !type:RemoveAssayFeedback
       assayFeedback: mass-sleep-power-metapsionic-feedback
 
-- type: psionicPower
-  id: MindSwapPower
-  name: Mind Swap
-  powerCategories:
-    - Mentalic
-  initializeFunctions:
-    - !type:AddPsionicActions
-      actions:
-        - ActionMindSwap
-    - !type:AddPsionicPowerComponents
-      components:
-        - type: MindSwapPower
-    - !type:PsionicFeedbackPopup
-    - !type:PsionicFeedbackSelfChat
-      feedbackMessage: mind-swap-power-initialization-feedback
-    - !type:PsionicModifyGlimmer
-      glimmerModifier: 4
-    - !type:AddPsionicAssayFeedback
-      assayFeedback: mind-swap-power-metapsionic-feedback
-    - !type:AddPsionicStatSources
-      amplificationModifier: 1
-  removalFunctions:
-    - !type:RemovePsionicActions
-    - !type:RemovePsionicPowerComponents
-      components:
-        - type: MindSwapPower
-    - !type:RemovePsionicStatSources
-    - !type:RemoveAssayFeedback
-      assayFeedback: mind-swap-power-metapsionic-feedback
+# - type: psionicPower
+  # id: MindSwapPower
+  # name: Mind Swap
+  # powerCategories:
+  #  - Mentalic
+  # initializeFunctions:
+   # - !type:AddPsionicActions
+   #   actions:
+   #     - ActionMindSwap
+   # - !type:AddPsionicPowerComponents
+   #   components:
+   #     - type: MindSwapPower
+   # - !type:PsionicFeedbackPopup
+   # - !type:PsionicFeedbackSelfChat
+   #   feedbackMessage: mind-swap-power-initialization-feedback
+   # - !type:PsionicModifyGlimmer
+   #   glimmerModifier: 4
+   # - !type:AddPsionicAssayFeedback
+   #   assayFeedback: mind-swap-power-metapsionic-feedback
+   # - !type:AddPsionicStatSources
+   #   amplificationModifier: 1
+  # removalFunctions:
+  #  - !type:RemovePsionicActions
+  #  - !type:RemovePsionicPowerComponents
+  #    components:
+  #      - type: MindSwapPower
+  #  - !type:RemovePsionicStatSources
+  #  - !type:RemoveAssayFeedback
+  #    assayFeedback: mind-swap-power-metapsionic-feedback
 
 - type: psionicPower
   id: NoosphericZapPower


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Right now mindswap is mostly used by shitters to do the most low effort shit like /suicide or disarm you completely, and you can't do anything for 20 seconds, if you get mindswapped by a shitter as cap, say goodbye to most of your equipment if there is no sec near you to aid.

During Nukies if they try RP Ops that requires them to be disguised as CC etc, shitters can just mindswap and ruin the whole thing, people only use mindswap to be incredibly annoying or soft RR someone and force them to be someone else.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Diggy
- remove: Removed Mindswap because people for the most part use it to either validhunt or self antag.
