### PR TITLE
Delay Passport Spawn so It Isn't Placed in a Deleted Bag

### DIFF
--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -61,6 +61,8 @@ public sealed class LoadoutSystem : EntitySystem
             _playTimeTracking.GetTrackerTimes(ev.Player),
             ev.Player.ContentData()?.Whitelisted ?? false,
             jobProto: job);
+
+        RaiseLocalEvent(ev.Mob, new PlayerLoadoutAppliedEvent(ev.Mob, ev.Player, ev.JobId, ev.LateJoin, ev.Silent, ev.JoinOrder, ev.Station, ev.Profile), broadcast: true);
     }
 
 

--- a/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
+++ b/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
@@ -8,7 +8,9 @@ using Content.Shared.Paint;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.Station;
+using JetBrains.Annotations;
 using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
@@ -206,4 +208,42 @@ public sealed partial class LoadoutPreference : Loadout
         string? customColorTint = null,
         bool? customHeirloom = null
     ) : base(loadoutName, customName, customDescription, customColorTint, customHeirloom) { }
+}
+
+/// <summary>
+///     Event raised both directed and broadcast when a player has been spawned and then given a Loadout.
+///     Most useful to delay actions that should happen on spawn for when the loadouts have been handled.
+/// </summary>
+[PublicAPI]
+public sealed class PlayerLoadoutAppliedEvent : EntityEventArgs
+{
+    public EntityUid Mob { get; }
+    public ICommonSession Player { get; }
+    public string? JobId { get; }
+    public bool LateJoin { get; }
+    public bool Silent { get; }
+    public EntityUid Station { get; }
+    public HumanoidCharacterProfile Profile { get; }
+
+    // Ex. If this is the 27th person to join, this will be 27.
+    public int JoinOrder { get; }
+
+    public PlayerLoadoutAppliedEvent(EntityUid mob,
+        ICommonSession player,
+        string? jobId,
+        bool lateJoin,
+        bool silent,
+        int joinOrder,
+        EntityUid station,
+        HumanoidCharacterProfile profile)
+    {
+        Mob = mob;
+        Player = player;
+        JobId = jobId;
+        LateJoin = lateJoin;
+        Silent = silent;
+        Station = station;
+        Profile = profile;
+        JoinOrder = joinOrder;
+    }
 }

--- a/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
@@ -1,9 +1,9 @@
 using Content.Shared._EE.Contractors.Components;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Clothing.Loadouts.Systems;
 using Content.Shared.Database;
 using Content.Shared.Examine;
-using Content.Shared.GameTicking;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
@@ -11,7 +11,6 @@ using Content.Shared.Item;
 using Content.Shared.Preferences;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
-using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -35,7 +34,7 @@ public class SharedPassportSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PassportComponent, UseInHandEvent>(OnUseInHand);
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<PlayerLoadoutAppliedEvent>(OnPlayerLoadoutApplied);
         SubscribeLocalEvent<PassportComponent, ExaminedEvent>(OnExamined);
     }
 
@@ -63,7 +62,7 @@ public class SharedPassportSystem : EntitySystem
             45);
     }
 
-    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
+    private void OnPlayerLoadoutApplied(PlayerLoadoutAppliedEvent ev)
     {
         if (Deleted(ev.Mob) || !Exists(ev.Mob))
             return;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fix the passport not spawning when your loadout replaces your bag by waiting for loadouts to be applied first

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: fix passports not spawning when your loadout replaces your bag
