### PR TITLE
Buff the EG-4 Energy Revolver

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -23,25 +23,26 @@
     - Back
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/erevolver.rsi
   - type: Gun
-    fireRate: 1.5
+    fireRate: 2.5
+    projectileSpeed: 37.50
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
       path: /Audio/DeltaV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 1005
+    startingCharge: 1005
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 100
+    fireCost: 50
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 55
+      fireCost: 50
       name: disabling
       state: disabler
     - proto: BulletEnergyGunMagnum
-      fireCost: 125
+      fireCost: 100
       name: lethal
       state: lethal
   - type: MagazineVisuals
@@ -58,9 +59,11 @@
   - type: Tag
     tags:
     - Sidearm
-  - type: BatterySelfRecharger
+  - type: BatterySelfRecharger # 20 seconds to fully recharge, but it does not do so if it has been fired in the last 5 seconds.
     autoRecharge: true
-    autoRechargeRate: 22
+    autoRechargeRate: 50
+    autoRechargePause: true
+    autoRechargePauseTime: 5
 
 - type: entity
   name: EG-4 energy revolver


### PR DESCRIPTION
# Description

The EG-4 Energy revolver has been buffed in several ways:
Firerate 1.5 > 2.5
Projectile Speed 25 > 37.50
Available Shots 8/18 > 10/20
Recharge rate 22 > 50
Recharge pause 0 > 5 [Nerf] (Means after you stop shooting for 5 seconds, it takes 20 seconds to recharge) 

This is done because as a very expensive loadout exclusive weapon, it should not be outclassed by cheaper and printable (arsenal t1) weapons like the PDW-9, which has a superior fire-rate AND damage, even if that weapon does not self recharge.

---

# Changelog

:cl: BramvanZijp
- tweak: The EG-4 Energy Revolver's fire-rate, projectile speed, power use, and recharge rate have been buffed, however a 5 second delay after shooting the weapon has been added before the weapon actually begins to self recharge.
