### PR TITLE
Armor Rebalancing Part 1

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/base_clothingeyes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/base_clothingeyes.yml
@@ -10,3 +10,15 @@
   - type: Item
     size: Small
     storedRotation: -90
+
+- type: entity
+  abstract: true
+  id: BallisticGlasses
+  components:
+  - type: Reflect # Ballistic glasses are any glasses that have a small chance to deflect projectiles
+    spread: 270
+    reflectProb: 0.01
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -208,7 +208,7 @@
     protectionTime: 5
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BallisticGlasses]
   id: ClothingEyesGlassesSecurity
   name: security glasses
   description: Upgraded sunglasses that provide flash immunity and a security HUD.
@@ -377,7 +377,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, BallisticGlasses]
   id: ClothingEyesGlassesMercenary
   name: mercenary glasses
   description: Glasses made for combat, to protect the eyes from bright blinding flashes.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -83,7 +83,7 @@
     sprite: Clothing/Eyes/Hud/epi.rsi
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, BallisticGlasses] # ODJ requested this for reasons he did not clarify.
   id: ClothingEyesHudBeer
   name: beer goggles
   description: A pair of sunHud outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion.
@@ -235,7 +235,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BallisticGlasses]
   id: ClothingEyesHudSyndicate
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
@@ -247,7 +247,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons]
+  parent: [ClothingEyesBase, ShowSecurityIcons, BallisticGlasses]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate agent visor
   description: The Syndicate Agent's professional heads-up display, designed for quick diagnosis of their team's status.

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -222,6 +222,13 @@
     slots:
     - Hair
     - Snout
+  - type: Reflect
+    spread: 270
+    reflectProb: 0.01
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -3,7 +3,7 @@
 
 #Basic Helmet (Security Helmet)
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BallisticGlasses]
   id: ClothingHeadHelmetBasic
   name: helmet
   description: Standard security gear. Protects the head from impacts.
@@ -38,7 +38,7 @@
 
 #SWAT Helmet
 - type: entity
-  parent: [ClothingHeadBase, ClothingHeadEVAHelmetBase]
+  parent: [ClothingHeadBase, ClothingHeadEVAHelmetBase, BallisticGlasses]
   id: ClothingHeadHelmetSwat
   name: SWAT helmet
   description: An extremely robust helmet, commonly used by paramilitary forces. This one has the Nanotrasen logo emblazoned on the top.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -100,7 +100,7 @@
   parent: ClothingOuterArmorBasic
   id: ClothingOuterArmorBulletproof
   name: bulletproof vest
-  description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
+  description: A Type III heavy bulletproof vest that provides superb protection against bullets, but is lackluster against anything else.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
@@ -108,13 +108,13 @@
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
   - type: Armor
     modifiers:
+      flatReductions:
+        Piercing: 4
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.4
-        Heat: 0.9
-  - type: ExplosionResistance
-    damageCoefficient: 0.80
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.5
+        Heat: 0.95
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing ]
@@ -200,13 +200,15 @@
     sprite: Clothing/OuterClothing/Armor/armor_reflec.rsi
   - type: Armor
     modifiers:
+      flatReductions:
+        Heat: 3
       coefficients:
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
+        Heat: 0.7
   - type: Reflect
-    reflectProb: 1
+    reflectProb: 0.33
     innate: true # armor grants a passive shield that does not require concentration to maintain
     reflects:
       - Energy
@@ -260,7 +262,7 @@
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterArmorHosSamurai
   name: daimyō's tousei gusoku
-  description: A tousei gusoku fashioned for the Head of Security, it's primarily for ceremonial use, lacking pockets and gauntlets to make handling firearms easier, but still provides suitable protection for the Head of Security. Pairs excellently with a Katana sheath or tuncheon! 
+  description: A tousei gusoku fashioned for the Head of Security, it's primarily for ceremonial use, lacking pockets and gauntlets to make handling firearms easier, but still provides suitable protection for the Head of Security. Pairs excellently with a Katana sheath or tuncheon!
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/hosamurai.rsi

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -213,6 +213,13 @@
     requiresWorn: true
     distanceWalking: 2
     distanceSprinting: 3
+  - type: Reflect
+    spread: 270
+    reflectProb: 0.03
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy
 
 - type: entity
   abstract: true
@@ -249,6 +256,13 @@
   - type: Clothing
     equipDelay: 4 # For stuff like standard Tacsuits and Heavy Hardsuits.
     unequipDelay: 4
+  - type: Reflect
+    spread: 270
+    reflectProb: 0.04
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy
 
 - type: entity
   abstract: true
@@ -285,6 +299,13 @@
   - type: Clothing
     equipDelay: 5 # For stuff like "Heavy" Tacsuits.
     unequipDelay: 5
+  - type: Reflect
+    spread: 270
+    reflectProb: 0.05
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -782,10 +782,14 @@
     damageCoefficient: 0.1
   - type: Armor
     modifiers:
+      flatReductions:
+        Blunt: 3
+        Piercing: 3
+        Slash: 3
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.4
+        Blunt: 0.4
+        Slash: 0.4
+        Piercing: 0.3
         Heat: 0.4
         Radiation: 0.75
         Caustic: 0.6
@@ -798,7 +802,7 @@
     coefficient: 1 # Replaced with HEAVY modify stun time and slow protection
   - type: Reflect
     spread: 270
-    reflectProb: 0.25
+    reflectProb: 0.45
     innate: true
     reflects:
       - Energy

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -779,24 +779,34 @@
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.1
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
+        Blunt: 0.35
+        Slash: 0.35
+        Piercing: 0.4
+        Heat: 0.4
+        Radiation: 0.75
+        Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.65
+    sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
   - type: StaminaDamageResistance
-    coefficient: 0.5 # 50%
+    coefficient: 1 # Replaced with HEAVY modify stun time and slow protection
+  - type: Reflect
+    spread: 270
+    reflectProb: 0.25
+    innate: true
+    reflects:
+      - Energy
+      - NonEnergy
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
+  - type: ClothingModifyStunTime # Goobstation
+    modifier: 0.2
 
 #Wizard Hardsuit
 - type: entity


### PR DESCRIPTION
# Description

Me and ODJ have been cooking. This PR introduces some fun new mechanics that'll make gunfights a bit more interesting, by introducing a small deflection chance for full body armor, and some accessories(such as ballistic glasses, helmets), which makes it so that projectiles have a very small chance to be deflected rather than taken. Deflection adds a lot more of a cinematic and sometimes comedic feel to a fight, as it can cause unintended things to happen regardless of how good you are at shooting. For example, firing an anti-material rifle at a person, only for the bullet to (un)fortunately deflect off the person by pure chance and vaporize a clown. 

To really show off this system, we comprehensively rebalanced the Juggernaut Suit. It no longer has 90% reduction to all damage, and instead has some flat reductions to provide significant protection from shotguns & shrapnel, as well as a monstrously high 45% deflect chance. For insane comedy, try firing birdshot with a kammerer at someone wearing a juggsuit, you won't be disappointed. 

Every hardsuit in the game has a baseline 3% deflect chance. Ballistic glasses in general have a 1% deflect. And helmets in general have a 1% deflect. The typical "Heavy" suits have a 5% deflect, while most Tacsuits have a 4% deflect. 

# TODO

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/535e33a8-3c7b-44c9-a1b9-b99a9a9af0d7

</p>
</details>

# Changelog

:cl:
- add: Added a 3% "Deflect" chance to all hardsuits. Each projectile fired at a hardsuit has a small chance to be "harmlessly" deflected into something else. Have fun if that something else is an unsuspecting clown.
- tweak: Comprehensively rebalanced the Juggernaut Suit around having a monstrous 45% projectile deflection chance. Go ahead. Shoot it with birdshot. You won't be disappointed in the visuals. 
