### PR TITLE
DRASTICALLY Reduce Stamina Damage Dealt by Throwing.

### DIFF
--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -119,7 +119,7 @@ public sealed partial class PullerComponent : Component
     };
 
     [DataField]
-    public float StaminaDamageOnThrown = 120f;
+    public float StaminaDamageOnThrown = 30f;
 
     [DataField]
     public float GrabThrownSpeed = 7f;


### PR DESCRIPTION
# Description

This PR reduces the stamina damage dealt as a result of throwing somebody from 120 to 30.
The reasoning for this is because all of the 3 martial arts have instant hard grabs, and with throwing being an instant stamcrit, all of them have the same exact optimal usage: Harm mode on, Control Leftclick, Control Q, Cuff em, win.

This PR Intends to make it so that the throwing aspect is relegated to a way to force an opponents movement, throwing them away from an area you do not want them in, or towards an area you do want them to be in. However, it loses its viability as an uncounterable stamcrit tool, as you have a lot more options to retaliate while the enemy has to throw you 3 more times, meaning if you want to stun somebody, you are better off using your specific martial art's unique combo attacks instead of this generic end all be all solution which removes 99% of the uniqueness and variety from these martial arts vs martial arts fights, which is a shame.

---

# Changelog

:cl: BramvanZijp
- tweak: The stamina damage dealt to somebody after throwing them has been reduced from 120 (Instant stamcrit) to 30.
