### PR TITLE
Oni Correction

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -292,17 +292,17 @@ trait-description-LightStep =
 trait-name-Swashbuckler = Swashbuckler
 trait-description-Swashbuckler =
     You are an expert in swordsmanship, wielding swords, knives, and other blades with unrivaled finesse.
-    Your melee Slash bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+    Your melee Slash bonus is increased to 35%, but your melee Blunt bonus is reduced to 25%.
 
 trait-name-Spearmaster = Spearmaster
 trait-description-Spearmaster =
     You have an outstanding proficiency with spears, wielding them as an extension of your body.
-    Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 20%.
+    Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 25%.
 
 trait-name-WeaponsGeneralist = Weapons Generalist
 trait-description-WeaponsGeneralist =
     You are a jack of all trades with melee weapons, enabling you to be versatile with your weapon arsenal.
-    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 25%.
+    Your melee damage bonus for all Brute damage types (Blunt, Slash, Piercing) becomes 30%.
 
 trait-name-Singer = Singer
 trait-description-Singer = You are naturally capable of singing simple melodies with your voice.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -15,8 +15,8 @@
     modifiers:
       coefficients:
         Blunt: 1.35
-        Slash: 1.2
-        Piercing: 1.2
+        Slash: 1.25
+        Piercing: 1.25
         Asphyxiation: 1.35
   - type: Damageable
     damageModifierSet: Oni

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -8,9 +8,9 @@
       - type: OniDamageModifier
         modifiers:
           coefficients:
-            Blunt: 1.2
+            Blunt: 1.25
             Slash: 1.35
-            Piercing: 1.2
+            Piercing: 1.25
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
@@ -31,8 +31,8 @@
       - type: OniDamageModifier
         modifiers:
           coefficients:
-            Blunt: 1.2
-            Slash: 1.2
+            Blunt: 1.25
+            Slash: 1.25
             Piercing: 1.35
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -54,9 +54,9 @@
       - type: OniDamageModifier
         modifiers:
           coefficients:
-            Blunt: 1.25
-            Slash: 1.25
-            Piercing: 1.25
+            Blunt: 1.30
+            Slash: 1.30
+            Piercing: 1.30
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Swashbuckler
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -24,7 +24,7 @@
 - type: trait
   id: Spearmaster
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -47,7 +47,7 @@
 - type: trait
   id: WeaponsGeneralist
   category: Physical
-  points: -2
+  points: -1
   functions:
     - !type:TraitReplaceComponent
       components:


### PR DESCRIPTION
# Description

Oni's melee buff description was wrong in the guidebook, so it's been re-adjusted (to fit the guidebook).
Adjusted Oni's unique traits so it's balanced properly.
Buffed, made Oni's unique traits cheaper because they're niche changes that simply changed their brute values around.

# Changelog

:cl:

- tweak: Tweaked values on Oni melee bonus to correctly reflect the guidebook
- tweak: Tweaked Blademaster and Spearmaster to mirror Default
- tweak: Buffed Oni's unique traits to be cheaper
- tweak: Buffed Weapon Generalist to 30% so it's not just a nerf

