### PR TITLE
IPC Brain Fixes

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/ipc.yml
+++ b/Resources/Prototypes/Body/Prototypes/ipc.yml
@@ -18,7 +18,7 @@
       - left leg
       - head
       organs:
-        brain: PositronicBrain
+        posibrain: PositronicBrain
         heart: OrganIPCPump
     right arm:
       part: RightArmIPC

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -52,6 +52,8 @@
   - type: LanguageKnowledge
     speaks: [TauCetiBasic, RobotTalk]
     understands: [TauCetiBasic, RobotTalk]
+  - type: Organ # Estacao Pirata - IPCs
+    slotId: posibrain
 
 - type: entity
   parent: MMI
@@ -131,6 +133,7 @@
       guides:
       - Cyborgs
     - type: Organ # Estacao Pirata - IPCs
+      slotId: posibrain
     - type: LanguageSpeaker
     - type: LanguageKnowledge
       speaks: [RobotTalk]

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -52,7 +52,7 @@
   - type: LanguageKnowledge
     speaks: [TauCetiBasic, RobotTalk]
     understands: [TauCetiBasic, RobotTalk]
-  - type: Organ # Estacao Pirata - IPCs
+  - type: Organ
     slotId: posibrain
 
 - type: entity
@@ -98,6 +98,7 @@
       stopSearchVerbPopup: positronic-brain-stopped-searching
     - type: BlockMovement
     - type: Examiner
+    - type: Brain # hopefully this doesn't break everything
     - type: BorgBrain
     - type: IntrinsicRadioReceiver
     - type: IntrinsicRadioTransmitter

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -52,8 +52,6 @@
   - type: LanguageKnowledge
     speaks: [TauCetiBasic, RobotTalk]
     understands: [TauCetiBasic, RobotTalk]
-  - type: Organ
-    slotId: posibrain
 
 - type: entity
   parent: MMI

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -389,6 +389,17 @@
     part: Torso
 
 - type: entity
+  parent: SurgeryRemoveBrainTorso
+  id: SurgeryRemovePosibrain
+  name: Remove Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOrganCondition
+    organ:
+    - type: BorgBrain
+    slotId: posibrain
+
+- type: entity
   parent: SurgeryBase
   id: SurgeryInsertBrain
   name: Insert Brain
@@ -417,6 +428,17 @@
   components:
   - type: SurgeryPartCondition
     part: Torso
+
+- type: entity
+  parent: SurgeryInsertBrainTorso
+  id: SurgeryInsertPosibrain
+  name: Insert Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOrganCondition
+    organ:
+    - type: BorgBrain
+    slotId: posibrain
 
 - type: entity
   parent: SurgeryBase


### PR DESCRIPTION
# Description

Fixes IPCs having their brains 'wiped' upon being gibbed and allows IPC brains to be surgically removed and inserted.
(I think what was happening was that you were never considered to be controlling the posibrain since it wasn't tagged as a brain?) This incidentally happened as part of me trying to allow you to put MMIs in IPCs, so look forward to that.

---

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/8e237104-9f2d-402a-a65b-e1052ce6bae1

You can see the lights on the freshly liberated posibrain indicating that it's active.

</p>
</details>

---

# Changelog

:cl:
- fix: Fixed IPCs losing control of their brain when gibbed
- fix: Fixed IPC brains being unable to be surgically inserted/removed
