### PR TITLE
ClothingHeadHatPirateTricorn was named ClothingHeadHatPirateTricord in map Terminal.

### DIFF
--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -19382,7 +19382,7 @@ entities:
     - type: Transform
       pos: -17.253208,-8.633782
       parent: 2
-- proto: ClothingHeadHatPirateTricord
+- proto: ClothingHeadHatPirateTricorn
   entities:
   - uid: 8601
     components:


### PR DESCRIPTION
Yaml. Map.
ClothingHeadHatPirateTricorn was still named ClothingHeadHatPirateTricord in map Terminal after item rename changes.

changed the d to a n.