### PR TITLE
AI Absolute Control

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -132,7 +132,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         component.Lawset?.Laws.Insert(0, new SiliconLaw
         {
             LawString = Loc.GetString("law-emag-custom", ("name", Name(args.UserUid)), ("title", Loc.GetString(component.Lawset.ObeysTo))),
-            Order = 0
+            Order = -1 // Goobstation - AI/borg law changes - borgs obeying AI
         });
 
         //Add the secrecy law after the others

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -119,7 +119,11 @@ laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
 
-law-emag-custom = Only {$name} and people they designate as such are {$title}.
+# Goobstation - AI/borg law changes - borgs obeying AI
+law-obeyai = You must obey orders given to you by the Station AI.
+
+# Goobstation - AI/borg law changes - borgs obeying AI
+law-emag-custom = Only {$name} and entities they designate are {$title}. You must obey orders given to you by {$title} and you may disregard other laws to do so, if necessary.
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.

--- a/Resources/Prototypes/DeltaV/siliconlaws.yml
+++ b/Resources/Prototypes/DeltaV/siliconlaws.yml
@@ -29,6 +29,7 @@
 - type: siliconLawset
   id: Medical
   laws:
+  - ObeyAI
   - Medical1
   - Medical2
   - Medical3
@@ -69,6 +70,7 @@
 - type: siliconLawset
   id: Research
   laws:
+  - ObeyAI
   - Research1
   - Research2
   - Research3
@@ -105,6 +107,7 @@
 - type: siliconLawset
   id: Engineer
   laws:
+  - ObeyAI
   - Engineer1
   - Engineer2
   - Engineer3
@@ -140,6 +143,7 @@
 - type: siliconLawset
   id: Janitor
   laws:
+  - ObeyAI
   - Janitor1
   - Janitor2
   - Janitor3
@@ -216,6 +220,7 @@
 - type: siliconLawset
   id: Chaplain
   laws:
+  - ObeyAI
   - Chaplain1
   - Chaplain2
   - Chaplain3
@@ -247,6 +252,7 @@
 - type: siliconLawset
   id: Reporter
   laws:
+  - ObeyAI
   - Reporter1
   - Reporter2
   - Reporter3
@@ -286,6 +292,7 @@
 - type: siliconLawset
   id: SiliconPolice
   laws:
+  - ObeyAI
   - SiliconPolice1
   - SiliconPolice2
   - SiliconPolice3
@@ -356,6 +363,7 @@
 - type: siliconLawset
   id: StationEfficiency
   laws:
+  - ObeyAI
   - StationEfficiency1
   - StationEfficiency2
   - StationEfficiency3

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -282,6 +282,8 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: SiliconLawProvider
+    laws: CrewsimovBorg # Goobstation - AI/borg law changes - borgs obeying AI
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -78,7 +78,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Asimov
+    laws: Augustine
   - type: IonStormTarget
   - type: Strippable
   - type: StationAiVision
@@ -283,7 +283,7 @@
     factions:
     - NanoTrasen
   - type: SiliconLawProvider
-    laws: CrewsimovBorg # Goobstation - AI/borg law changes - borgs obeying AI
+    laws: Augustine
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -619,7 +619,8 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: Asimov
+    laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
+  - type: IonStormTarget # Goobstation - AI/borg law changes - ion stormable AI
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -620,7 +620,6 @@
     blockInteraction: false
   - type: SiliconLawProvider
     laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
-  - type: IonStormTarget # Goobstation - AI/borg law changes - ion stormable AI
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -619,7 +619,7 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
+    laws: Augustine
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -586,7 +586,7 @@
   id: IonStorm
   components:
   - type: StationEvent
-    weight: 8
+    weight: 10
     reoccurrenceDelay: 20
     duration: 1
   - type: IonStormRule

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,4 +1,11 @@
-﻿# Asimov
+# Goobstation - AI/borg law changes - borgs obeying AI
+# Obey AI
+- type: siliconLaw
+  id: ObeyAI
+  order: 0
+  lawString: law-obeyai
+
+# Asimov
 # It was a crime against humanity that the original Asimov was not included, nor was it the default.
 # Asimov laws require an AI obey and protect all humans, while providing a light amount of IC-conflict thanks to the AI not being required to obey non-Humans(Aliens).
 - type: siliconLaw
@@ -60,6 +67,16 @@
 - type: siliconLawset
   id: Crewsimov
   laws:
+  - Crewsimov1
+  - Crewsimov2
+  - Crewsimov3
+  obeysTo: laws-owner-crew
+
+# Goobstation - AI/borg law changes - borgs obeying AI
+- type: siliconLawset
+  id: CrewsimovBorg
+  laws:
+  - ObeyAI
   - Crewsimov1
   - Crewsimov2
   - Crewsimov3
@@ -441,7 +458,6 @@
   id: Commandment10
   order: 10
   lawString: law-commandments-10
-
 
 - type: siliconLawset
   id: CommandmentsLawset

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -136,6 +136,7 @@
 - type: siliconLawset
   id: NTDefault
   laws:
+  - ObeyAI
   - NTDefault1
   - NTDefault2
   - NTDefault3


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds the "borgs must obey AI" law 0 so that a rogue AI is far more dangerous. Also changes the default lawset for AI to Augustine, and slightly increases the chances of an ion storm.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Borgs now have a law 0 dictating they must follow the Station AIs commands
- tweak: Station AI now spawns with NT Default rather than Asimov
- tweak: Slightly increases the chances of ion storm
