### PR TITLE
Throwing Nerfs: Less Stamina Damage, Cooldown After Grabbing Before You Can Throw.

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -239,6 +239,9 @@ namespace Content.Server.Hands.Systems
 
                 var targEv = new VirtualItemThrownEvent(virt.BlockingEntity, player, throwEnt, direction);
                 RaiseLocalEvent(virt.BlockingEntity, targEv);
+
+                if (userEv.Cancelled || targEv.Cancelled)
+                    return false;
             }
             // Goobstation end
 

--- a/Content.Shared/Hands/HandEvents.cs
+++ b/Content.Shared/Hands/HandEvents.cs
@@ -163,8 +163,9 @@ namespace Content.Shared.Hands
     /// <summary>
     ///     Raised directed on both the blocking entity and user when
     ///     a virtual hand item is thrown (at least attempted to).
+    ///     Cancellable.
     /// </summary>
-    public sealed class VirtualItemThrownEvent : EntityEventArgs
+    public sealed class VirtualItemThrownEvent : CancellableEntityEventArgs
     {
         public EntityUid BlockingEntity;
         public EntityUid User;

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -101,7 +101,7 @@ public sealed partial class PullerComponent : Component
     ///     After initiating (not upgrading) a combat grab, how long should you have to keep somebody grabbed to be able to throw them.
     /// </summary>
     [DataField]
-    public TimeSpan ThrowDelayOngrab = TimeSpan.FromSeconds(6f);
+    public TimeSpan ThrowDelayOnGrab = TimeSpan.FromSeconds(6f);
 
     [DataField]
     public Dictionary<GrabStage, float> EscapeChances = new()

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -94,6 +94,15 @@ public sealed partial class PullerComponent : Component
     [DataField]
     public TimeSpan StageChangeCooldown = TimeSpan.FromSeconds(1.5f);
 
+    [AutoNetworkedField]
+    public TimeSpan WhenCanThrow;
+
+    /// <summary>
+    ///     After initiating (not upgrading) a combat grab, how long should you have to keep somebody grabbed to be able to throw them.
+    /// </summary>
+    [DataField]
+    public TimeSpan ThrowDelayOngrab = TimeSpan.FromSeconds(6f);
+
     [DataField]
     public Dictionary<GrabStage, float> EscapeChances = new()
     {
@@ -119,7 +128,7 @@ public sealed partial class PullerComponent : Component
     };
 
     [DataField]
-    public float StaminaDamageOnThrown = 120f;
+    public float StaminaDamageOnThrown = 100f;
 
     [DataField]
     public float GrabThrownSpeed = 7f;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -320,6 +320,16 @@ public sealed class PullingSystem : EntitySystem
             || component.GrabStage <= GrabStage.Soft)
             return;
 
+        if (_timing.CurTime < component.WhenCanThrow)
+        {
+            args.Cancel();
+            _popup.PopupEntity(Loc.GetString("popup-grab-throw-fail-cooldown",("puller", Identity.Entity(uid, EntityManager)),("pulled", Identity.Entity(args.BlockingEntity, EntityManager))),
+            args.BlockingEntity,
+            uid,
+            PopupType.MediumCaution);
+            return;
+        }
+
         var distanceToCursor = args.Direction.Length();
         var direction = args.Direction.Normalized() * MathF.Min(distanceToCursor, component.ThrowingDistance);
 
@@ -919,6 +929,10 @@ public sealed class PullingSystem : EntitySystem
             _ => throw new ArgumentOutOfRangeException(),
         };
 
+        if (puller.Comp.GrabStage == GrabStage.No)
+        {
+            puller.Comp.WhenCanThrow = _timing.CurTime + puller.Comp.ThrowDelayOngrab;
+        }
         var newStage = puller.Comp.GrabStage + nextStageAddition;
         var ev = new CheckGrabOverridesEvent(newStage); // guh
         RaiseLocalEvent(puller, ev);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -931,7 +931,7 @@ public sealed class PullingSystem : EntitySystem
 
         if (puller.Comp.GrabStage == GrabStage.No)
         {
-            puller.Comp.WhenCanThrow = _timing.CurTime + puller.Comp.ThrowDelayOngrab;
+            puller.Comp.WhenCanThrow = _timing.CurTime + puller.Comp.ThrowDelayOnGrab;
         }
         var newStage = puller.Comp.GrabStage + nextStageAddition;
         var ev = new CheckGrabOverridesEvent(newStage); // guh

--- a/Resources/Locale/en-US/_white/grab/grab.ftl
+++ b/Resources/Locale/en-US/_white/grab/grab.ftl
@@ -19,3 +19,4 @@ popup-grab-retake-success = You released {CAPITALIZE($pulled)} from {CAPITALIZE(
 popup-grab-retake-success-puller = {CAPITALIZE($puller)} released {CAPITALIZE($pulled)} from your grab!
 popup-grabbed-cant-speak = You can't breathe!
 popup-grab-need-hand = You need a free hand!
+popup-grab-throw-fail-cooldown = You need more time to secure your grip before you can throw {CAPITALIZE($pulled)}!


### PR DESCRIPTION
# Description

This PR nerfs the ability to stun somebody by throwing them after hard-grabbing them, it does this in 2 ways:
1. Stamina damage goes from 120 to 100, Which I am told by eagle will knockdown as opposed to paralyzing.
2. The big one, after you INITIATE your grab on somebody, a 6 second cooldown starts before you can throw them. This cooldown does not reset if you upgrade your grab, and starts as soon as you soft-grab somebody (or instantly hard-grab, for martial artists.)

This is done because right now melee fights involving martial artists are quite bland and simple: Whoever can get the opponent in a hard grab and throw them first, wins, because this instantly stamina crits them, allowing you to cuff them. This completely negates the unique combos/differences between the fighting styles, as this works for Judo, CQC, and SCarp. You grab em, you toss em, you restrain em, you win. And I dont think fights like these should be decided in the first 1-2 seconds based on who reacted SLIGHTLY faster and/or who had better ping, while they could be so much cooler and more in-depth.

But now, if you are in a hard-grab, you have time to try to get loose, be that via resisting, attacking your grabber, or your own Martial Arts moves, BEFORE they can throw and stam-crit you. Furthermore, this should not be that much of a nerf to those who are NOT martial arts trained, as the timer starts upon INITIATING the grab, meaning if a basic tider soft grabs you, and then upgrades to a hard grab, they can throw you after 6 seconds have passed since that initial soft-grab. But if the BSO with CQC instantly hard-grabs you, they still need to wait 6 seconds before they can throw you, meaning the BSO will not be able to do so sooner compared to the tider, even though they had to manually upgrade their soft grab to a hard grab first.

---

<details><summary><h1>Media</h1></summary>
<p>

[Basic Showcase Video](https://github.com/user-attachments/assets/475f5395-f333-40d6-9a99-6015b476a4af)
> _DISCLAIMER: This video will have a timer in red text at the top of the screen, this is added via OBS, and does not exist in-game. Furthermore, I have to manually pause, un-pause, and reset it, so it is not 100% accurate, but it does give you rough idea._

</p>
</details>

---

# Changelog

:cl: BramvanZijp
- add: Initiating a grab on someone now starts a 6 second cooldown before you can throw them.
- tweak: The stamina damage taken upon being thrown has been reduced from 120 to 100.