### PR TITLE
Moff Buffs 2 & Harpies

### DIFF
--- a/Content.Server/Flight/FlightSystem.cs
+++ b/Content.Server/Flight/FlightSystem.cs
@@ -68,7 +68,7 @@ public sealed class FlightSystem : SharedFlightSystem
             new FlightDoAfterEvent(), uid, target: uid)
             {
                 BlockDuplicate = true,
-                BreakOnMove = true,
+                BreakOnMove = false,
                 BreakOnDamage = true,
                 NeedHand = true
             };

--- a/Content.Shared/Flight/FlightComponent.cs
+++ b/Content.Shared/Flight/FlightComponent.cs
@@ -43,6 +43,13 @@ public sealed partial class FlightComponent : Component
     public float SpeedModifier = 1.15f;
 
     /// <summary>
+    ///     Does the flier need hands free?
+    /// </summary>
+    [DataField]
+    public bool NeedsHands = true;
+
+
+    /// <summary>
     ///     Path to a sound specifier or collection for the noises made during flight
     /// </summary>
     [DataField]

--- a/Content.Shared/Flight/FlightComponent.cs
+++ b/Content.Shared/Flight/FlightComponent.cs
@@ -40,7 +40,7 @@ public sealed partial class FlightComponent : Component
     ///     Speed modifier while in flight
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SpeedModifier = 2.0f;
+    public float SpeedModifier = 1.15f;
 
     /// <summary>
     ///     Path to a sound specifier or collection for the noises made during flight

--- a/Content.Shared/Flight/FlightComponent.cs
+++ b/Content.Shared/Flight/FlightComponent.cs
@@ -40,7 +40,7 @@ public sealed partial class FlightComponent : Component
     ///     Speed modifier while in flight
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SpeedModifier = 1.15f;
+    public float SpeedModifier = 2.0f;
 
     /// <summary>
     ///     Does the flier need hands free?

--- a/Content.Shared/Flight/SharedFlightSystem.cs
+++ b/Content.Shared/Flight/SharedFlightSystem.cs
@@ -44,7 +44,8 @@ public abstract class SharedFlightSystem : EntitySystem
         RaiseNetworkEvent(new FlightEvent(GetNetEntity(uid), component.On, component.IsAnimated));
         _staminaSystem.ToggleStaminaDrain(uid, component.StaminaDrainRate, active, false);
         _movementSpeed.RefreshMovementSpeedModifiers(uid);
-        UpdateHands(uid, active);
+        if (component.NeedsHands == true)
+            UpdateHands(uid, active);
         Dirty(uid, component);
     }
 

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -613,4 +613,4 @@ trait-description-Vampirism =
 trait-name-MothFlight = True Flight
 trait-description-MothFlight =
     Unlike other mothpeople, your body is light enough and your wings are strong enough to be able to fly under normal gravity.
-    Flight is strenuous, however, requiring your hands to be free and quickly draining your stamina.
+    Flight is faster than running; however, it is strenuous and quickly drains your stamina.

--- a/Resources/Prototypes/Body/Parts/harpy.yml
+++ b/Resources/Prototypes/Body/Parts/harpy.yml
@@ -164,6 +164,7 @@
     toolName: "a right arm" # Shitmed Change
     onAdd:
     - type: Flight
+      speedModifier: 1.25
       isLayerAnimated: true
       layer: "/Textures/Mobs/Customization/Harpy/harpy_wings.rsi"
       animationKey: "Flap"

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -105,7 +105,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
-    WeightlessModifier: 1.75
+    weightlessModifier: 1.75
   - type: Inventory
     speciesId: harpy
     templateId: digitigrade

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -105,7 +105,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
-    weightlessModifier: 1.75
+    weightlessModifier: 1.6
   - type: Inventory
     speciesId: harpy
     templateId: digitigrade

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -105,6 +105,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
+    WeightlessModifier: 1.75
   - type: Inventory
     speciesId: harpy
     templateId: digitigrade

--- a/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/harpy.yml
@@ -105,7 +105,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 5.5
     weightlessAcceleration: 2.5
-    weightlessModifier: 1.6
+    weightlessModifier: 1.12
   - type: Inventory
     speciesId: harpy
     templateId: digitigrade

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -53,7 +53,7 @@
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Move around more easily in space.
-    weightlessModifier: 1.35
+    weightlessModifier: 1.1
     weightlessFriction: 2 # makes you turn more sharply while weightless
   - type: Flammable
     damage:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -53,7 +53,7 @@
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Move around more easily in space.
-    weightlessModifier: 1.3
+    weightlessModifier: 1.35
     weightlessFriction: 2 # makes you turn more sharply while weightless
   - type: Flammable
     damage:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -53,6 +53,8 @@
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Move around more easily in space.
+    WeightlessModifier: 1.5
+    WeightlessFriction: 0.15 # half of magboots
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -53,8 +53,8 @@
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Move around more easily in space.
-    WeightlessModifier: 1.5
-    WeightlessFriction: 0.15 # half of magboots
+    weightlessModifier: 1.5
+    weightlessFriction: 0.15 # half of magboots
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -53,8 +53,8 @@
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Move around more easily in space.
-    weightlessModifier: 1.5
-    weightlessFriction: 0.15 # half of magboots
+    weightlessModifier: 1.3
+    weightlessFriction: 2 # makes you turn more sharply while weightless
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -134,6 +134,7 @@
       components:
         - type: Flight
           speedModifier: 1
+          flapInterval: 0.75
           needsHands: false
   requirements:
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -133,7 +133,7 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
-          SpeedModifier: 6 #test value
+          speedModifier: 6 #test value
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -133,7 +133,8 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
-          speedModifier: 6 #test value
+          speedModifier: 1
+          needsHands: false
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -21,7 +21,7 @@
         - Spearmaster
         - WeaponsGeneralist
         - Mystic
-        
+
 
 - type: trait
   id: Spearmaster
@@ -133,9 +133,10 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
+          SpeedModifier: 6 #test value
   requirements:
     - !type:CharacterSpeciesRequirement
       species:
         - Moth
     - !type:CharacterWeightRequirement # big moffs are too heavy to fly
-      max: 35
+      max: 60

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -137,7 +137,5 @@
     - !type:CharacterSpeciesRequirement
       species:
         - Moth
-    - !type:CharacterHeightRequirement # big moffs are too heavy to fly
-      max: 160
-    - !type:CharacterWidthRequirement
+    - !type:CharacterWeightRequirement # big moffs are too heavy to fly
       max: 35

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -133,7 +133,7 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
-          speedModifier: 1
+          speedModifier: 1.09 # gives an effective 20% increase over walking with base moth weightless modifier
           flapInterval: 0.75
           needsHands: false
   requirements:


### PR DESCRIPTION
# Description

Rebalances flight for both harpies and moths to make more sense and be more distinct between them. Even when not flying, both harpies and moths now move slightly faster while weightless than while walking under gravity. Both can also now move during the doafter to take off. Moths additionally gain weightless friction which improves their turning ability while weightless. Moth flight was tweaked to no longer block your hands but give a significantly smaller speed boost to compensate (20% as compared to 40% for harpies). (This was sort of the original idea since moths aren't realistically using their arms to fly.) The requirements for the True Flight trait have also been changed to be based on weight instead of size, allowing for a bit more freedom in body type and opening up potential interactions with weight-modifying traits.

---

# Changelog

:cl:
- tweak: Buffed harpy speed while weightless
- tweak: Buffed moth speed while weightless
- tweak: Allowed movement during the doafter to start flying
- tweak: Made moth flight slower but no longer require open hands
- tweak: Changed moth True Flight requirements to be based on weight
