### PR TITLE
Salvage Wreck Loot Buff + a Little Extra

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -28,7 +28,7 @@
     - id: ToolboxEmergencyFilled
       prob: 0.5
     - id: MedkitOxygenFilled
-      prob: 0.2
+      prob: 0.3
     - id: WeaponFlareGun
       prob: 0.05
     - id: BoxMRE
@@ -203,3 +203,4 @@
           id: GeigerCounter
           amount: !type:ConstantNumberSelector
             value: 2
+        - id: MedkitRadiationFilled

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -116,7 +116,7 @@
       tableId: TreasureCoinPile
       rolls: !type:RangeNumberSelector
         range: 4, 7
-    - id: SpaceCash1000
+    - id: SpaceCash5000
 
 - type: entityTable
   id: SalvageTreasureRare
@@ -139,13 +139,13 @@
         rolls: !type:RangeNumberSelector
           range: 3, 5
         children:
-        - id: SpaceCash1000
-          weight: 60
-        - id: SpaceCash2500
-          weight: 25
-        - id: SpaceCash5000
-          weight: 14
         - id: SpaceCash10000
+          weight: 60
+        - id: SpaceCash20000
+          weight: 25
+        - id: SpaceCash30000
+          weight: 14
+        - id: SpaceCash50000
           weight: 1
 
 - type: entityTable
@@ -160,6 +160,7 @@
     - id: TreasureCoinDiamond
       amount: !type:RangeNumberSelector
         range: 2, 5
+    - id: SpaceCash100000
 
 # Equipment: Tools and things used by salvagers. Quote unquote "Gamer Loot"
 

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -87,7 +87,7 @@
     - id: SheetPlasma1
       amount: !type:RangeNumberSelector
         range: 3, 5
-    - id: ResearchDisk
+    - id: ResearchDisk5000
     - id: DrinkGoldenCup
     - id: TreasureSampleTube
     - !type:NestedSelector
@@ -105,6 +105,7 @@
     - id: IngotGold1
       amount: !type:RangeNumberSelector
         range: 3, 5
+    - id: ResearchDisk10000
     - id: TreasureDatadiskEncrypted
     - !type:GroupSelector
       children:
@@ -125,7 +126,7 @@
     - id: TreasureCPUSupercharged
     - id: TechnologyDiskRare
       weight: 0.5
-    - id: ResearchDisk10000
+    - id: ResearchDisk20000
       weight: 0.5
     - !type:NestedSelector
       tableId: TreasureCoinPileRare
@@ -153,6 +154,7 @@
     children:
     - id: ClothingMaskGoldenCursed
     - id: ClothingHeadHatFancyCrown
+    - id: ResearchDisk50000
     - id: GoldenBikeHorn
     - id: ClothingHeadHatCatEars
     - id: TreasureCoinDiamond

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -169,6 +169,28 @@
 
 - type: entity
   parent: SpaceCash
+  id: SpaceCash50000
+  suffix: 50000
+  components:
+  - type: Icon
+    sprite: _NF/Objects/Economy/cash.rsi # Frontier: use Frontier sprite set
+    state: cash_50000 # Frontier: cash_1000<cash_50000
+  - type: Stack
+    count: 50000
+
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash100000
+  suffix: 100000
+  components:
+  - type: Icon
+    sprite: _NF/Objects/Economy/cash.rsi # Frontier: use Frontier sprite set
+    state: cash_100000 # Frontier: cash_1000<cash_100000
+  - type: Stack
+    count: 100000
+
+- type: entity
+  parent: SpaceCash
   id: SpaceCash1000000
   suffix: 1000000
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -47,6 +47,15 @@
 
 - type: entity
   parent: ResearchDisk
+  id: ResearchDisk50000
+  name: research point disk (50000)
+  description: A disk for the R&D server containing 50000 points.
+  components:
+  - type: ResearchDisk
+    points: 50000
+
+- type: entity
+  parent: ResearchDisk
   id: ResearchDiskDebug
   name: research point disk
   suffix: DEBUG, DO NOT MAP

--- a/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/oracle.yml
@@ -76,8 +76,9 @@
   id: OracleRewardDisks
   weights:
     ResearchDisk5000: 20
-    ResearchDisk10000: 5
-    ResearchDisk20000: 1
+    ResearchDisk10000: 10
+    ResearchDisk20000: 3
+    ResearchDisk50000: 1
 
 - type: weightedRandomEntity
   id: OracleRewardCrystals

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -81,20 +81,20 @@
         - proto: ResearchAndDevelopmentServerMachineCircuitboard
           cost: 5
           prob: 0.5
-        - proto: ResearchDisk10000
+        - proto: ResearchDisk20000
           prob: 0.5
-        - proto: ResearchDisk5000
+        - proto: ResearchDisk10000
           prob: 0.5
         - proto: RipleyHarness
           cost: 3
           prob: 0.5
         - proto: RPED
-        - proto: SpaceCash1000
-        - proto: SpaceCash10000
-          cost: 10
         - proto: SpaceCash2500
-          cost: 3
+        - proto: SpaceCash20000
+          cost: 10
         - proto: SpaceCash5000
+          cost: 3
+        - proto: SpaceCash10000
           cost: 5
         - proto: TechnologyDiskRare
           cost: 5


### PR DESCRIPTION
# Description

Buffs to Salvage Loot
Minor Buff to Oracle loot
Added Radiation Medkits to Radiation Lockers

Why? 

Well Salvage doesn't really make any real money and the station suffers if there's no cargo techs. And I hate receiving a single 1000 research disk from salvage like it's worth something. 

Oracle buffed (not really shit should be rare af) because at the point where you're doing multiple Tier 3s the cost get real silly high.

Radiation Lockers should always have had Rad Medkits.

# Changelog

:cl:
- add: Higher amount variants of Research Disk and Spesos
- add: Increased the amount of Research and Spesos Salvage can randomly find
- add: Added 20000 Disk to Oracle's Loot Table (Super Rare)
- add: Added Radiation Medkits to Radiation Lockers
