### PR TITLE
Small Atmos Fixes

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -125,11 +125,13 @@ namespace Content.Shared.Maps
             TileId = id;
         }
 
+        /// <summary>
+        ///     For optionally handling per-tile behavior of airflow simulation. Which is useful for ZAS-like air sim, and for MAS.
+        ///     Intentionally public because I want entities to be able to mess with this, such as ship shielding that prevents air from flowing across a shielded tile.
+        ///     For planet maps, you can instead mark the GridAtmosphere as !Simulated. Which will make the entire atmos system not run on a given grid.
+        /// </summary>
         [DataField]
-        public bool Reinforced = false;
-
-        [DataField]
-        public float TileRipResistance = 125f;
+        public bool SimulatedTurf = true;
     }
 
     [Flags]

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -131,6 +131,9 @@ namespace Content.Shared.Maps
         ///     For planet maps, you can instead mark the GridAtmosphere as !Simulated. Which will make the entire atmos system not run on a given grid.
         /// </summary>
         [DataField]
+        public bool Reinforced;
+
+        [DataField]
         public bool SimulatedTurf = true;
     }
 

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -92,7 +92,7 @@ public abstract partial class SharedEntityStorageComponent : Component
     /// Whether or not the container is sealed and traps air inside of it
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool Airtight = true;
+    public bool Airtight;
 
     /// <summary>
     /// Whether or not the entitystorage is open or closed


### PR DESCRIPTION
# Description

This fixes a few issues with SWV5, albeit what I can fix for now until I have completed work on the Matrix Airflow System.

# Changelog

:cl:
- fix: Fixed some bugs with Space Wind related to lockers causing massive air flow spikes,
- fix: Fixed space wind not being calculated correctly for stations which get gravity from their planet, such as Glacier.
- fix: Fixed an issue where Space Wind wasn't respecting the cosmic speed limit of 30 meters per second.
