### PR TITLE
Moff Buffs

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -599,3 +599,8 @@ trait-name-Vampirism = Vampirism
 trait-description-Vampirism =
     Your body has evolved to be able to suck blood from beings that contain it and metabolize it into useful compounds.
     You cannot eat normal food, but drinking blood satiates your hunger and thirst, and also improves your health.
+
+trait-name-MothFlight = True Flight
+trait-description-MothFlight =
+    Unlike other mothpeople, your body is light enough and your wings are strong enough to be able to fly under normal gravity.
+    Flight is strenuous, however, requiring your hands to be free and quickly draining your stamina.

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -240,7 +240,7 @@
 - type: entity
   id: ActionToggleFlight
   name: Fly
-  description: Make use of your wings to fly. Beat the flightless bird allegations.
+  description: Make use of your wings to fly. Beat the flightlessness allegations.
   categories: [ HideSpawnMenu ]
   components:
   - type: InstantAction

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -70,9 +70,11 @@
         Heat : 3 #per second, scales with temperature & other constants
   - type: TemperatureSpeed
     thresholds:
-      289: 0.8
-      275: 0.6
-      250: 0.4
+      289: 0.85
+      275: 0.7
+      250: 0.55
+  - type: TemperatureProtection # moff fluff acts as insulation
+    coefficient: 0.5 # less than vulp fur but still significant
   - type: Sprite # sprite again because we want different layer ordering
     noRot: true
     drawdepth: Mobs

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -92,7 +92,7 @@
     - !type:TraitAddComponent
       components:
         - type: entity
-          id: ActionToggleMothFlight
+          id: ActionToggleFlight
           name: Fly
           description: Make use of your wings to fly. Beat the flightless moff allegations.
           categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -107,6 +107,6 @@
       species:
         - Moth
     - !type:CharacterHeightRequirement # big moffs are too heavy to fly
-      max: 150
+      max: 170
     - !type:CharacterWidthRequirement
-      max: 32
+      max: 38

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -91,17 +91,9 @@
   functions:
     - !type:TraitAddComponent
       components:
-        - type: entity
-          id: ActionToggleFlight
-          name: Fly
+        - type: Flight
+          action: ActionToggleFlight
           description: Make use of your wings to fly. Beat the flightless moff allegations.
-          categories: [ HideSpawnMenu ]
-          components:
-          - type: InstantAction
-            checkCanInteract: false
-            icon: { sprite: Interface/Actions/flight.rsi, state: flight_off }
-            iconOn: { sprite : Interface/Actions/flight.rsi, state: flight_on }
-            event: !type:ToggleFlightEvent
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -92,8 +92,6 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
-          action: ActionToggleFlight
-          description: Make use of your wings to fly. Beat the flightless moff allegations.
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -97,6 +97,6 @@
       species:
         - Moth
     - !type:CharacterHeightRequirement # big moffs are too heavy to fly
-      max: 170
+      max: 160
     - !type:CharacterWidthRequirement
-      max: 38
+      max: 35

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -83,3 +83,30 @@
     - !type:CharacterSpeciesRequirement
       species:
         - Shadowkin
+
+- type: trait
+  id: MothFlight
+  category: Physical
+  points: -5
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: entity
+          id: ActionToggleMothFlight
+          name: Fly
+          description: Make use of your wings to fly. Beat the flightless moff allegations.
+          categories: [ HideSpawnMenu ]
+          components:
+          - type: InstantAction
+            checkCanInteract: false
+            icon: { sprite: Interface/Actions/flight.rsi, state: flight_off }
+            iconOn: { sprite : Interface/Actions/flight.rsi, state: flight_on }
+            event: !type:ToggleFlightEvent
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Moth
+    - !type:CharacterHeightRequirement # big moffs are too heavy to fly
+      max: 150
+    - !type:CharacterWidthRequirement
+      max: 32


### PR DESCRIPTION
# Description

Makes some changes to moths to hopefully make them a bit more mechanically interesting. Changes moths' cold slowdowns from the default 80/60/40% speed to 85/70/55% (on top of their lower thresholds) and gives them inherent 50% temperature protection (equivalent to beanies). Also adds True Flight, a 5-point trait exclusive to small moths that grants access to harpy-style flight.

---

# Changelog

:cl:
- add: Added True Flight, a moth-exclusive trait that grants temporary flight
- tweak: Gave moths 50% temperature protection
- tweak: Reduced severity of slowdown due to cold on moths
