### PR TITLE
Fix Improper Offset & BB for N14 Trees

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
@@ -7,17 +7,18 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/floradesert.rsi
     state: cactus
-    offset: 0,0
+    noRot: true
+    offset: 0.5,0.7
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.7,-0.3,-0.4,-1.2"
+            bounds: "0.2,0.2,-0.2,-0.2"
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraDesertCactus
   id: N14FloraDesertTree1
@@ -26,37 +27,38 @@
   components:
   - type: Sprite
     state: joshua_1
+    offset: -0.2,0.9
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.3,-0.3,-0.2,-1.2"
+            bounds: "0.2,0.2,-0.2,-0.2"
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree2
   components:
   - type: Sprite
     state: joshua_2
-    
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree3
   components:
   - type: Sprite
     state: joshua_3
-    
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree4
   components:
   - type: Sprite
     state: joshua_4
-    
+
 - type: entity
   parent: N14FloraDesertCactus
   id: N14FloraTreeBald
@@ -66,16 +68,17 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/trees-ms.rsi
     state: bald
+    offset: 0,1.8
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.2,-1.4,-0.2,-1.8"
+            bounds: "0.2,0.2,-0.2,-0.2"
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraTreeBald
   id: N14FloraTreePine
@@ -91,7 +94,7 @@
       - tree:
           pine_1: ""
           pine_1_alt: ""
-          
+
 - type: entity
   parent: N14FloraTreeBald
   id: N14FloraTreeDead1
@@ -108,7 +111,7 @@
           dead_tree1: ""
           dead_tree2: ""
           dead_tree3: ""
-          
+
 - type: entity
   parent: N14FloraTreeDead1
   id: N14FloraTreeDead2


### PR DESCRIPTION
# Description

Adds proper PhysShapeAabb boundaries and offsets for N14 trees: N14 Cactus, N14 Yucca Tree, N14 Bald Tree, and all childs.
Need this for decorating up Setrina.
Images under media.
Closes #2025

---

# TODO

- [ ] Entire uses of these trees will have to be remapped.

---


<details><summary><h1>Media</h1></summary>
<p>

### Pre
![pre-def](https://github.com/user-attachments/assets/863fd96a-f2b1-458f-8676-6b20ce561659)
![pre-rot1](https://github.com/user-attachments/assets/2dfb1c89-1184-43a8-b955-135ee9c80232)
![pre-rot2](https://github.com/user-attachments/assets/3282ba68-b8aa-4495-b565-a108b1c2aa58)
![pre-rot3](https://github.com/user-attachments/assets/2f53c3a6-3b2f-4464-975a-d8c3d2bc8f5d)


### Post
![post-def](https://github.com/user-attachments/assets/7ae38a8e-6b9a-4f51-a6c3-b3a6bcd7c2f2)
![post-rot1](https://github.com/user-attachments/assets/8a263102-f5a7-4080-b244-b3510ec5399a)

</p>
</details>

## Note
What you will see in the post is that some have moved a few tiles over. That is because of the offset being re-set. So any maps that used them will have to be remapped. When asked ODJ about if any are mapped on EE. They said they aren't so I guess we be fine.

---

# Changelog

:cl:
- tweak: Proper offsets & BB for N14 Trees. Remap if they already were mapped.
