### PR TITLE
Rework the IPC Maintenance Panel.

### DIFF
--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -21,6 +21,12 @@ public sealed partial class AccessReaderComponent : Component
     public bool Enabled = true;
 
     /// <summary>
+    /// Whether or not the owner of the lock (IPC/Cyborg) can always access it.
+    /// </summary>
+    [DataField]
+    public bool OwnerHasAccess = true;
+
+    /// <summary>
     /// The set of tags that will automatically deny an allowed check, if any of them are present.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class AccessReaderComponent : Component
     /// Whether or not the owner of the lock (IPC/Cyborg) can always access it.
     /// </summary>
     [DataField]
-    public bool OwnerHasAccess = true;
+    public bool OwnerHasAccess = false;
 
     /// <summary>
     /// The set of tags that will automatically deny an allowed check, if any of them are present.

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -100,6 +100,9 @@ public sealed class AccessReaderSystem : EntitySystem
         if (!reader.Enabled)
             return true;
 
+        if (reader.OwnerHasAccess && reader.Owner == user)
+            return true;
+
         var accessSources = FindPotentialAccessItems(user);
         var access = FindAccessTags(user, accessSources);
         FindStationRecordKeys(user, out var stationKeys, accessSources);

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -100,8 +100,11 @@ public sealed class AccessReaderSystem : EntitySystem
         if (!reader.Enabled)
             return true;
 
-        if (reader.OwnerHasAccess && reader.Owner == user)
+        if (reader.OwnerHasAccess && target == user)
+        {
+            LogAccess((target, reader), user);
             return true;
+        }
 
         var accessSources = FindPotentialAccessItems(user);
         var access = FindAccessTags(user, accessSources);

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -21,13 +21,16 @@
     minInterval: 15
     maxInterval: 30
     popUp: "silicon-power-low"
+  - type: WiresPanel
+  - type: LockedWiresPanel
   - type: Lock
     locked: true
     lockOnClick: false
     unlockOnClick: false
-    # Por algum motivo esse componente é bem bugado, então o "LockTime" é quem diz o tempo de tudo enquanto o unlock só está servindo como um bool (???)
-    lockTime: 5
-    unlockTime: 5
+    breakOnEmag: false
+  - type: AccessReader
+    breakOnEmag: true
+    ownerHasAccess: true
   - type: NpcFactionMember
     factions:
       - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -22,6 +22,7 @@
     maxInterval: 30
     popUp: "silicon-power-low"
   - type: WiresPanel
+    openDelay: 5
   - type: LockedWiresPanel
   - type: Lock
     locked: true


### PR DESCRIPTION
# Description

IPC panels now work simularly to borg panels, as follows:
You can unlock/lock them instantly if you have the requires access.
Unlike borgs, IPCs start unlockable by anyone, but this can be changed with an access config.
IPCs can ALWAYS unlock/lock their own panel, regardless of the access requirement.
After it is unlocked, you can then use a screwdriver to ACTUALLY open/close the panel.

---

<details><summary><h1>Media</h1></summary>
<p>

[Link to a video in contribution-general (file too big to attach)](https://discord.com/channels/1218698320155906090/1218698321053356060/1351936832434077787)

</p>
</details>

---

# Changelog

:cl: BramvanZijp
- add: You can now add an access requirement to an IPC's maintenance panel using an access configurator, though an IPC can always unlock their own panel.
- tweak: After unlocking an IPC maintenance panel, which is now instant, you need to use a screwdriver to actually open it.
