### PR TITLE
Makes Operating Table Buildable From G Menu Instead of Being a Machine

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
@@ -13,18 +13,21 @@
     state: operating_table
   - type: OperatingTable
   # Begin Shitmed Changes
+  # - type: Construction
+  #   graph: Machine
+  #   node: machine
+  #   containers:
+  #    - machine_board
+  #    - machine_parts
+  # - type: Machine
+  #   board: OperatingTableCircuitboard
+  # - type: ContainerContainer
+  #   containers:
+  #     machine_board: !type:Container
+  #     machine_parts: !type:Container
   - type: Construction
-    graph: Machine
-    node: machine
-    containers:
-     - machine_board
-     - machine_parts
-  - type: Machine
-    board: OperatingTableCircuitboard
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
+    graph: bed
+    node: operatingtable
   - type: DeviceList
   - type: DeviceNetwork
     deviceNetId: Wired

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -604,7 +604,7 @@
     - SalvageExpeditionsComputerCircuitboard
     - JukeboxCircuitBoard
     - AutodocCircuitboard # Shitmed Change
-    - OperatingTableCircuitboard # Shitmed Change
+#    - OperatingTableCircuitboard # Shitmed Change
     - MaterialSiloCircuitboard
     - GygaxCentralElectronics
     - GygaxPeripheralsElectronics

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
@@ -42,7 +42,7 @@
               doAfter: 1
             - material: Plastic
               amount: 2
-              doafter: 1
+              doAfter: 1
     - node: bed
       entity: Bed
       edges:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
@@ -33,6 +33,16 @@
             - material: Durathread
               amount: 2
               doAfter: 1
+        - to: operatingtable
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 5
+              doAfter: 1
+            - material: Plastic
+              amount: 2
+              doafter: 1
     - node: bed
       entity: Bed
       edges:
@@ -72,3 +82,18 @@
           steps:
             - tool: Screwing
               doAfter: 1
+    - node: operatingtable
+      entity: OperatingTable
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 5
+            - !type:SpawnPrototype
+              prototype: SheetPlastic1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 1
+

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -631,6 +631,41 @@
   conditions:
     - !type:TileNotBlocked
 
+#medical
+- type: construction
+  id: MedicalBed
+  name: medical bed
+  description: A hospital bed for patients to recover in. Resting here provides fairly slow healing.
+  graph: bed
+  startNode: start
+  targetNode: medicalbed
+  category: construction-category-furniture
+  icon:
+    sprite: Structures/Furniture/furniture.rsi
+    state: bed-MED
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: OperatingTable
+  name: operating table
+  description: Used for advanced medical procedures.
+  graph: bed
+  startNode: start
+  targetNode: operatingtable
+  category: construction-category-furniture
+  icon:
+    sprite: Structures/Furniture/Tables/optable.rsi
+    state: operating_table
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
 #bedroom
 - type: construction
   id: Bed
@@ -643,23 +678,6 @@
   icon:
     sprite: Structures/Furniture/furniture.rsi
     state: bed
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: MedicalBed
-  name: medical bed
-  description: A hospital bed for patients to recover in. Resting here provides fairly slow healing.
-  graph: bed
-  startNode: start
-  targetNode: medicalbed
-  category: construction-category-furniture
-  icon:
-    sprite: Structures/Furniture/furniture.rsi
-    state: bed-MED
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false

--- a/Resources/Prototypes/_Shitmed/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -25,18 +25,18 @@
   - type: MachineBoard
     prototype: AutodocSyndie
 
-- type: entity
-  parent: BaseMachineCircuitboard
-  id: OperatingTableCircuitboard
-  name: operating table machine board
-  description: A machine printed circuit board for an operating table.
-  components:
-  - type: MachineBoard
-    prototype: OperatingTable
-    materialRequirements:
-      Cable: 3
-      Silver: 2
-      Steel: 4
+# - type: entity
+#   parent: BaseMachineCircuitboard
+#   id: OperatingTableCircuitboard
+#   name: operating table machine board
+#   description: A machine printed circuit board for an operating table.
+#   components:
+#   - type: MachineBoard
+#     prototype: OperatingTable
+#     materialRequirements:
+#       Cable: 3
+#       Silver: 2
+#       Steel: 4
 
 - type: entity
   id: MedicalBiofabMachineBoard

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/electronics.yml
@@ -8,12 +8,12 @@
      Glass: 500
      Gold: 100
 
-- type: latheRecipe
-  id: OperatingTableCircuitboard
-  result: OperatingTableCircuitboard
-  category: Circuitry
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 500
-     Gold: 100
+# - type: latheRecipe
+#   id: OperatingTableCircuitboard
+#   result: OperatingTableCircuitboard
+#   category: Circuitry
+#   completetime: 4
+#   materials:
+#      Steel: 100
+#      Glass: 500
+#      Gold: 100


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The operating table is currently a machine that requires a frame and a board to craft.
This is a table. Why does it need this? Why does it have the same cost as an autodoc?

It now instead is buildable from the G menu, for the cost of 5 steel and 2 plastic.
Maints surgeons rejoice!

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://media.discordapp.net/attachments/1323488538750353442/1354227345363304619/image.png?ex=67e485ff&is=67e3347f&hm=3fbe6aea23c9c1143cf5be90fe15de5b81e15a54f9485d2af6b8b651d32abb32&=&format=webp&quality=lossless&width=573&height=257)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: operating tables can now be assembled from the G menu for the cost of 5 steel and 2 plastic