### PR TITLE
Let Foxes and Dogs Track Scents

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
@@ -66,6 +66,7 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: ScentTracker
 
 - type: entity
   name: security dog

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2846,6 +2846,7 @@
   - type: RandomBark
     barkType: fox
     barkMultiplier: 0.5 # Talkative <3
+  - type: ScentTracker
 
 - type: entity
   name: corgi
@@ -2916,6 +2917,7 @@
     - VimPilot
   - type: RandomBark
     barkType: dog
+  - type: ScentTracker
 
 - type: entity
   name: corrupted corgi

--- a/Resources/Prototypes/Entities/Mobs/NPCs/dogs.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/dogs.yml
@@ -89,6 +89,7 @@
     understands:
     - Dog
     - TauCetiBasic
+  - type: ScentTracker
 
 - type: entity
   parent: MobPibble


### PR DESCRIPTION
# Description

I thought it was weird that foxes and dogs can't track scents like Vulpines, so I fixed it. That's all there is really. I'm just surprised this wasn't done when Vulpines initially got the ability, it just makes sense.

This makes it so every dog and fox have the ability to track scents when controlled by a player. This includes Laika, Ians, Renault, Siobhan, Waltuh, and Cerberus (since it extends MobCorgi), as well as all foxes and dogs purchased from cargo.

# Changelog

:cl: PsychoLogik (musicman928)
- tweak: Dogs and Foxes can now track scents (Cerberus included)