### PR TITLE
Salvage Vendor Improvements

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -53,6 +53,8 @@
     cost: 500
   - id: FoodBoxDonkpocketPizza
     cost: 500
+  - id: DrinkCanPack
+    cost: 600
   - id: LavalandJaunter
     cost: 750
   - id: WeaponCrusher

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -10,6 +10,12 @@
     cost: 150
   - id: Soap
     cost: 200
+  - id: BoxMRE
+    cost: 500
+  - id: CardBoxBlack
+    cost: 200
+  - id: DrinkBeerBottleFull
+    cost: 100
   - id: PKAUpgradeLight
     cost: 500
   - id: SeismicCharge
@@ -29,14 +35,30 @@
     cost: 500
   - id: ClothingShoesBootsJack
     cost: 550
+  - id: MedkitFilled
+    cost: 400
   - id: MedkitBruteFilled
     cost: 600
   - id: MedkitBurnFilled
     cost: 600
+  - id: MedkitAdvancedFilled
+    cost: 1500
+  - id: FoodBoxPizzaFilled
+    cost: 300
+  - id: MicrowaveMachineCircuitboard
+    cost: 500
+  - id: FoodBoxDonkpocketBerry
+    cost: 500
+  - id: FoodBoxDonkpocketHonk
+    cost: 500
+  - id: FoodBoxDonkpocketPizza
+    cost: 500
   - id: LavalandJaunter
     cost: 750
   - id: WeaponCrusher
     cost: 750
+  - id: WeaponCrusherGlaive
+    cost: 2400
   - id: WeaponProtoKineticAccelerator
     cost: 750
   - id: SurvivalMedipen
@@ -78,10 +100,12 @@
     cost: 6400
   - id: WeaponRifleSVTEmpty
     cost: 6400
+  - id: OreBagOfHolding
+    cost: 6600
  # - id: WeaponPlasmaCutter -- TODO: Port from goob
  #   cost: 1700
   - id: SpaceCash1000
-    cost: 2000
+    cost: 1000
   - id: ShelterCapsule
     cost: 2000
   # TODO: super resonator for 2500


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# You can now buy food and build your own microwave with this PR

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Salvage specialist felt a bit too tiring for me, felt like I just kept working and working without reason, so I decided to improve it, now salv can buy their own food, with their own microwave that they can build, along with buying a ore bag of holding for 6k points.

We offer no refunds if the microwave blows up.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Diggy
- add: Salvage can now buy food, medkits, advanced medkits, a ore bag of holding for 6k and the most important part, you can now build a microwave.
