### PR TITLE
Prevent IPCs From Having Their Access Panel Emagged Permanently.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -28,7 +28,7 @@
     # Por algum motivo esse componente é bem bugado, então o "LockTime" é quem diz o tempo de tudo enquanto o unlock só está servindo como um bool (???)
     lockTime: 5
     unlockTime: 5
-    breakOnEmag: false # Emagging an IPC panel is irreversible without admin intervention, and I have a funny feeling making somebody permanently pretty much combat ineffective as their cell can instantly be yanked out, with no do-after bar, counterplay, or even indicator to the victim, is fair.
+    breakOnEmag: false # Emagging an IPC panel is irreversible without admin intervention, and I have a funny feeling making somebody permanently pretty much combat ineffective as their cell can instantly be yanked out, with no do-after bar, counterplay, or even indicator to the victim, is not exactly fair.
   - type: NpcFactionMember
     factions:
       - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -28,6 +28,7 @@
     # Por algum motivo esse componente é bem bugado, então o "LockTime" é quem diz o tempo de tudo enquanto o unlock só está servindo como um bool (???)
     lockTime: 5
     unlockTime: 5
+    breakOnEmag: false # Emagging an IPC panel is irreversible without admin intervention, and I have a funny feeling making somebody permanently pretty much combat ineffective as their cell can instantly be yanked out, with no do-after bar, counterplay, or even indicator to the victim, is fair.
   - type: NpcFactionMember
     factions:
       - NanoTrasen


### PR DESCRIPTION
# Description

I get it, IPCs right now are already overtuned, but there are also SEVERAL ways to instantly disable them, which I dont know how to feel about. EMPs I will think on if that should be changed, and if so, how, later on. But I feel like the fact that it pretty much kills them, as they will remain unable to do anything without outside help, without even actually killing them (Meaning you can't spectate unless you ghost out, which round removes you.) is not ideal, since staring at an inverse black circle until you get lucky and somebody who actually knows how IPCs work, and how to help them if they get killed or emped, is not very fun gameplay.

However, the more pressing issue is the emag. If you use it on a locked IPC, it unlocks their panel instantly with zero warning to the IPC, which then allows you to rip out their cell, which has all the same consequences and thus problems as being EMPed. 
However, the emag is actually worse, as upon use, it DELETES the lock component from that IPC, meaning their panel will remain open forever unless an admin re-adds the component, meaning from there on out for the rest of the round, ANYONE can right click you, eject your cell, and you can do NOTHING about it. So this PR is removing that emag interaction entirely, as again, you already have EMPs if you want to instantly render an IPC defenseless with 0 counterplay, but atleast being hit by an EMP doesnt permanently give anyone the ability to shut you off instantly with no way to revert or repair that.

---

# Changelog

:cl: BramvanZijp
- remove: An IPC's maintenancepanel can no longer be emagged to instantly and permanently open it.
