### PR TITLE
Changed type for item in map Terminal

### DIFF
--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -19382,7 +19382,7 @@ entities:
     - type: Transform
       pos: -17.253208,-8.633782
       parent: 2
-- proto: ClothingHeadHatPirateTricord
+- proto: ClothingHeadHatPirateTricorn
   entities:
   - uid: 8601
     components:


### PR DESCRIPTION
Fixed typo in a hat on map terminal.
changed ClothingHeadHatPirateTricord to ClothingHeadHatPirateTricorn. 

Changed a 'd' to 'n' to match up with item naming.