### PR TITLE
Skelly Gib Crash #1987 Pr Fix for Pr #2040

### DIFF
--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -3,12 +3,10 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Gibbing.Events;
-using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.Gibbing.Systems;

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -157,8 +157,8 @@ public sealed class GibbingSystem : EntitySystem
                     foreach(var ent in entities)
                     {
                         GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
-                        ref droppedEntities, launchGibs,
-                        launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                            ref droppedEntities, launchGibs,
+                            launchDirection, launchImpulse, launchImpulseVariance, launchCone);
                     }
                 }
 

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -1,7 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Gibbing.Events;
+using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -138,8 +140,11 @@ public sealed class GibbingSystem : EntitySystem
             {
                 foreach (var container in validContainers)
                 {
-                    foreach (var ent in container.ContainedEntities)
+                    var enteties = container.ContainedEntities.ToList();
+                    while (enteties.Count != 0)
                     {
+                        var ent = enteties.First();
+                            enteties.RemoveAt(0);
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -138,8 +138,8 @@ public sealed class GibbingSystem : EntitySystem
             {
                 foreach (var container in validContainers)
                 {
-                    var enteties = container.ContainedEntities.ToList();
-                    foreach(var ent in enteties)
+                    var entities = container.ContainedEntities.ToList();
+                    foreach(var ent in entities)
                     {
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
@@ -153,8 +153,8 @@ public sealed class GibbingSystem : EntitySystem
             {
                 foreach (var container in validContainers)
                 {
-                    var enteties = container.ContainedEntities.ToList();
-                    foreach (var ent in enteties)
+                    var entities = container.ContainedEntities.ToList();
+                    foreach(var ent in entities)
                     {
                         GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                         ref droppedEntities, launchGibs,

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -139,10 +139,8 @@ public sealed class GibbingSystem : EntitySystem
                 foreach (var container in validContainers)
                 {
                     var enteties = container.ContainedEntities.ToList();
-                    while (enteties.Count != 0)
+                    foreach(var ent in enteties)
                     {
-                        var ent = enteties.First();
-                            enteties.RemoveAt(0);
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -153,11 +153,12 @@ public sealed class GibbingSystem : EntitySystem
             {
                 foreach (var container in validContainers)
                 {
-                    foreach (var ent in container.ContainedEntities)
+                    var enteties = container.ContainedEntities.ToList();
+                    foreach (var ent in enteties)
                     {
                         GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
-                            ref droppedEntities, launchGibs,
-                            launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                        ref droppedEntities, launchGibs,
+                        launchDirection, launchImpulse, launchImpulseVariance, launchCone);
                     }
                 }
 


### PR DESCRIPTION

# Description

Fixed Pull Request.
The previous pull request only contained conversion of basecontainer to list in on of the switch cases. Changed to both to keept it consistant.

This relates to closed PR #2040 
as well as Gibbing Skeleton Crash Bug #1987 

BaseContainer content could be changed mid loop by events.

---

# TODO

- [x] Check if server keeps running on gibbage of skeleton
- [x] Make sure no errors are reported from tests
- [x] Fix previous errors repported by bot. 

---

:cl:
- add: BaseContainer ToList for both Switch cases using it.
