### PR TITLE
Prisoner QOL 1: Sustenance Vendor Tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -5,8 +5,14 @@
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
+    FoodCondimentPacketPepper: 5
+    FoodCondimentPacketSalt: 5
     ReagentTinPowderedMilkSoy: 2
     ReagentTinPowderedJuiceOrange: 1
+    FoodBowlBig: 3
+    ForkPlastic: 3
+    SpoonPlastic: 3
+    KnifePlastic: 3
   emaggedInventory:
     KitchenKnife: 2
     SpaceMedipen: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -10,6 +10,7 @@
     ReagentTinPowderedMilkSoy: 2
     ReagentTinPowderedJuiceOrange: 1
     FoodBowlBig: 3
+    FoodPlateTin: 1
     ForkPlastic: 3
     SpoonPlastic: 3
     KnifePlastic: 3


### PR DESCRIPTION
# Description

Adds bowls, a pie tin, salt and pepper packets, and plastic utensils to the perma sustenance vendor. This will let prisoners make more kinds of food by themselves as well as not have to use shivs to cut food.

---

# Changelog

:cl:
- add: Added bowls, a pie tin, salt and pepper packets, and plastic utensils to the perma sustenance vendor.
