### PR TITLE
The Shotgun Update Part 2

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -28,6 +28,7 @@ research-technology-draconic-munitions = Draconic Munitions
 research-technology-uranium-munitions = Uranium Munitions
 research-technology-explosive-technology = Explosive Technology
 research-technology-practice-ammunition = Practice Ammunition
+research-technology-shrapnel-munitions = Shrapnel Munitions
 research-technology-advanced-weapons = Advanced Weapons
 research-technology-prototype-weapons = Prototype Weapons
 research-technology-advanced-tacsuits = Advanced Tacsuits

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -91,6 +91,9 @@ uplink-pistol-magazine-rubber-desc = Pistol magazine with 10 cartridges. For whe
 uplink-pistol-magazine-incendiary-name = Pistol Magazine (.35 auto, incendiary)
 uplink-pistol-magazine-incendiary-desc = A premium magazine for putting burning holes in both your wallet, and your victims.
 
+uplink-pistol-magazine-shrapnel-name = Pistol Magazine (.35 auto, shrapnel)
+uplink-pistol-magazine-shrapnel-desc = A premium magazine for firing clouds of bullets at the crew.
+
 uplink-pistol-magazine-c20r-name = SMG magazine (.35 auto)
 uplink-pistol-magazine-c20r-desc = Rifle magazine with 30 catridges. Compatible with C-20r.
 
@@ -100,17 +103,32 @@ uplink-pistol-magazine-c20r-rubber-desc = Rifle magazine with 30 catridges. For 
 uplink-pistol-magazine-c20r-incendiary-name = SMG magazine (.35 auto, incendiary)
 uplink-pistol-magazine-c20r-incendiary-desc = WAKE THE FUCK UP SAMURAI, WE GOT A STATION TO BURN!
 
+uplink-pistol-magazine-c20r-shrapnel-name = SMG magazine (.35 auto, shrapnel)
+uplink-pistol-magazine-c20r-shrapnel-desc = A premium magazine with 30 cartridges for firing clouds of bullets at the crew.
+
 uplink-pistol-magazine-caseless-name = Pistol Magazine (.25 caseless)
 uplink-pistol-magazine-caseless-desc = Pistol magazine with 10 catridges. Compatible with the Cobra.
 
 uplink-pistol-magazine-caseless-rubber-name = Pistol Magazine (.25 caseless, rubber)
 uplink-pistol-magazine-caseless-rubber-desc = Pistol magazine with 10 catridges. For when you need to (quietly) take someone alive.
 
+uplink-pistol-magazine-caseless-incendiary-name = Pistol Magazine (.25 caseless, incendiary)
+uplink-pistol-magazine-caseless-incendiary-desc = A premium magazine with 10 catridges, for (quietly) burning holes in your wallet and your victims.
+
+uplink-pistol-magazine-caseless-shrapnel-name = Pistol Magazine (.25 caseless, shrapnel)
+uplink-pistol-magazine-caseless-shrapnel-desc = A premium magazine with 10 catridges, for (quietly) firing clouds of lead at the crew.
+
 uplink-magazine-caseless-name = SMG magazine (.25 caseless)
 uplink-magazine-caseless-desc = Rifle magazine with 30 cartridges. Compatible with the FPA-90.
 
 uplink-magazine-caseless-rubber-name = SMG magazine (.25 caseless, rubber)
 uplink-magazine-caseless-rubber-desc = Rifle magazine with 30 cartridges. For when you need to (quietly) take many hostages.
+
+uplink-magazine-caseless-incendiary-name = SMG magazine (.25 caseless, incendiary)
+uplink-magazine-caseless-incendiary-desc = A premium magazine with 30 cartridges for burning holes in both your wallet, and your victims.
+
+uplink-magazine-caseless-shrapnel-name = SMG magazine (.25 caseless, shrapnel)
+uplink-magazine-caseless-shrapnel-desc = A premium magazine with 30 cartridges for (quietly) firing clouds of lead at the crew.
 
 uplink-speedloader-magnum-name = Speedloader (.45 magnum AP)
 uplink-speedloader-magnu-desc = Revolver speedloader with 6 armor-piercing catridges, capable of ignoring armor entirely. Compatible with the Python.
@@ -120,6 +138,9 @@ uplink-mosin-ammo-desc = A box of 50 cartridges for the surplus rifle.
 
 uplink-sniper-ammo-name = Ammunition box (.60 antimateriel)
 uplink-sniper-ammo-desc = A box of 10 cartridges for the Hristov sniper rifle.
+
+uplink-sniper-ammo-shrapnel-name = Ammunition box (.60 antipersonnel shrapnel)
+uplink-sniper-ammo-shrapnel-desc = A box of 10 anti-personnel cannister shots for the Hristov sniper rifle.
 
 # Utility
 uplink-holopara-kit-name = Holoparasite Kit
@@ -241,11 +262,21 @@ uplink-meds-bundle-desc = An assortment of autoinjectors and premium medical equ
 uplink-ammo-bundle-name = Ammo Bundle
 uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW.
 
+uplink-ammo-bundle-rubber-name = Ammo Bundle (Rubber)
+uplink-ammo-bundle-rubber-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW.
+
+uplink-ammo-bundle-incendiary-name = Ammo Bundle (Incendiary)
+uplink-ammo-bundle-incendiary-desc = WAKE THE FUCK UP SAMURAI, WE HAVE A STATION TO BURN!
+
+uplink-ammo-bundle-shrapnel-name = Ammo Bundle (Shrapnel)
+uplink-ammo-bundle-shrapnel-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW.
+
+
 uplink-sniper-bundle-name = Sniper Bundle
 uplink-sniper-bundle-desc = An inconspicuous briefcase that contains a Hristov, 10 spare bullets and a convenient disguise.
 
 uplink-c20r-bundle-name = C-20r Bundle
-uplink-c20r-bundle-desc = Old faithful: The classic C-20r Submachine Gun, bundled with three magazines.
+uplink-c20r-bundle-desc = Old faithful: The classic C-20r Submachine Gun, ammo comes separately.
 
 uplink-buldog-bundle-name = Bulldog Bundle
 uplink-buldog-bundle-desc = Lean and mean: Contains the popular Bulldog Shotgun, a 12g beanbag drum and three 12g buckshot drums.
@@ -266,7 +297,7 @@ uplink-super-surplus-bundle-name = Super Surplus Crate
 uplink-super-surplus-bundle-desc = Contains 125 telecrystals worth of completely random Syndicate items.
 
 uplink-fpa-90-bundle-name = FPA-90 Bundle
-uplink-fpa-90-bundle-desc = A cheap integrally suppressed SMG. Comes bundled with three .25 caseless magazines.
+uplink-fpa-90-bundle-desc = A cheap integrally suppressed SMG. Ammo comes separately.
 
 # Tools
 uplink-toolbox-name = Toolbox

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -154,24 +154,24 @@
     contents:
       - id: MagazinePistolSubMachineGunRubber
         amount: 4
-      - id: MagazineShotgunRubber
+      - id: MagazineShotgunBeanbag
         amount: 4
       - id: MagazineLightRifleBoxRubber
         amount: 2
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateAmmo
-  id: ClothingBackpackDuffelSyndicateAmmoFilledUranium
+  id: ClothingBackpackDuffelSyndicateAmmoFilledIncendiary
   name: ammo bundle
   description: "Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
   components:
   - type: StorageFill
     contents:
-      - id: MagazinePistolSubMachineGunUranium
+      - id: MagazinePistolSubMachineGunIncendiary
         amount: 4
-      - id: MagazineShotgunUranium
+      - id: MagazineShotgunIncendiary
         amount: 4
-      - id: MagazineLightRifleBoxUranium
+      - id: MagazineLightRifleBoxIncendiary
         amount: 2
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -71,9 +71,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: WeaponSubMachineGunC20r
-      - id: MagazinePistolSubMachineGun
-        amount: 2
+      - id: WeaponSubMachineGunC20rEmpty
 #     - id: SMGSuppressor
 
 - type: entity
@@ -144,6 +142,51 @@
       - id: MagazineShotgun
         amount: 4
       - id: MagazineLightRifleBox
+        amount: 2
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateAmmo
+  id: ClothingBackpackDuffelSyndicateAmmoFilledRubber
+  name: ammo bundle
+  description: "Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
+  components:
+  - type: StorageFill
+    contents:
+      - id: MagazinePistolSubMachineGunRubber
+        amount: 4
+      - id: MagazineShotgunRubber
+        amount: 4
+      - id: MagazineLightRifleBoxRubber
+        amount: 2
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateAmmo
+  id: ClothingBackpackDuffelSyndicateAmmoFilledUranium
+  name: ammo bundle
+  description: "Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
+  components:
+  - type: StorageFill
+    contents:
+      - id: MagazinePistolSubMachineGunUranium
+        amount: 4
+      - id: MagazineShotgunUranium
+        amount: 4
+      - id: MagazineLightRifleBoxUranium
+        amount: 2
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateAmmo
+  id: ClothingBackpackDuffelSyndicateAmmoFilledShrapnel
+  name: ammo bundle
+  description: "Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
+  components:
+  - type: StorageFill
+    contents:
+      - id: MagazinePistolSubMachineGunShrapnel
+        amount: 4
+      - id: MagazineShotgunBirdshot
+        amount: 4
+      - id: MagazineLightRifleBoxShrapnel
         amount: 2
 
 - type: entity
@@ -438,6 +481,4 @@
   components:
   - type: StorageFill
     contents:
-      - id: WeaponSubMachineGunFPA90
-      - id: MagazineCaselessRifle
-        amount: 2
+      - id: WeaponSubMachineGunFPA90Empty

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -5,12 +5,12 @@
   id: UplinkPistolViper
   name: uplink-pistol-viper-name
   description: uplink-pistol-viper-desc
-  productEntity: WeaponPistolViper
+  productEntity: WeaponPistolViperEmpty
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 5
   cost:
-    Telecrystal: 15
+    Telecrystal: 10
   categories:
   - UplinkWeaponry
 
@@ -32,12 +32,12 @@
   id: UplinkPistolCobra
   name: uplink-pistol-cobra-name
   description: uplink-pistol-cobra-desc
-  productEntity: WeaponPistolCobra
+  productEntity: WeaponPistolCobraEmpty
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 5
   cost:
-    Telecrystal: 20
+    Telecrystal: 15
   categories:
   - UplinkWeaponry
 
@@ -167,9 +167,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledSMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 50
+    Telecrystal: 20
   cost:
-    Telecrystal: 85
+    Telecrystal: 55
   categories:
   - UplinkWeaponry
 
@@ -223,9 +223,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledFPA90
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 40
+    Telecrystal: 10
   cost:
-    Telecrystal: 80
+    Telecrystal: 50
   categories:
   - UplinkWeaponry
 
@@ -510,6 +510,17 @@
   categories:
   - UplinkAmmo
 
+- type: listing
+  id: UplinkPistol9mmMagazineShrapnel
+  name: uplink-pistol-magazine-shrapnel-name
+  description: uplink-pistol-magazine-shrapnel-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: practice }
+  productEntity: MagazinePistolShrapnel
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkAmmo
+
 # For the C20R
 - type: listing
   id: UplinkMagazinePistolSubMachineGun
@@ -544,6 +555,17 @@
   categories:
   - UplinkAmmo
 
+- type: listing
+  id: UplinkMagazinePistolSubMachineGunShrapnel
+  name: uplink-pistol-magazine-c20r-shrapnel-name
+  description: uplink-pistol-magazine-c20r-shrapnel-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: practice }
+  productEntity: MagazinePistolSubMachineGunShrapnel
+  cost:
+    Telecrystal: 12
+  categories:
+  - UplinkAmmo
+
 # .25 Caseless Rifle, for the Cobra and FPA-90
 - type: listing
   id: UplinkMagazinePistolCaselessRifle
@@ -568,6 +590,28 @@
   - UplinkAmmo
 
 - type: listing
+  id: UplinkMagazinePistolCaselessRifleIncendiary
+  name: uplink-pistol-magazine-caseless-incendiary-name
+  description: uplink-pistol-magazine-caseless-incendiary-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolCaselessRifleIncendiary
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazinePistolCaselessRifleShrapnel
+  name: uplink-pistol-magazine-caseless-shrapnel-name
+  description: uplink-pistol-magazine-caseless-shrapnel-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: red-icon }
+  productEntity: MagazinePistolCaselessRifleShrapnel
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkAmmo
+
+- type: listing
   id: UplinkMagazineCaselessRifle
   name: uplink-magazine-caseless-name
   description: uplink-magazine-caseless-desc
@@ -586,6 +630,28 @@
   productEntity: MagazineCaselessRifleRubber
   cost:
     Telecrystal: 10
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazineCaselessRifleIncendiary
+  name: uplink-magazine-caseless-incendiary-name
+  description: uplink-magazine-caseless-incendiary-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_rifle_mag.rsi, state: rubber }
+  productEntity: MagazineCaselessRifleIncendiary
+  cost:
+    Telecrystal: 14
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazineCaselessRifleShrapnel
+  name: uplink-magazine-caseless-shrapnel-name
+  description: uplink-magazine-caseless-shrapnel-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_rifle_mag.rsi, state: rubber }
+  productEntity: MagazineCaselessRifleShrapnel
+  cost:
+    Telecrystal: 12
   categories:
   - UplinkAmmo
 
@@ -624,12 +690,92 @@
   - UplinkAmmo
 
 - type: listing
+  id: UplinkHristovAmmoShrapnel
+  name: uplink-sniper-ammo-shrapnel-name
+  description: uplink-sniper-ammo-shrapnel-desc
+  productEntity: MagazineBoxAntiMaterielShrapnel
+  cost:
+    Telecrystal: 12
+  categories:
+  - UplinkAmmo
+
+- type: listing
   id: UplinkAmmoBundle
   name: uplink-ammo-bundle-name
   description: uplink-ammo-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateAmmoFilled
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 35
   cost:
     Telecrystal: 75
+  categories:
+  - UplinkAmmo
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+          - SurplusBundle
+
+- type: listing
+  id: UplinkAmmoBundleRubber
+  name: uplink-ammo-bundle-rubber-name
+  description: uplink-ammo-bundle-rubber-desc
+  productEntity: ClothingBackpackDuffelSyndicateAmmoFilledRubber
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 35
+  cost:
+    Telecrystal: 75
+  categories:
+  - UplinkAmmo
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+          - SurplusBundle
+
+
+- type: listing
+  id: UplinkAmmoBundleIncendiary
+  name: uplink-ammo-bundle-incendiary-name
+  description: uplink-ammo-bundle-incendiary-desc
+  productEntity: ClothingBackpackDuffelSyndicateAmmoFilledIncendiary
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 50
+  cost:
+    Telecrystal: 95
+  categories:
+  - UplinkAmmo
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+          - SurplusBundle
+
+- type: listing
+  id: UplinkAmmoBundleShrapnel
+  name: uplink-ammo-bundle-shrapnel-name
+  description: uplink-ammo-bundle-shrapnel-desc
+  productEntity: ClothingBackpackDuffelSyndicateAmmoFilledShrapnel
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 50
+  cost:
+    Telecrystal: 85
   categories:
   - UplinkAmmo
   conditions:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
@@ -58,3 +58,11 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  parent: MagazineBoxAntiMateriel
+  id: MagazineBoxAntiMaterielShrapnel
+  name: ammunition box (.60 anti-personnel shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeAntiMaterielShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
@@ -129,3 +129,27 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: rubber
+
+- type: entity
+  parent: MagazineBoxCaselessRifle
+  id: MagazineBoxCaselessRifleIncendiary
+  name: ammunition box (.25 caseless incendiary)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleIncendiary
+
+- type: entity
+  parent: MagazineBoxCaselessRifle
+  id: MagazineBoxCaselessRifleUranium
+  name: ammunition box (.25 caseless uranium)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleUranium
+
+- type: entity
+  parent: MagazineBoxCaselessRifle
+  id: MagazineBoxCaselessRifleShrapnel
+  name: ammunition box (.25 caseless shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
@@ -28,7 +28,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleBig
-  name: ammunition box (.30 rifle)
+  name: bulk ammunition box (.30 rifle)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -44,6 +44,46 @@
     steps: 2
     zeroVisible: false
   - type: Appearance
+
+- type: entity
+  parent: MagazineBoxLightRifleBig
+  id: MagazineBoxLightRifleBigPractice
+  name: bulk ammunition box (.30 rifle practice)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRiflePractice
+
+- type: entity
+  parent: MagazineBoxLightRifleBig
+  id: MagazineBoxLightRifleBigRubber
+  name: bulk ammunition box (.30 rifle rubber)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleRubber
+
+- type: entity
+  parent: MagazineBoxLightRifleBig
+  id: MagazineBoxLightRifleBigIncendiary
+  name: bulk ammunition box (.30 rifle incendiary)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleIncendiary
+
+- type: entity
+  parent: MagazineBoxLightRifleBig
+  id: MagazineBoxLightRifleBigUranium
+  name: bulk ammunition box (.30 rifle uranium)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleUranium
+
+- type: entity
+  parent: MagazineBoxLightRifleBig
+  id: MagazineBoxLightRifleBigShrapnel
+  name: bulk ammunition box (.30 rifle shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleShrapnel
 
 - type: entity
   parent: BaseMagazineBoxLightRifle
@@ -118,3 +158,11 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: uranium
+
+- type: entity
+  parent: MagazineBoxLightRifle
+  id: MagazineBoxLightRifleShrapnel
+  name: ammunition box (.30 rifle shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -112,3 +112,17 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: piercing
+
+- type: entity
+  parent: BaseMagazineBoxMagnum
+  id: MagazineBoxMagnumShrapnel
+  name: ammunition box (.45 magnum shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeMagnumShrapnel
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -98,3 +98,17 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: uranium
+
+- type: entity
+  parent: BaseMagazineBoxPistol
+  id: MagazineBoxPistolShrapnel
+  name: ammunition box (.35 auto shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolShrapnel
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
@@ -138,3 +138,17 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: uranium
+
+- type: entity
+  parent: BaseMagazineBoxRifle
+  id: MagazineBoxRifleShrapnel
+  name: ammunition box (.20 rifle shrapnel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeRifleShrapnel
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -127,3 +127,42 @@
       layers:
         - state: boxwide
         - state: shellslug
+
+- type: entity
+  name: ".50 Birdshot Box"
+  parent: AmmoProviderShotgunShell
+  id: BoxShotgunBirdshot
+  description: A dispenser box full of .50 birdshot. Used for centuries by colonists to hunt small game on alien worlds.
+  components:
+    - type: BallisticAmmoProvider
+      proto: ShellShotgunBirdshot
+    - type: Sprite
+      layers:
+        - state: boxwide
+        - state: shelllethal
+
+- type: entity
+  name: ".50 00-Buckshot Box"
+  parent: AmmoProviderShotgunShell
+  id: BoxShotgun00Buckshot
+  description: A dispenser box full of .50 "Double-Aught" buckshot. Used for centuries by colonists to hunt mid-sized game. The knowledge of what a "Buck" means has been lost to time.
+  components:
+    - type: BallisticAmmoProvider
+      proto: ShellShotgun00Buckshot
+    - type: Sprite
+      layers:
+        - state: boxwide
+        - state: shelllethal
+
+- type: entity
+  name: ".50 0000-Buckshot Box"
+  parent: AmmoProviderShotgunShell
+  id: BoxShotgun0000Buckshot
+  description: A dispenser box full of .50 "Quad-Aught" buckshot. Used for centuries by colonists to hunt alien megafauna. It'll rip through a hardsuit just as easily as thick hides.
+  components:
+    - type: BallisticAmmoProvider
+      proto: ShellShotgun0000Buckshot
+    - type: Sprite
+      layers:
+        - state: boxwide
+        - state: shelllethal

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -18,3 +18,11 @@
   - type: SpentAmmoVisuals
   - type: StaticPrice
     price: 20
+
+- type: entity
+  parent: CartridgeAntiMateriel
+  id: CartridgeAntiMaterielShrapnel
+  name: cartridge (.60 anti-personnel shrapnel)
+  components:
+  - type: CartridgeAmmo
+    proto: BulletAntiMaterielShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -96,3 +96,10 @@
   components:
   - type: CartridgeAmmo
     proto: BulletCaselessRifleShrapnelSpread
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#FF00FF"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -58,3 +58,41 @@
       - state: tip
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#43c4f7"
+
+- type: entity
+  id: CartridgeCaselessRifleIncendiary
+  name: cartridge (.25 caseless incendiary)
+  parent: BaseCartridgeCaselessRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletCaselessRifleIncendiary
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#ff6e52"
+
+- type: entity
+  id: CartridgeCaselessRifleUranium
+  name: cartridge (.25 caseless uranium)
+  parent: BaseCartridgeCaselessRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletCaselessRifleUranium
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#65fe08"
+
+- type: entity
+  id: CartridgeCaselessRifleShrapnel
+  name: cartridge (.25 caseless shrapnel)
+  parent: BaseCartridgeCaselessRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletCaselessRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -85,3 +85,11 @@
       - state: tip
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#65fe08"
+
+- type: entity
+  id: CartridgeLightRifleShrapnel
+  name: cartridge (.30 rifle shrapnel)
+  parent: BaseCartridgeLightRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletLightRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -93,3 +93,10 @@
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifleShrapnelSpread
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#FF00FF"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -101,3 +101,10 @@
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#65fe08"
 
+- type: entity
+  id: CartridgeMagnumShrapnel
+  name: cartridge (.45 magnum shrapnel)
+  parent: BaseCartridgeMagnum
+  components:
+  - type: CartridgeAmmo
+    proto: BulletMagnumShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -108,3 +108,10 @@
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumShrapnelSpread
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#FF00FF"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -85,3 +85,11 @@
       - state: tip
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#65fe08"
+
+- type: entity
+  id: CartridgePistolShrapnel
+  name: cartridge (.35 auto shrapnel)
+  parent: BaseCartridgePistol
+  components:
+  - type: CartridgeAmmo
+    proto: BulletPistolShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -93,3 +93,10 @@
   components:
   - type: CartridgeAmmo
     proto: BulletPistolShrapnelSpread
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#FF00FF"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -86,3 +86,11 @@
       - state: tip
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#65fe08"
+
+- type: entity
+  id: CartridgeRifleShrapnel
+  name: cartridge (.20 rifle shrapnel)
+  parent: BaseCartridgeRifle
+  components:
+  - type: CartridgeAmmo
+    proto: BulletRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -94,3 +94,10 @@
   components:
   - type: CartridgeAmmo
     proto: BulletRifleShrapnelSpread
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#FF00FF"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -138,7 +138,7 @@
     maxTransferAmount: 7
   - type: SpentAmmoVisuals
     state: "practice"
-    
+
 - type: entity
   id: ShellShotgunImprovised
   name: improvised shotgun shell
@@ -175,3 +175,39 @@
       proto: PelletShotgunUraniumSpread
     - type: SpentAmmoVisuals
       state: "depleted-uranium"
+
+- type: entity
+  id: ShellShotgunBirdshot
+  name: shell (.50 birdshot)
+  parent: BaseShellShotgun
+  components:
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: CartridgeAmmo
+    proto: PelletShotgunSpreadBirdshot
+
+- type: entity
+  id: ShellShotgun00Buckshot
+  name: shell (.50 00-Buckshot)
+  parent: BaseShellShotgun
+  components:
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: CartridgeAmmo
+    proto: PelletShotgunSpread00Buckshot
+
+- type: entity
+  id: ShellShotgun0000Buckshot
+  name: shell (.50 0000-Buckshot)
+  parent: BaseShellShotgun
+  components:
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: CartridgeAmmo
+    proto: PelletShotgunSpread0000Buckshot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -99,7 +99,6 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
-    capacity: 10
   - type: Sprite
     slayers:
     - state: red
@@ -119,7 +118,6 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRiflePractice
-    capacity: 10
   - type: Sprite
     layers:
     - state: practice
@@ -139,7 +137,6 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifleRubber
-    capacity: 10
   - type: Sprite
     layers:
     - state: rubber
@@ -151,6 +148,30 @@
     steps: 6
     zeroVisible: false
   - type: Appearance
+
+- type: entity
+  id: MagazinePistolCaselessRifleIncendiary
+  name: "pistol magazine (.25 caseless incendiary)"
+  parent: BaseMagazinePistolCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleIncendiary
+
+- type: entity
+  id: MagazinePistolCaselessRifleUranium
+  name: "pistol magazine (.25 caseless uranium)"
+  parent: BaseMagazinePistolCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleUranium
+
+- type: entity
+  id: MagazinePistolCaselessRifleShrapnel
+  name: "pistol magazine (.25 caseless shrapnel)"
+  parent: BaseMagazinePistolCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleShrapnel
 
 - type: entity
   id: MagazineCaselessRifle
@@ -195,6 +216,30 @@
       map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
+  id: MagazineCaselessRifleIncendiary
+  name: "magazine (.25 caseless incendiary)"
+  parent: MagazineCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleIncendiary
+
+- type: entity
+  id: MagazineCaselessRifleUranium
+  name: "magazine (.25 caseless uranium)"
+  parent: MagazineCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleUranium
+
+- type: entity
+  id: MagazineCaselessRifleShrapnel
+  name: "magazine (.25 caseless shrapnel)"
+  parent: MagazineCaselessRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleShrapnel
+
+- type: entity
   id: MagazineCaselessRifleShort
   name: "short magazine (.25 caseless)"
   parent: BaseMagazineCaselessRifleShort
@@ -216,7 +261,6 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRiflePractice
-    capacity: 20
   - type: Sprite
     layers:
     - state: practice
@@ -231,10 +275,33 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifleRubber
-    capacity: 20
   - type: Sprite
     layers:
     - state: rubber
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazineCaselessRifleShortIncendiary
+  name: "short magazine (.25 caseless incendiary)"
+  parent: BaseMagazineCaselessRifleShort
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleIncendiary
+
+- type: entity
+  id: MagazineCaselessRifleShortUranium
+  name: "short magazine (.25 caseless uranium)"
+  parent: BaseMagazineCaselessRifleShort
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleUranium
+
+- type: entity
+  id: MagazineCaselessRifleShortShrapnel
+  name: "short magazine (.25 caseless shrapnel)"
+  parent: BaseMagazineCaselessRifleShort
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeCaselessRifleShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -36,7 +36,7 @@
 # Magazines
 - type: entity
   id: MagazineLightRifleBox
-  name: "L6 SAW magazine box (.30 rifle)"
+  name: "box magazine (.30 rifle)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag
@@ -53,6 +53,46 @@
     steps: 8
     zeroVisible: false
   - type: Appearance
+
+- type: entity
+  id: MagazineLightRifleBoxPractice
+  name: "box magazine (.30 rifle practice)"
+  parent: MagazineLightRifleBox
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRiflePractice
+
+- type: entity
+  id: MagazineLightRifleBoxRubber
+  name: "box magazine (.30 rifle rubber)"
+  parent: MagazineLightRifleBox
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleRubber
+
+- type: entity
+  id: MagazineLightRifleBoxIncendiary
+  name: "box magazine (.30 rifle incendiary)"
+  parent: MagazineLightRifleBox
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleIncendiary
+
+- type: entity
+  id: MagazineLightRifleBoxUranium
+  name: "box magazine (.30 rifle uranium)"
+  parent: MagazineLightRifleBox
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleUranium
+
+- type: entity
+  id: MagazineLightRifleBoxShrapnel
+  name: "L6 SAW magazine box (.30 rifle shrapnel)"
+  parent: MagazineLightRifleBox
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleShrapnel
 
 - type: entity
   id: MagazineLightRifle
@@ -130,6 +170,14 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleIncendiary
+
+- type: entity
+  id: MagazineLightRifleShrapnel
+  name: "magazine (.30 rifle shrapnel)"
+  parent: BaseMagazineLightRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeLightRifleShrapnel
 
 - type: entity
   id: MagazineLightRifleMaxim

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -145,6 +145,20 @@
       map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
+  id: MagazineMagnumShrapnel
+  name: pistol magazine (.45 magnum shrapnel)
+  parent: BaseMagazineMagnum
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeMagnumShrapnel
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
   id: MagazineMagnumSubMachineGunEmpty
   name: "Vector magazine (.45 magnum any)"
   suffix: empty

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -215,6 +215,20 @@
       map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
+  id: MagazinePistolShrapnel
+  name: pistol magazine (.35 auto shrapnel)
+  parent: BaseMagazinePistol
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolShrapnel
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
   id: MagazinePistolHighCapacityEmpty
   name: machine pistol magazine (.35 auto any)
   suffix: empty
@@ -265,6 +279,20 @@
   - type: Sprite
     layers:
     - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazinePistolHighCapacityShrapnel
+  name: machine pistol magazine (.35 auto shrapnel)
+  parent: BaseMagazinePistolHighCapacity
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolShrapnel
+  - type: Sprite
+    layers:
+    - state: red
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
@@ -357,3 +385,11 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazinePistolSubMachineGunShrapnel
+  name: SMG magazine (.35 auto shrapnel)
+  parent: BaseMagazinePistolSubMachineGun
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -109,3 +109,17 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazineRifleShrapnel
+  name: "magazine (.20 rifle shrapnel)"
+  parent: BaseMagazineRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeRifleShrapnel
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
@@ -99,6 +99,20 @@
       map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
+  id: MagazineShotgunUranium
+  name: ammo drum (.50 uranium slug)
+  parent: BaseMagazineShotgun
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgunUranium
+  - type: Sprite
+    layers:
+    - state: slug
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
   id: MagazineShotgunBirdshot
   name: ammo drum (.50 birdshot)
   parent: BaseMagazineShotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
@@ -97,3 +97,45 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazineShotgunBirdshot
+  name: ammo drum (.50 birdshot)
+  parent: BaseMagazineShotgun
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgunBirdshot
+  - type: Sprite
+    layers:
+    - state: pellets
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazineShotgun00Buckshot
+  name: ammo drum (.50 00-Buckshot)
+  parent: BaseMagazineShotgun
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgun00Buckshot
+  - type: Sprite
+    layers:
+    - state: pellets
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazineShotgun0000Buckshot
+  name: ammo drum (.50 0000-Buckshot)
+  parent: BaseMagazineShotgun
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgun0000Buckshot
+  - type: Sprite
+    layers:
+    - state: pellets
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -23,6 +23,8 @@
     damage:
       types:
         Piercing: 3
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletAntiMaterielShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -8,7 +8,28 @@
     damage:
       types:
         Piercing: 70 # AntiMateriel Sniper should hurt real bad
-        Structural: 400 # Sniper is rarely used this way, but this ammo type exists to burst down CONCRETE and TANKS 
+        Structural: 400 # Sniper is rarely used this way, but this ammo type exists to burst down CONCRETE and TANKS
     ignoreResistances: true
   - type: StaminaDamageOnCollide
     damage: 75 # Getting hit with this should knock you the fuck down
+
+- type: entity
+  id: BulletAntiMaterielShrapnel
+  name: bullet (.60 anti-personnel shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 3
+
+- type: entity
+  id: BulletAntiMaterielShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletAntiMaterielShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletAntiMaterielShrapnel
+    count: 30
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -65,6 +65,8 @@
     damage:
       types:
         Piercing: 4.37
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletCaselessRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -30,3 +30,48 @@
     damage:
       types:
         Blunt: 3
+
+- type: entity
+  id: BulletCaselessRifleIncendiary
+  name: bullet (.25 caseless incendiary)
+  parent: BaseBulletIncendiary
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 3
+        Heat: 16
+
+- type: entity
+  id: BulletCaselessRifleUranium
+  name: bullet (.25 caseless uranium)
+  parent: BaseBulletUranium
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Radiation: 9
+        Piercing: 10
+
+- type: entity
+  id: BulletCaselessRifleShrapnel
+  name: bullet (.25 caseless shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 4.37
+
+- type: entity
+  id: BulletCaselessRifleShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletCaselessRifleShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletCaselessRifleShrapnel
+    count: 5
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -54,3 +54,24 @@
       types:
         Radiation: 9
         Piercing: 10
+
+- type: entity
+  id: BulletLightRifleShrapnel
+  name: bullet (.20 rifle shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 5.525
+
+- type: entity
+  id: BulletLightRifleShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletLightRifleShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletLightRifleShrapnel
+    count: 4
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -65,6 +65,8 @@
     damage:
       types:
         Piercing: 5.525
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletLightRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -68,3 +68,24 @@
       types:
         Radiation: 15
         Piercing: 10
+
+- type: entity
+  id: BulletMagnumShrapnel
+  name: bullet (.45 magnum shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 4.7916
+
+- type: entity
+  id: BulletMagnumShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletMagnumShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletMagnumShrapnel
+    count: 6
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -79,6 +79,8 @@
     damage:
       types:
         Piercing: 4.7916
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletMagnumShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -54,3 +54,24 @@
       types:
         Radiation: 6
         Piercing: 10
+
+- type: entity
+  id: BulletPistolShrapnel
+  name: bullet (.35 auto shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 6.1333
+
+- type: entity
+  id: BulletPistolShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletPistolShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletPistolShrapnel
+    count: 3
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -65,6 +65,8 @@
     damage:
       types:
         Piercing: 6.1333
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletPistolShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -42,7 +42,7 @@
       types:
         Blunt: 2
         Heat: 15
-  
+
 - type: entity
   id: BulletRifleUranium
   parent: BaseBulletUranium
@@ -54,4 +54,25 @@
       types:
         Radiation: 7
         Piercing: 12
-        
+
+- type: entity
+  id: BulletRifleShrapnel
+  name: bullet (0.20 rifle shrapnel)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 6.325
+
+- type: entity
+  id: BulletRifleShrapnelSpread
+  categories: [ HideSpawnMenu ]
+  parent: BulletRifleShrapnel
+  components:
+  - type: ProjectileSpread
+    proto: BulletRifleShrapnel
+    count: 4
+    spread: 15
+

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -65,6 +65,8 @@
     damage:
       types:
         Piercing: 6.325
+  - type: Sprite
+    scale: 0.5, 0.5
 
 - type: entity
   id: BulletRifleShrapnelSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -284,3 +284,78 @@
     proto: PelletGlass
     count: 5
     spread: 10
+
+- type: entity
+  id: PelletShotgunBirdshot
+  name: pellet (.50 birdshot)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Sprite
+    scale: 0.5, 0.5
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 3.333
+
+- type: entity
+  id: PelletShotgunSpreadBirdshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgunBirdshot
+    count: 18
+    spread: 15
+
+- type: entity
+  id: PelletShotgun00Buckshot
+  name: pellet (.50 00-Buckshot)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Sprite
+    scale: 1.1, 1.1
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 15
+
+- type: entity
+  id: PelletShotgunSpread00Buckshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgun00Buckshot
+    count: 4
+    spread: 15
+
+- type: entity
+  id: PelletShotgun0000Buckshot
+  name: pellet (.50 0000-Buckshot)
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  components:
+  - type: Sprite
+    scale: 1.25, 1.25
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 20
+
+- type: entity
+  id: PelletShotgunSpread0000Buckshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgun0000Buckshot
+    count: 3
+    spread: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -139,3 +139,11 @@
     steps: 7
     zeroVisible: false
   - type: Appearance
+
+- type: entity
+  id: SpeedLoaderMagnumShrapnel
+  name: "speed loader (.45 magnum shrapnel)"
+  parent: SpeedLoaderMagnum
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeMagnumShrapnel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -74,7 +74,7 @@
 
 - type: entity
   id: GrenadeBlast
-  name: blast grenade
+  name: "40mm blast grenade"
   parent: BaseGrenade
   components:
   - type: CartridgeAmmo
@@ -91,7 +91,7 @@
 
 - type: entity
   id: GrenadeFlash
-  name: flash grenade
+  name: "40mm flash grenade"
   parent: BaseGrenade
   components:
   - type: CartridgeAmmo
@@ -108,7 +108,7 @@
 
 - type: entity
   id: GrenadeFrag
-  name: frag grenade
+  name: "40mm frag grenade"
   parent: BaseGrenade
   components:
   - type: CartridgeAmmo
@@ -122,10 +122,10 @@
   - type: SpentAmmoVisuals
     state: frag
     suffix: false
-    
+
 - type: entity
   id: GrenadeEMP
-  name: EMP grenade
+  name: "40mmEMP grenade"
   parent: BaseGrenade
   components:
   - type: CartridgeAmmo
@@ -134,6 +134,95 @@
     sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
     layers:
     - state: emp
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+    state: frag
+    suffix: false
+
+- type: entity
+  id: GrenadeBeanbagShotgun
+  name: "40mm beanbag shot"
+  parent: BaseGrenade
+  components:
+  - type: CartridgeAmmo
+    proto: BulletGrenadeSpreadBeanbag
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    layers:
+    - state: frag
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+    state: frag
+    suffix: false
+
+- type: entity
+  id: GrenadeBirdshot
+  name: "40mm birdshot"
+  description: "For hunting alien birds of unusual size."
+  parent: BaseGrenade
+  components:
+  - type: CartridgeAmmo
+    proto: BulletGrenadeSpreadBirdshot
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    layers:
+    - state: frag
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+    state: frag
+    suffix: false
+
+- type: entity
+  id: GrenadeSlug
+  name: "40mm slug"
+  description: "For hunting alien game the size of a mountain."
+  parent: BaseGrenade
+  components:
+  - type: CartridgeAmmo
+    proto: BulletGrenadeSlug
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    layers:
+    - state: frag
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+    state: frag
+    suffix: false
+
+- type: entity
+  id: Grenade00Buckshot
+  name: "40mm 00-Buckshot"
+  description: "For when you're hunting alien game animals the size of a house."
+  parent: BaseGrenade
+  components:
+  - type: CartridgeAmmo
+    proto: BulletGrenadeSpread00Buckshot
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    layers:
+    - state: frag
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+    state: frag
+    suffix: false
+
+- type: entity
+  id: Grenade0000Buckshot
+  name: "40mm 0000-Buckshot"
+  parent: BaseGrenade
+  description: "For when you're hunting alien game animals the size of a dropship."
+  components:
+  - type: CartridgeAmmo
+    proto: BulletGrenadeSpread0000Buckshot
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    layers:
+    - state: frag
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
@@ -154,7 +243,7 @@
   - type: Item
     size: Small
   - type: Sprite
-  
+
 - type: entity
   id: CannonBall
   name: cannonball

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -836,6 +836,81 @@
     energy: 0.5
 
 - type: entity
+  id: BulletGrenadeSpreadBeanbag
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgunBeanbag
+    count: 8
+    spread: 25
+
+- type: entity
+  id: BulletGrenadeSpreadBirdshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: BulletGrenadeBirdshot
+    count: 50
+    spread: 25
+
+- type: entity
+  id: BulletGrenadeBirdshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: Sprite
+    scale: 0.5, 0.5
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 10
+
+- type: entity
+  id: BulletGrenadeSpread00Buckshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgun00Buckshot
+    count: 32
+    spread: 25
+
+- type: entity
+  id: BulletGrenadeSpread0000Buckshot
+  categories: [ HideSpawnMenu ]
+  parent: PelletShotgun
+  components:
+  - type: ProjectileSpread
+    proto: PelletShotgun0000Buckshot
+    count: 24
+    spread: 25
+
+- type: entity
+  id: BulletGrenadeSlug
+  name: baton grenade
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    layers:
+      - state: grenade
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 250 # At this point you're firing a cannon shell at someone.
+        Structural: 800 # Will instantly destroy pretty much any structure it hits.
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/DeltaV/Misc/reducedtoatmos.ogg
+  - type: StaminaDamageOnCollide
+    damage: 150 # JUST IN CASE THEY SOMEHOW SURVIVE IT.
+
+- type: entity
   id: BulletCap
   name: cap bullet
   parent: BaseBullet

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -904,8 +904,8 @@
       types:
         Blunt: 250 # At this point you're firing a cannon shell at someone.
         Structural: 800 # Will instantly destroy pretty much any structure it hits.
-  - type: EmitSoundOnCollide
-    sound:
+    forceSound: true
+    soundHit:
       path: /Audio/DeltaV/Misc/reducedtoatmos.ogg
   - type: StaminaDamageOnCollide
     damage: 150 # JUST IN CASE THEY SOMEHOW SURVIVE IT.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -140,6 +140,31 @@
   - type: Appearance
 
 - type: entity
+  name: C-20r sub machine gun
+  parent: [WeaponSubMachineGunC20r]
+  id: WeaponSubMachineGunC20rEmpty
+  description: Manufactured by Cybersun-Armaments, the C-20r is one of the most popular personal small-arms in the Coalition of Colonies. Uses .35 auto ammo.
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazinePistolSubMachineGun
+      gun_chamber:
+        name: Chamber
+        startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+            - CartridgePistol
+
+- type: entity
   name: antique C-20r submachine gun
   parent: WeaponSubMachineGunC20r
   id: WeaponSubMachineGunC20rHoS

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -142,6 +142,24 @@
     staminaCost: 9.5
 
 - type: entity
+  name: Bulldog
+  parent: [WeaponShotgunBulldog]
+  id: WeaponShotgunBulldogEmpty
+  description: It's a magazine-fed shotgun designed for close quarters combat. Uses .50 shotgun shells.
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+        priority: 2
+        whitelist:
+          tags:
+          - MagazineShotgun
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+
+- type: entity
   name: antique Bulldog
   parent: WeaponShotgunBulldog
   id: WeaponShotgunBulldogHoS

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1013,6 +1013,9 @@
       - MagazineBoxPistolRubber # Frontier
       - MagazineBoxRifleRubber # Frontier
       - SpeedLoaderRifleHeavyRubber
+      - BoxShotgunBirdshot
+      - BoxShotgun00Buckshot
+      - BoxShotgun0000Buckshot
     dynamicRecipes:
       - Truncheon
       - Terminus
@@ -1117,6 +1120,17 @@
       - WeaponPistolN1984
       - WeaponPistolViper
       - WeaponPistolCobra
+      - MagazineRifleShrapnel
+      - MagazinePistolShrapnel
+      - MagazinePistolSubMachineGunShrapnel
+      - MagazineMagnumShrapnel
+      - MagazineLightRifleShrapnel
+      - MagazineCaselessRifleShrapnel
+      - MagazineBoxPistolShrapnel
+      - MagazineBoxMagnumShrapnel
+      - MagazineBoxLightRifleShrapnel
+      - MagazineBoxRifleShrapnel
+      - MagazineBoxCaselessRifleShrapnel
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1126,11 +1126,15 @@
       - MagazineMagnumShrapnel
       - MagazineLightRifleShrapnel
       - MagazineCaselessRifleShrapnel
+      - MagazineCaselessRifleIncendiary
+      - MagazineCaselessRifleUranium
       - MagazineBoxPistolShrapnel
       - MagazineBoxMagnumShrapnel
       - MagazineBoxLightRifleShrapnel
       - MagazineBoxRifleShrapnel
       - MagazineBoxCaselessRifleShrapnel
+      - MagazineBoxCaselessRifleIncendiary
+      - MagazineBoxCaselessRifleUranium
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -320,6 +320,27 @@
   materials:
     Plastic: 350
 
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineCaselessRifleIncendiary
+  result: MagazineCaselessRifleIncendiary
+  materials:
+    Plastic: 350
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineCaselessRifleUranium
+  result: MagazineCaselessRifleUranium
+  materials:
+    Uranium: 350
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineCaselessRifleShrapnel
+  result: MagazineCaselessRifleShrapnel
+  materials:
+    Steel: 350
+
 # .25 Caseless (Box Mag) Rifle Magazines
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -339,6 +360,27 @@
   parent: BaseAmmoRecipe
   id: MagazineBoxCaselessRifleRubber
   result: MagazineBoxCaselessRifleRubber
+  materials:
+    Steel: 720
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineBoxCaselessRifleIncendiary
+  result: MagazineBoxCaselessRifleIncendiary
+  materials:
+    Plastic: 720
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineBoxCaselessRifleUranium
+  result: MagazineBoxCaselessRifleUranium
+  materials:
+    Uranium: 720
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineBoxCaselessRifleShrapnel
+  result: MagazineBoxCaselessRifleShrapnel
   materials:
     Steel: 720
 
@@ -396,6 +438,14 @@
     Plastic: 120
 
 - type: latheRecipe
+  id: MagazinePistolShrapnel
+  result: MagazinePistolShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 145
+
+- type: latheRecipe
   id: MagazinePistolSubMachineGunEmpty
   result: MagazinePistolSubMachineGunEmpty
   category: Ammo
@@ -440,6 +490,14 @@
     Plastic: 400
 
 - type: latheRecipe
+  id: MagazinePistolSubMachineGunShrapnel
+  result: MagazinePistolSubMachineGunShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 300
+
+- type: latheRecipe
   id: MagazinePistolSubMachineGunTopMountedEmpty
   result: MagazinePistolSubMachineGunTopMountedEmpty
   category: Ammo
@@ -473,8 +531,24 @@
     Plastic: 300
 
 - type: latheRecipe
+  id: MagazineBoxPistolShrapnel
+  result: MagazineBoxPistolShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 600
+
+- type: latheRecipe
   id: MagazineBoxMagnum
   result: MagazineBoxMagnum
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 240
+
+- type: latheRecipe
+  id: MagazineBoxMagnumShrapnel
+  result: MagazineBoxMagnumShrapnel
   category: Ammo
   completetime: 5
   materials:
@@ -542,6 +616,14 @@
     Plastic: 450
 
 - type: latheRecipe
+  id: MagazineRifleShrapnel
+  result: MagazineRifleShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 475
+
+- type: latheRecipe
   id: MagazineLightRifleEmpty
   result: MagazineLightRifleEmpty
   category: Ammo
@@ -594,6 +676,14 @@
     Plastic: 540
 
 - type: latheRecipe
+  id: MagazineLightRifleShrapnel
+  result: MagazineLightRifleShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 565
+
+- type: latheRecipe
   id: MagazineMagnumEmpty
   result: MagazineMagnumEmpty
   category: Ammo
@@ -638,8 +728,24 @@
     Plastic: 150
 
 - type: latheRecipe
+  id: MagazineMagnumShrapnel
+  result: MagazineMagnumShrapnel
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 150
+
+- type: latheRecipe
   id: MagazineBoxRifle
   result: MagazineBoxRifle
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 750
+
+- type: latheRecipe
+  id: MagazineBoxRifleShrapnel
+  result: MagazineBoxRifleShrapnel
   category: Ammo
   completetime: 5
   materials:
@@ -657,6 +763,14 @@
 - type: latheRecipe
   id: MagazineBoxLightRifle
   result: MagazineBoxLightRifle
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 900
+
+- type: latheRecipe
+  id: MagazineBoxLightRifleShrapnel
+  result: MagazineBoxLightRifleShrapnel
   category: Ammo
   completetime: 5
   materials:
@@ -687,6 +801,30 @@
   materials:
     Steel: 240
     Plastic: 160
+
+- type: latheRecipe
+  id: BoxShotgunBirdshot
+  result: BoxShotgunBirdshot
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 320
+
+- type: latheRecipe
+  id: BoxShotgun00Buckshot
+  result: BoxShotgun00Buckshot
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 320
+
+- type: latheRecipe
+  id: BoxShotgun0000Buckshot
+  result: BoxShotgun0000Buckshot
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 320
 
 - type: latheRecipe
   id: MagazineBoxLightRifleRubber

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -46,6 +46,7 @@
   - MagazinePistolSubMachineGunIncendiary
   - MagazineMagnumIncendiary
   - MagazineLightRifleIncendiary
+  - MagazineCaselessRifleIncendiary
   - SpeedLoaderMagnumIncendiary
   - SpeedLoaderRifleHeavyIncendiary
   - MagazineShotgunIncendiary
@@ -53,6 +54,7 @@
   - MagazineBoxMagnumIncendiary
   - MagazineBoxLightRifleIncendiary
   - MagazineBoxRifleIncendiary
+  - MagazineBoxCaselessRifleIncendiary
   - CartridgeSpecialIncendiary
   - MagazineBoxSpecialIncendiary
 
@@ -71,12 +73,14 @@
   - MagazinePistolSubMachineGunUranium
   - MagazineMagnumUranium
   - MagazineLightRifleUranium
+  - MagazineCaselessRifleUranium
   - SpeedLoaderMagnumUranium
   - SpeedLoaderRifleHeavyUranium # Frontier
   - MagazineBoxPistolUranium
   - MagazineBoxMagnumUranium
   - MagazineBoxLightRifleUranium
   - MagazineBoxRifleUranium
+  - MagazineBoxCaselessRifleUranium
   - BoxShotgunUranium
   - CartridgeSpecialUranium
   - MagazineBoxSpecialUranium
@@ -115,6 +119,28 @@
   - ExplosivePayload
   - ChemicalPayload
   # TODO: Add "Explosive Ammunition" to this tech to make it waaaay more interesting.
+
+- type: technology
+  id: ShrapnelMunitions
+  name: research-technology-shrapnel-munitions
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/shotgun_shell.rsi
+    state: base
+  discipline: Arsenal
+  tier: 2
+  cost: 7500
+  recipeUnlocks:
+  - MagazineRifleShrapnel
+  - MagazinePistolShrapnel
+  - MagazinePistolSubMachineGunShrapnel
+  - MagazineMagnumShrapnel
+  - MagazineLightRifleShrapnel
+  - MagazineCaselessRifleShrapnel
+  - MagazineBoxPistolShrapnel
+  - MagazineBoxMagnumShrapnel
+  - MagazineBoxLightRifleShrapnel
+  - MagazineBoxRifleShrapnel
+  - MagazineBoxCaselessRifleShrapnel
 
 - type: technology
   id: AdvancedWeapons

--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -87,7 +87,6 @@
         whitelist:
           tags:
             - CartridgeCaselessRifle
-        requireDetailRange: false
 
 - type: entity
   name: BRDI R-25

--- a/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -64,6 +64,32 @@
         requireDetailRange: false
 
 - type: entity
+  name: FPA-90 sub machine gun
+  parent: WeaponSubMachineGunFPA90
+  id: WeaponSubMachineGunFPA90Empty
+  description: It's a cheap piece of shit made by a company well known for cheap guns, but at least you don't need hearing protection while using it. It fires .25 caseless.
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: null
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazineCaselessRifle
+      gun_chamber:
+        name: Chamber
+        startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+            - CartridgeCaselessRifle
+        requireDetailRange: false
+
+- type: entity
   name: BRDI R-25
   parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunBRDIR25


### PR DESCRIPTION
# Description

This PR makes use of the Shotgun Refactor by adding a new type of special ammunition called "Shrapnel" ammo, as well as a variety of new shotgun shell types. There's also new 40mm shotshell ammo types, which let you turn a china lake into a 40mm shotgun of DOOM.

Shrapnel ammo essentially makes "Any gun into a shotgun", splitting the damage of the original base ammo across multiple projectiles in a cone. It has a small damage multiplier as a tradeoff, such that they deal increased damage at incredibly close range. But realistically, you want this ammo for the hilarious fun that is throwing 4x as many bullets down a hallway. 

Shrapnel ammo can be bought in the Syndicate Uplink, alongside the other varieties of exotic special ammo, and can even be purchased in a Shrapnel Ammo Bundle for nukie teams. To better encourage players to not feel like they're being punished for taking special ammo, most of the traitor weapons no longer spawn with ammo, and are in turn discounted by the cost of the ammo they no longer spawn with. The C20r for instance has gone all the way down to 50tc.

<details><summary><h1>Media</h1></summary>
<p>

8mb video isn't working right now.

</p>
</details>

# Changelog

:cl:
- add: Added "Shrapnel Ammo" to most weapon types as a new special ammunition. Shrapnel ammo essentially turns any gun into a baby shotgun. This includes guns like the L6 Saw.
- add: Added Shrapnel Ammo and specialty ammo bundles to the Syndicate Uplink.
- tweak: To encourage people to buy different kinds of ammo, certain guns in the Syndicate Uplink no longer spawn with ammo, and are in return discounted by the cost of the ammo that was removed. Have fun buying C20 magazines with incendiary ammo. 
- add: Added Shrapnel Munitions to Arsenal Research T2. Once researched, shrapnel ammo can be manufactured at a security techfab.
