### PR TITLE
Disable Healing Word Revive

### DIFF
--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -173,7 +173,7 @@
             Burn: -10
         rotReduction: 10
         useDelay: 1
-        doRevive: true
+        doRevive: false
         powerName: Healing Word
         popupText: healing-word-begin
         playSound: true


### PR DESCRIPTION
# Description

As it turns out, Healing Word can actually revive people. If we're giving it roundstart as a trait, that should probably be removed.

---

# Changelog

:cl:
- tweak: Made Healing Word no longer revive