### PR TITLE
Misc Changes

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -244,7 +244,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 7.5
+    weight: 5
     minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
     startAnnouncement: true
     endAnnouncement: true
@@ -261,7 +261,7 @@
     startAnnouncement: true
     startDelay: 10
     earliestStart: 15
-    weight: 6
+    weight: 3
     duration: 50
   - type: VentCrittersRule
     entries:
@@ -285,7 +285,7 @@
   - type: StationEvent
     startAnnouncement: true
     startDelay: 10
-    weight: 6
+    weight: 3
     duration: 50
   - type: VentCrittersRule
     entries:
@@ -301,7 +301,7 @@
   - type: StationEvent
     startAnnouncement: true
     startDelay: 10
-    weight: 6
+    weight: 3
     duration: 50
   - type: VentCrittersRule
     entries:
@@ -319,7 +319,7 @@
   - type: StationEvent
     startAnnouncement: true
     earliestStart: 15
-    weight: 6
+    weight: 3
     duration: 50
     minimumPlayers: 30
   - type: VentCrittersRule
@@ -412,7 +412,7 @@
     startDelay: 10
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 3
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -433,7 +433,7 @@
     startDelay: 10
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 3
     duration: 60
   - type: VentCrittersRule
     entries:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -281,8 +281,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: RampingStationEventScheduler
-    chaosModifier: 4 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
-    startingChaosRatio: 0.025 # Starts as slow as survival, but quickly ramps up
+    chaosModifier: 5 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
+    startingChaosRatio: 0.1 
     shiftLengthModifier: 2.5
 
 - type: entity

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -720,13 +720,14 @@
        jobs:
          - Brigmedic
 
-- type: loadout
-  id: LoadoutItemPAI
-  category: Items
-  cost: 3
-  canBeHeirloom: true
-  items:
-    - PersonalAI
+ # 5 zillion ghostroles, more people will take them if theyre less common.
+ # - type: loadout
+ # id: LoadoutItemPAI
+ # category: Items
+ # cost: 3
+ # canBeHeirloom: true
+ # items:
+ #   - PersonalAI
 
 - type: loadout
   id: LoadoutItemCrayonBox

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -73,17 +73,16 @@
   - SubGamemodesRule
   - LavalandStormScheduler # Lavaland Change
 
-# - type: gamePreset
-#  id: Greenshift
-#  alias:
-#  - greenshift
-#  - shittersafarideluxeedition
-#  name: greenshift-title
-#  showInVote: false #4boring4vote
-#  description: greenshift-description
-# rules:
-#  - BasicRoundstartVariation
-#  - LavalandStormScheduler # Lavaland Change
+- type: gamePreset
+  id: Greenshift
+  alias:
+  - greenshift
+  - shittersafarideluxeedition
+  name: greenshift-title
+  showInVote: true
+  description: greenshift-description
+  rules:
+  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Secret

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -73,17 +73,17 @@
   - SubGamemodesRule
   - LavalandStormScheduler # Lavaland Change
 
-- type: gamePreset
-  id: Greenshift
-  alias:
-  - greenshift
-  - shittersafarideluxeedition
-  name: greenshift-title
-  showInVote: false #4boring4vote
-  description: greenshift-description
-  rules:
-  - BasicRoundstartVariation
-  - LavalandStormScheduler # Lavaland Change
+# - type: gamePreset
+#  id: Greenshift
+#  alias:
+#  - greenshift
+#  - shittersafarideluxeedition
+#  name: greenshift-title
+#  showInVote: false #4boring4vote
+#  description: greenshift-description
+# rules:
+#  - BasicRoundstartVariation
+#  - LavalandStormScheduler # Lavaland Change
 
 - type: gamePreset
   id: Secret

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -203,3 +203,20 @@
   - BasicStationEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
+
+- type: gamePreset
+  id: Changeling
+  alias:
+  - Changeling
+  - Changelings
+  - Ling
+  - Lings
+  name: changeling-gamemode-title
+  description: changeling-gamemode-description
+  showInVote: false
+  rules:
+  - Changeling
+  - SubGamemodesRule
+  - BasicStationEventScheduler
+  - BasicRoundstartVariation
+  - LavalandStormScheduler # Lavaland Change


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Decreases weights on various animal spawn events so that interesting stuff actually happens again, removes pAI from loadout so having one is actually cool and there aren't 5 zillion ghost roles, makes greenshift vote only so it can be used for events but doesn't make rounds boring by getting a greenshift with no admins on, makes hellshift more violent (hopefully), and adds a roundstart event for changelings so they can actually spawn.

---
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Changelings can now spawn as a game mode. don't know why they couldn't before.
- remove: Greenshift can no longer randomly happen; it has to be voted for.
- remove: No more loadout pAIs
- tweak: Animal spawn events are rarer
- tweak: Random Sentience event is rarer
- tweak: Hellshift should be more hellish

