### PR TITLE
Power Cell Draw Fixes

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -28,7 +28,8 @@ public sealed partial class PowerCellSystem
             if (!TryGetBatteryFromSlot(uid, out var batteryEnt, out var battery, slot))
                 continue;
 
-            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
+            // TCJ: "Multiplying by frameTime to make this tick-invariant. Otherwise it'll draw 30x to 60x faster than you expect."
+            if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate * frameTime, battery))
                 continue;
 
             var ev = new PowerCellSlotEmptyEvent();

--- a/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
@@ -87,6 +87,8 @@
           Heat: 0.50
           Radiation: 0.50
           Caustic: 0.50
+    - type: TemperatureProtection
+      coefficient: 0.01
     - type: StaminaDamageResistance
       coefficient: 0.5
     - type: EmitsSoundOnMove

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/modsuit.yml
@@ -43,7 +43,7 @@
     requiredSlot: back
     blockUnequipWhenAttached: true
     replaceCurrentClothing: true
-    clothingPrototypes: 
+    clothingPrototypes:
       head: ClothingModsuitHelmetStandard
       gloves: ClothingModsuitGauntletsStandard
       outerClothing: ClothingModsuitChestplateStandard
@@ -61,7 +61,6 @@
       cell_slot: true
   - type: PowerCellDraw
     drawRate: 1 # Sealed draw rate
-    useRate: 5 # Draw rate for sealing
   - type: PowerCellSlot
     cellSlotId: cell_slot
     fitsInCharger: false


### PR DESCRIPTION
# Description

Power cell draw wasn't tick invariant, so batteries on this codebase were being drained anywhere from 30 to 60x faster than people expect, depending on server performance. This was notably something that severely effected MODSuits, which can now enjoy a battery lifespan of around 30 minutes. But it's also a big deal for IPCs.

Closes https://github.com/Simple-Station/Einstein-Engines/issues/1956

# Changelog

:cl:
- fix: Batteries no longer drain power 30 to 60 times faster than physics states. This is particularly a large buff to IPCs and MODSuits, who both no longer have to deal with batteries lasting an absurdly short amount of time. 
- tweak: Solarian Modsuit now provides protection from cold.
