### PR TITLE
Add the BSO CQC Manual to Their Loadout and Make the Crew Monitor Cheaper.

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -87,7 +87,7 @@
 - type: loadout
   id: LoadoutBSORifleBRDIR25
   category: JobsCommandBlueshieldOfficer
-  cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy a crew monitor with it.
+    cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, alongside being unable to buy both it and the CQC manual.
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:
@@ -143,13 +143,24 @@
 - type: loadout
   id: LoadoutBSOCrewMonitor
   category: JobsCommandBlueshieldOfficer
-  cost: 6
+  cost: 2 # BSO's main job is to keep command safe, they should be able to monitor their status & location without that costing too many points.
   requirements:
     - !type:CharacterJobRequirement
       jobs:
         - BlueshieldOfficer
   items:
     - HandheldCrewMonitor
+
+- type: loadout
+  id: LoadoutBSOCQCManual
+  category: JobsCommandBlueshieldOfficer
+  cost: 8 # You can run this alongside the 3 medical items, but then you will be restricted to free gear for everything else such as weapons or other utilities.
+  requirements: # Knowledge does not occupy a weapon slot. You are a trained bodyguard, so it makes sense to have it. Balanced out by costing over half of your loadout points.
+    - !type:CharacterJobRequirement
+      jobs:
+        - BlueshieldOfficer
+  items:
+    - BSOManual
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -87,7 +87,7 @@
 - type: loadout
   id: LoadoutBSORifleBRDIR25
   category: JobsCommandBlueshieldOfficer
-    cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, alongside being unable to buy both it and the CQC manual.
+  cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, plus being unable to buy it alongside the CQC Manual.
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:


### PR DESCRIPTION
# Description

This PR makes the following changes:
- Reduce the cost of the Handheld Crew Monitor in the BSO's Loadout from 6 to 2.
- Add the BSO CQC Manual, which was previously unobtainable, to the BSO's loadout at a cost of 8, it currently does not occupy a weapon category.


The monitor I believe has always been overpriced. Your main job as a BSO is to keep command safe, so it should not be this expensive to be able to easily check on their status and location if they do not forget to turn on their suit sensors, and there is plenty of counterplay to it via emps, jammers, or sabotaging the crew monitoring server or its power supply. I am doing this in the same PR as the manual because the price change is also relevant to that. And yes, I know this means you can get a crewmon + BRDI now, but you still can't get BRDI + all 3 medical items.

As for the CQC Manual, its meant for the BSO, so it was always going to be added, though I will still briefly justify it anyway, but the main question is why make it cost 8, and why make it not occupy a weapon slot, so I will be explaining that here.
You are a highly trained and specialized bodyguard, with CC level equipment and training. As a bodyguard, you should be able to keep command and yourself safe, so if somebody runs at you or a command member you are next to with a weapon, It seems pretty realistic that as a bodyguard you'd be trained to throw them to the ground and put your body in-between the threat and the command member you are sworn to protect, even if that comes at the expense of your own personal safety.

Now as for the price and lack of category restriction. Again, you are a bodyguard, so knowledge and training on fighting in close quarters to keep somebody safe should be standard, and not something you have to sacrifice a weapon for, furthermore I do not see the BSO sacrificing their primary for this, as the eshield (soon to be greatshield), energy shotgun (goob only), or even just the chester, are very solid options (Yes, I know the BRDI is also very good, but due to its heavy price, it is never going to be compatible with the CQC manual, even if it does not occupy your primary weapon slot.), and if you have to choose, you are better off choosing one of those and grabbing a judo belt from a security locker, which while judo is not AS good, its still pretty damn solid, but that would defeat the entire purpose of HAVING the BSO have their own custom CQC training manual.
The cost of 8 is primarily because of the fact that martial arts are admittedly pretty strong, especially if you know how to use them properly. And if you get them at no extra cost, that would be a balancing concern, so there needs to be some downside to having it without sacrificing your ability to still have conventional weapons to do your job with. The exact number 8 also has a reason, as you can get the CQC Manual ALONGSIDE your defib, combat kit, and crew monitor (This is a primary reason on why I cut its price, but even if you ignore this, I still believe the crew monitor to be HEAVILY overpriced currently), but will then not have any points left over for utility items or paid weapons. This is in my opinion very crucial, as if we force people to choose between being able to kick ass with martial arts, or having the proper equipment to provide medical aid to command, which is a key part of your job, people will still end up picking the ability to kick ass, and I worry that this will cause the BSO to be pushed further into being played by some people as just an elite security officer, which it is not. You should be able to have the neccesary equipment to render aid to command while also being able to defend them from threats in close quarters if that is where you choose to spend the remainder of your loadout points. It also makes sense from an RP standpoint that these highly specialized elite NT Close Quarters Combat training sessions would come with a hefty price-tag, even for Blueshield Officers.

---

# Changelog

:cl: BramvanZijp
- add: Added the previously unobtainable BSO CQC Manual to the BSO's loadout at a cost of 8 points.
- tweak: The BSO's Crew Monitor loadout price has been reduced from 6 points to 2.
