### PR TITLE
Fix for (Gibbing a Skeleton Crashes the Server #1987)

### DIFF
--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -3,12 +3,10 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Gibbing.Events;
-using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.Gibbing.Systems;

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -1,7 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Gibbing.Events;
+using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -138,8 +140,11 @@ public sealed class GibbingSystem : EntitySystem
             {
                 foreach (var container in validContainers)
                 {
-                    foreach (var ent in container.ContainedEntities)
+                    var enteties = container.ContainedEntities.ToList();
+                    while (enteties.Count != 0)
                     {
+                        var ent = enteties.First();
+                            enteties.RemoveAt(0);
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -139,10 +139,8 @@ public sealed class GibbingSystem : EntitySystem
                 foreach (var container in validContainers)
                 {
                     var enteties = container.ContainedEntities.ToList();
-                    while (enteties.Count != 0)
+                    foreach(var ent in enteties)
                     {
-                        var ent = enteties.First();
-                            enteties.RemoveAt(0);
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);


### PR DESCRIPTION
Description: Fix for Gibbing a skeleton crashes the server.
#1987 

Details:
The skeleton contains components in its bodyparts that got auto removed from the BaseContainer on gibbage by events triggered mid loop, causing a modification to the list and a exception to trigger.

The current fix gets a list of the current components so its content won't be effected by removal events, and loop it instead. Leaving it to the internal systems to handle if the provided id is valid or not.

- replaced: BaseContainer with List<> from BaseContainer in loop.