### PR TITLE
Make Context Menu Uses Spritetree 

### DIFF
--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 using Content.Client.Examine;
 using Content.Client.Gameplay;
 using Content.Client.Popups;
@@ -7,6 +8,7 @@ using Content.Shared.Examine;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
+using Robust.Client.ComponentTrees;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -21,10 +23,11 @@ namespace Content.Client.Verbs
     {
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly ExamineSystem _examine = default!;
+        [Dependency] private readonly SpriteTreeSystem _tree = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly IStateManager _stateManager = default!;
-        [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         /// <summary>
@@ -32,14 +35,14 @@ namespace Content.Client.Verbs
         /// </summary>
         public const float EntityMenuLookupSize = 0.25f;
 
-        [Dependency] private readonly IEyeManager _eyeManager = default!;
-
         /// <summary>
         ///     These flags determine what entities the user can see on the context menu.
         /// </summary>
         public MenuVisibility Visibility;
 
         public Action<VerbsResponseEvent>? OnVerbsResponse;
+
+        private List<EntityUid> _entities = new();
 
         public override void Initialize()
         {
@@ -77,49 +80,50 @@ namespace Content.Client.Verbs
             visibility = ev.Visibility;
 
             // Get entities
-            List<EntityUid> entities;
-            var examineFlags = LookupFlags.All & ~LookupFlags.Sensors;
+            _entities.Clear();
+            var entitiesUnderMouse = _tree.QueryAabb(targetPos.MapId, Box2.CenteredAround(targetPos.Position, new Vector2(EntityMenuLookupSize, EntityMenuLookupSize)));
 
             // Do we have to do FoV checks?
             if ((visibility & MenuVisibility.NoFov) == 0)
             {
-                var entitiesUnderMouse = gameScreenBase.GetClickableEntities(targetPos).ToHashSet();
-                bool Predicate(EntityUid e) => e == player || entitiesUnderMouse.Contains(e);
+                bool Predicate(EntityUid e) => e == player;
 
                 TryComp(player.Value, out ExaminerComponent? examiner);
 
-                entities = new();
-                foreach (var ent in _entityLookup.GetEntitiesInRange(targetPos, EntityMenuLookupSize, flags: examineFlags))
+                foreach (var ent in entitiesUnderMouse)
                 {
-                    if (_examine.CanExamine(player.Value, targetPos, Predicate, ent, examiner))
-                        entities.Add(ent);
+                    if (_examine.CanExamine(player.Value, targetPos, Predicate, ent.Uid, examiner))
+                        _entities.Add(ent.Uid);
                 }
             }
             else
             {
-                entities = _entityLookup.GetEntitiesInRange(targetPos, EntityMenuLookupSize, flags: examineFlags).ToList();
+                foreach (var ent in entitiesUnderMouse)
+                {
+                    _entities.Add(ent.Uid);
+                }
             }
 
-            if (entities.Count == 0)
+            if (_entities.Count == 0)
                 return false;
 
             if (visibility == MenuVisibility.All)
             {
-                result = entities;
+                result = new (_entities);
                 return true;
             }
 
             // remove any entities in containers
             if ((visibility & MenuVisibility.InContainer) == 0)
             {
-                for (var i = entities.Count - 1; i >= 0; i--)
+                for (var i = _entities.Count - 1; i >= 0; i--)
                 {
-                    var entity = entities[i];
+                    var entity = _entities[i];
 
                     if (ContainerSystem.IsInSameOrTransparentContainer(player.Value, entity))
                         continue;
 
-                    entities.RemoveSwap(i);
+                    _entities.RemoveSwap(i);
                 }
             }
 
@@ -128,23 +132,23 @@ namespace Content.Client.Verbs
             {
                 var spriteQuery = GetEntityQuery<SpriteComponent>();
 
-                for (var i = entities.Count - 1; i >= 0; i--)
+                for (var i = _entities.Count - 1; i >= 0; i--)
                 {
-                    var entity = entities[i];
+                    var entity = _entities[i];
 
                     if (!spriteQuery.TryGetComponent(entity, out var spriteComponent) ||
                         !spriteComponent.Visible ||
                         _tagSystem.HasTag(entity, "HideContextMenu"))
                     {
-                        entities.RemoveSwap(i);
+                        _entities.RemoveSwap(i);
                     }
                 }
             }
 
-            if (entities.Count == 0)
+            if (_entities.Count == 0)
                 return false;
 
-            result = entities;
+            result = new(_entities);
             return true;
         }
 

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -127,11 +127,6 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      # Context / examine fixture
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
       slipFixture:
         shape:
           !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -8,11 +8,6 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      # This exists for examine.
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
       light:
         shape:
           !type:PhysShapeCircle


### PR DESCRIPTION
Rather than doing goofy hacks we just use what sprites are near the mouse.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

https://github.com/space-wizards/space-station-14/pull/31792

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Make context menu uses spritetree 
