### PR TITLE
sunglasses are more expensive

### DIFF
--- a/Resources/Locale/en-US/loadouts/generic/eyes.ftl
+++ b/Resources/Locale/en-US/loadouts/generic/eyes.ftl
@@ -8,8 +8,8 @@ loadout-description-LoadoutEyesBlindfold = Why would you want this?
 loadout-name-LoadoutEyesBlindfoldColor = blindfold (colorable)
 loadout-description-LoadoutEyesBlindfoldColor = Why would you want this? At least it comes in a wide assortment of colors.
 
-loadout-name-LoadoutEyesGlassesCheapSunglassesAviator = cheap aviators (colorable)
-loadout-name-LoadoutEyesGlassesSunglassesAviator = aviators (colorable)
+loadout-name-LoadoutEyesGlassesCheapSunglassesAviator = aviators (colorable)
+loadout-name-LoadoutEyesGlassesSunglassesAviator = shielded aviators (colorable)
 
 loadout-name-LoadoutItemBlindfoldFake = "blind"fold
 loadout-description-LoadoutItemBlindfoldFake = This product may not work as advertised.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -182,8 +182,8 @@
 - type: entity
   parent: ClothingEyesBase
   id: ClothingEyesGlassesCheapSunglasses
-  name: cheap sunglasses
-  description: A pair of black sunglasses. Doesn't block light well, more of an accessory than something useful.
+  name: sunglasses
+  description: A pair of black sunglasses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi
@@ -200,8 +200,8 @@
 - type: entity
   parent: ClothingEyesGlassesCheapSunglasses
   id: ClothingEyesGlassesSunglasses
-  name: sun glasses
-  description: A pair of black sunglasses.
+  name: shielded sunglasses
+  description: A pair of black sunglasses. These ones are specially made to protect the eye from blinding flashes of light.
   components:
   - type: FlashImmunity
   - type: EyeProtection
@@ -253,8 +253,8 @@
 - type: entity
   parent: ClothingEyesGlassesCheapSunglasses
   id: ClothingEyesGlassesCheapSunglassesAviator
-  name: cheap aviators
-  description: A pair of replica sunglasses. Doesn't block light well, more of an accessory than something useful.
+  name: aviators
+  description: A pair of designer sunglasses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/aviators.rsi
@@ -267,8 +267,8 @@
 - type: entity
   parent: ClothingEyesGlassesSunglasses
   id: ClothingEyesGlassesSunglassesAviator
-  name: aviators
-  description: A pair of designer sunglasses.
+  name: shielded aviators
+  description: A pair of designer sunglasses. These ones are specially made to protect the eye from blinding flashes of light.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/aviators.rsi
@@ -295,8 +295,8 @@
 - type: entity
   parent: ClothingEyesGlassesCheapSunglasses
   id: ClothingEyesGlassesCheapSunglassesBig
-  name: cheap big sunglasses
-  description: A pair of black sunglasses with big lenses. Doesn't block light well, more of an accessory than something useful.
+  name: big sunglasses
+  description: A pair of black sunglasses with big lenses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses_big.rsi
@@ -309,8 +309,8 @@
 - type: entity
   parent: ClothingEyesGlassesSunglasses
   id: ClothingEyesGlassesSunglassesBig
-  name: big sunglasses
-  description: A pair of black sunglasses with big lenses.
+  name: big shielded sunglasses
+  description: A pair of black sunglasses with big lenses. These ones are specially made to protect the eye from blinding flashes of light.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses_big.rsi
@@ -337,8 +337,8 @@
 - type: entity
   parent: ClothingEyesGlassesCheapSunglasses
   id: ClothingEyesGlassesCheapSunglassesVisor
-  name: cheap visor sunglasses
-  description: A pair of replica visor sunglasses. Doesn't block light well, more of an accessory than something useful.
+  name: visor sunglasses
+  description: A pair of visor sunglasses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses_visor.rsi
@@ -351,8 +351,8 @@
 - type: entity
   parent: ClothingEyesGlassesSunglasses
   id: ClothingEyesGlassesSunglassesVisor
-  name: visor sunglasses
-  description: A pair of visor sunglasses.
+  name: shielded visor sunglasses
+  description: A pair of visor sunglasses. These ones are specially made to protect the eye from blinding flashes of light.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses_visor.rsi

--- a/Resources/Prototypes/Loadouts/Generic/eyes.yml
+++ b/Resources/Prototypes/Loadouts/Generic/eyes.yml
@@ -183,7 +183,7 @@
 - type: loadout
   id: LoadoutItemSunglasses
   category: Eyes
-  cost: 3
+  cost: 7
   exclusive: true
   items:
     - ClothingEyesGlassesSunglasses
@@ -194,7 +194,7 @@
 - type: loadout
   id: LoadoutEyesGlassesSunglassesAviator
   category: Eyes
-  cost: 3
+  cost: 7
   exclusive: true
   customColorTint: true
   items:
@@ -206,7 +206,7 @@
 - type: loadout
   id: LoadoutEyesGlassesSunglassesBig
   category: Eyes
-  cost: 3
+  cost: 7
   exclusive: true
   items:
     - ClothingEyesGlassesSunglassesBig
@@ -217,7 +217,7 @@
 - type: loadout
   id: LoadoutEyesGlassesSunglassesVisor
   category: Eyes
-  cost: 3
+  cost: 7
   exclusive: true
   items:
     - ClothingEyesGlassesSunglassesVisor


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR changes the sunglasses to be more expensive in loadouts, as I find the fact that they are as cheap as they are to be very unbalanced. As per the suggestion of Parky, I have also renamed the default such that it specifies ones that are rated for flash protection.

---
<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![sunglasses](https://github.com/user-attachments/assets/fafa0734-d6ee-4c9b-a003-6c9c21072c7c)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: sunglasses with flash protection are more expensive in the loadouts
- tweak: sunglasses are either "default" or "shielded" rather than "cheap" or "standard." the description has also been changed to reflect this
