### PR TITLE
Butcherable Laser Raptor

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -35,6 +35,10 @@
           Base: laser_raptor
         Dead:
           Base: laser_raptor_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 2
     - type: MobThresholds
       thresholds:
         0: Alive


### PR DESCRIPTION
# Description
Allows Laser Raptors to be Butchered from the Menu, QoL for Logistics so they can get Laser Eyes faster.

I filled the indents this time 100%

# Changelog

:cl:
- add: Butchering to Laser Raptors