### PR TITLE
Shield Blocking/Raising Fixes

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -180,9 +180,10 @@ public sealed partial class BlockingSystem : EntitySystem
             {
                 var intersecting = _lookup.GetLocalEntitiesIntersecting(playerTileRef.Value, 0f);
                 var mobQuery = GetEntityQuery<MobStateComponent>();
+                var physicsQuery = GetEntityQuery<PhysicsComponent>();
                 foreach (var uid in intersecting)
                 {
-                    if (uid != user && mobQuery.HasComponent(uid))
+                    if (uid != user && mobQuery.HasComponent(uid) && physicsQuery.TryGetComponent(uid, out var physicsComp) && physicsComp.CanCollide)
                     {
                         TooCloseError(user);
                         return false;
@@ -224,14 +225,20 @@ public sealed partial class BlockingSystem : EntitySystem
 
     private void CantBlockError(EntityUid user)
     {
-        var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
-        _popupSystem.PopupEntity(msgError, user, user);
+        if (_net.IsServer)
+        {
+            var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
+            _popupSystem.PopupEntity(msgError, user, user);
+        }
     }
 
     private void TooCloseError(EntityUid user)
     {
-        var msgError = Loc.GetString("action-popup-blocking-user-too-close");
-        _popupSystem.PopupEntity(msgError, user, user);
+        if (_net.IsServer)
+        {
+            var msgError = Loc.GetString("action-popup-blocking-user-too-close");
+            _popupSystem.PopupEntity(msgError, user, user);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

When trying to raise your shield, it is only prevented if the mob you share a tile with actually can be collided with physics wise.
This makes it so that an IPC trying to raise their shield is not prevented from doing so by their own brain.
Also made it so only the server sends the tile is blocked popup, to prevent it being spammed several times.

---

# Changelog

:cl: BramvanZijp
- fix: IPCs are no longer prevented from raising their shield due to the tile being blocked by their own brain.
- fix: If you attempt to raise your shield but get blocked by another mob, you will now only get one popup indicating this.
