### PR TITLE
Tweak IPC's Damage Resistances to Reduce Their Extreme Weaknesses

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -338,5 +338,9 @@
   coefficients:
     Poison: 0
     Cold: 0.2
-    Heat: 2
-    Shock: 2.5
+    Heat: 1.25
+    Shock: 1.5
+    Ion: 1 # They are already the only player species to take this damage at all, so no need to compound that weakness
+    Brute: 1
+    Slash: 0.9
+    Piercing: 0.9

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -338,9 +338,9 @@
   coefficients:
     Poison: 0
     Cold: 0.2
-    Heat: 1.25
-    Shock: 1.5
+    Heat: 1
+    Shock: 2
     Ion: 1 # They are already the only player species to take this damage at all, so no need to compound that weakness
     Blunt: 1
-    Slash: 0.9
-    Piercing: 0.9
+    Slash: 1
+    Piercing: 1

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -341,6 +341,6 @@
     Heat: 1.25
     Shock: 1.5
     Ion: 1 # They are already the only player species to take this damage at all, so no need to compound that weakness
-    Brute: 1
+    Blunt: 1
     Slash: 0.9
     Piercing: 0.9


### PR DESCRIPTION
# Description

Title:
Heat damage multiplier: 2 > 1
Shock damage Multiplier: 2.5 > 2

While I get that in terms of UTILITY, IPCs are in a powerfull state, they suck at combat. EMPs, double heat, 2.5x shock, and now a dedicated ion damage type is being added to further nerf IPCs in combat, so this is going to become neccesary.

The new modifier set is still a net negative, but nowhere near as severe as it was before.

---

# Changelog

:cl: BramvanZijp
- tweak: Tweaked IPC's damage resistances to no longer take double heat damage, and slightly reduce their shock weakness.
