### PR TITLE
Shadowkin lung fix

### DIFF
--- a/Resources/Prototypes/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/Body/Organs/shadowkin.yml
@@ -27,7 +27,7 @@
     state: ears
 
 - type: entity
-  id: OrganShadowkinCore
+  id: OrganShadowkinCore #Should require half as much oxygen as normal lung IE 18kpa pure oxy -> 9kpa pure oxy
   parent: OrganHumanLungs
   description: "What is this thing?"
   components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Apparently with Glass cannon shadowkin (https://github.com/Simple-Station/Einstein-Engines/pull/1531) , they were suppose to be able to breath safely with half the oxygen other species need, but it seems to have not been implemented. they should be able to survive off of 9 kpa of pure oxy, compared to the 18 most species require
draft PR so bot can help
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Fix the lungs

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Shadowkin lungs now work at half standard pressure.