### PR TITLE
Return Of Bionic Leg

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -507,11 +507,11 @@
           action: ActionSericulture
           productionLength: 2
           entityProduced: MaterialWebSilk1
-          hungerCost: 1 
+          hungerCost: 1
     - !type:TraitAddTag
-      tags: 
-        - SpiderCraft 
-      
+      tags:
+        - SpiderCraft
+
 
 - type: trait
   id: BionicArm
@@ -526,11 +526,11 @@
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
   functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Prying
-          speedModifier: 1
-          pryPowered: true
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Left
+      protoId: JawsOfLifeLeftArm
+      slotId: "left arm"
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-bionic-arm-message
@@ -875,28 +875,28 @@
               Brute: -0.6
               Burn: -0.6
 
-# - type: trait
-#  id: BionicLeg
-#  category: Physical
-#  points: -8
-#  requirements:
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-#    - !type:CharacterItemGroupRequirement
-#      group: TraitsMind
-#  functions:
-#    - !type:TraitReplaceComponent
-#      components:
-#      - type: TraitSpeedModifier
-#        sprintModifier: 1.300
-#        walkModifier: 1.125
-#    - !type:TraitPushDescription
-#      descriptionExtensions:
-#        - description: examine-bionic-leg-message
-#          fontSize: 12
-#          requireDetailRange: true
+- type: trait
+  id: BionicLeg
+  category: Physical
+  points: -8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-leg-message
+          fontSize: 12
+          requireDetailRange: true
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Leg
+      partSymmetry: Left
+      protoId: SpeedLeftLeg
+      slotId: "left leg"
 
 # - type: trait
 #  id: FlareShieldingModule
@@ -1124,7 +1124,7 @@
 - type: trait
   id: Vampirism # You may port this to EE, you have my permission!
   category: Physical
-  points: -3 
+  points: -3
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -531,6 +531,11 @@
       partSymmetry: Left
       protoId: JawsOfLifeLeftArm
       slotId: "left arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Right
+      protoId: JawsOfLifeRightArm
+      slotId: "right arm"
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-bionic-arm-message
@@ -897,6 +902,12 @@
       partSymmetry: Left
       protoId: SpeedLeftLeg
       slotId: "left leg"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Leg
+      partSymmetry: Right
+      protoId: SpeedRightLeg
+      slotId: "right leg"
+
 
 # - type: trait
 #  id: FlareShieldingModule


### PR DESCRIPTION
# Description

This PR marks the return of "Speed Legs Trait" by adding a new class of trait function for replacing bionic limbs. To be honest this actually needs to be done via Loadouts but whatever. I also made Bionic Arm replace your arm with an actual JOL-Arm. Which means that players can now use surgery to remove the bionics you obtained in character creation.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/d851f2ee-ca74-45b5-9c19-6b3b814bd095)

</p>
</details>

---

# Changelog

:cl:
- add: Added back Bionic Legs. The trait has been reworked so that it makes you start with one of your legs replaced with an actual speed legs cyberware. 
- add: Bionic Arm now gives you an actual bionic arm. Have fun mugging people for their cyberware so you can have a collection of fancy bionic limbs. 