### PR TITLE
Sechud Trait to Dignitary

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -478,7 +478,7 @@ trait-description-CyberEyes =
 
 trait-name-CyberEyesSecurity = Cyber-Eyes: SecHud Module
 trait-description-CyberEyesSecurity =
-    Your Cyber-Eyes have been upgraded to include a built-in Security Hud. Note that this augmentation is considered Contraband
+    Your Cyber-Eyes have been upgraded to include a built-in Security Hud and flash protection. Note that this augmentation is considered Contraband
     for anyone not under the employ of station Security personel, and may be disabled by your employer before dispatch to the station.
 
 trait-name-CyberEyesMedical = Cyber-Eyes: MedHud Module

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -754,7 +754,14 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
+        - type: SolutionScanner
         - type: EyeProtection
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
           damageContainers:
           - Biological
         - type: ShowHealthBars

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -756,12 +756,6 @@
         - type: ShowHealthIcons
         - type: SolutionScanner
         - type: FlashImmunity
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-        - type: ShowHealthIcons
-          damageContainers:
-          - Biological
           damageContainers:
           - Biological
         - type: ShowHealthBars
@@ -1072,13 +1066,7 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
-        - type: ShowJobIcons
-        - type: ShowMindShieldIcons
-        - type: ShowCriminalRecordIcons
-        - type: ShowHealthIcons
         - type: FlashImmunity
-          damageContainers:
-          - Biological
           damageContainers:
           - Biological
         - type: ShowHealthBars

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1066,6 +1066,7 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
+        - type: SolutionScanner
         - type: FlashImmunity
           damageContainers:
           - Biological

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -666,7 +666,7 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
-        - type: EyeProtection
+        - type: FlashImmunity
 
 - type: trait
   id: CyberEyesMedical
@@ -755,7 +755,7 @@
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
         - type: SolutionScanner
-        - type: EyeProtection
+        - type: FlashImmunity
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
@@ -969,7 +969,7 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
-        - type: EyeProtection
+        - type: FlashImmunity
 
 - type: trait
   id: MedicalEyesModule
@@ -1076,6 +1076,7 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
+        - type: FlashImmunity
           damageContainers:
           - Biological
           damageContainers:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1072,7 +1072,12 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
-        - type: EyeProtection
+        - type: ShowJobIcons
+        - type: ShowMindShieldIcons
+        - type: ShowCriminalRecordIcons
+        - type: ShowHealthIcons
+          damageContainers:
+          - Biological
           damageContainers:
           - Biological
         - type: ShowHealthBars

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -651,6 +651,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+        - Command
+        - Dignitary
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -664,6 +666,7 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
+        - type: EyeProtection
 
 - type: trait
   id: CyberEyesMedical
@@ -732,6 +735,7 @@
       departments:
         - Security
         - Command
+        - Dignitary
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -750,6 +754,7 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
+        - type: EyeProtection
           damageContainers:
           - Biological
         - type: ShowHealthBars
@@ -937,6 +942,8 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+        - Command
+        - Dignitary
     - !type:CharacterSpeciesRequirement
       species:
         - IPC
@@ -955,6 +962,7 @@
         - type: ShowJobIcons
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
+        - type: EyeProtection
 
 - type: trait
   id: MedicalEyesModule
@@ -1033,6 +1041,7 @@
       departments:
         - Security
         - Command
+        - Dignitary
     - !type:CharacterSpeciesRequirement
       species:
         - IPC
@@ -1056,6 +1065,7 @@
         - type: ShowMindShieldIcons
         - type: ShowCriminalRecordIcons
         - type: ShowHealthIcons
+        - type: EyeProtection
           damageContainers:
           - Biological
         - type: ShowHealthBars


### PR DESCRIPTION
# Description

Added the Dignitary tag to Sechud Trait and Omnihud Trait
Also added Flash Protection to Sechud and Omnihud

Why? Someone complained about the first one.
SecHud Sunglasses which sec come with in loadout have Flash Protection already. This just improves it from a SecHud to Security Sunglasses. OmniHud gets it because Command gets a Flash loadout item to blind themselves and no sunglasses.

# Changelog

:cl:
- add: Dignitary tag to Cyber-Eyes SecHud and OmniHud
- add: Flash Protection to Cyber-Eyes SecHud and OmniHud