### PR TITLE
Coat and Scrubs Restricted to Respective Employers

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -31,6 +31,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Client.Utility;
 using Robust.Client.Player;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
@@ -38,6 +39,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using CCVars = Content.Shared._EE.Contractors.CCVars.CCVars;
 using Direction = Robust.Shared.Maths.Direction;
 
 namespace Content.Client.Lobby.UI
@@ -257,30 +259,37 @@ namespace Content.Client.Lobby.UI
 
             #region Contractors
 
-            Background.Orphan();
-            CTabContainer.AddTab(Background, Loc.GetString("humanoid-profile-editor-background-tab"));
-
-            RefreshNationalities();
-            RefreshEmployers();
-            RefreshLifepaths();
-
-            NationalityButton.OnItemSelected += args =>
+            if(_cfgManager.GetCVar(CCVars.ContractorsEnabled))
             {
-                NationalityButton.SelectId(args.Id);
-                SetNationality(_nationalies[args.Id].ID);
-            };
+                Background.Orphan();
+                CTabContainer.AddTab(Background, Loc.GetString("humanoid-profile-editor-background-tab"));
 
-            EmployerButton.OnItemSelected += args =>
-            {
-                EmployerButton.SelectId(args.Id);
-                SetEmployer(_employers[args.Id].ID);
-            };
+                RefreshNationalities();
+                RefreshEmployers();
+                RefreshLifepaths();
 
-            LifepathButton.OnItemSelected += args =>
+                NationalityButton.OnItemSelected += args =>
+                {
+                    NationalityButton.SelectId(args.Id);
+                    SetNationality(_nationalies[args.Id].ID);
+                };
+
+                EmployerButton.OnItemSelected += args =>
+                {
+                    EmployerButton.SelectId(args.Id);
+                    SetEmployer(_employers[args.Id].ID);
+                };
+
+                LifepathButton.OnItemSelected += args =>
+                {
+                    LifepathButton.SelectId(args.Id);
+                    SetLifepath(_lifepaths[args.Id].ID);
+                };
+            }
+            else
             {
-                LifepathButton.SelectId(args.Id);
-                SetLifepath(_lifepaths[args.Id].ID);
-            };
+                Background.Visible = false;
+            }
 
             #endregion Contractors
 

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -39,7 +39,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using CCVars = Content.Shared._EE.Contractors.CCVars.CCVars;
+using Content.Shared._EE.Contractors.CCVars;
 using Direction = Robust.Shared.Maths.Direction;
 
 namespace Content.Client.Lobby.UI

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -39,7 +39,6 @@ using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared._EE.Contractors.CCVars;
 using Direction = Robust.Shared.Maths.Direction;
 
 namespace Content.Client.Lobby.UI

--- a/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._EE.Contractors.Prototypes;
+using Content.Shared.CCVar;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;

--- a/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
@@ -7,6 +8,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -70,6 +72,12 @@ public sealed class EmployerSystem : EntitySystem
     /// </summary>
     public void AddEmployer(EntityUid uid, EmployerPrototype employerPrototype)
     {
+        if (!_configuration.GetCVar(CCVars.ContractorsEnabled) ||
+            !_configuration.GetCVar(CCVars.ContractorsTraitFunctionsEnabled))
+        {
+            return;
+        }
+
         foreach (var function in employerPrototype.Functions)
             function.OnPlayerSpawn(uid, _componentFactory, EntityManager, _serialization);
     }

--- a/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/EmployerSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
-using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;

--- a/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
@@ -7,6 +8,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -70,6 +72,12 @@ public sealed class LifepathSystem : EntitySystem
     /// </summary>
     public void AddLifepath(EntityUid uid, LifepathPrototype lifepathPrototype)
     {
+        if (!_configuration.GetCVar(CCVars.ContractorsEnabled) ||
+            !_configuration.GetCVar(CCVars.ContractorsTraitFunctionsEnabled))
+        {
+            return;
+        }
+
         foreach (var function in lifepathPrototype.Functions)
             function.OnPlayerSpawn(uid, _componentFactory, EntityManager, _serialization);
     }

--- a/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._EE.Contractors.Prototypes;
+using Content.Shared.CCVar;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;

--- a/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
-using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;

--- a/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._EE.Contractors.Prototypes;
+using Content.Shared.CCVar;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;

--- a/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
-using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;

--- a/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Shared._EE.Contractors.CCVars;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Customization.Systems;
 using Content.Shared.GameTicking;
@@ -7,6 +8,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -70,6 +72,12 @@ public sealed class NationalitySystem : EntitySystem
     /// </summary>
     public void AddNationality(EntityUid uid, NationalityPrototype nationalityPrototype)
     {
+        if (!_configuration.GetCVar(CCVars.ContractorsEnabled) ||
+            !_configuration.GetCVar(CCVars.ContractorsTraitFunctionsEnabled))
+        {
+            return;
+        }
+
         foreach (var function in nationalityPrototype.Functions)
             function.OnPlayerSpawn(uid, _componentFactory, EntityManager, _serialization);
     }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -68,6 +68,13 @@ namespace Content.Shared.Roles
         public bool CanBeAntag { get; private set; } = true;
 
         /// <summary>
+        /// Used by Contractors to determine if a given job should have a passport
+        /// This should be disabled for Borgs and Station AI, for example.
+        /// </summary>
+        [DataField("canHavePassport")]
+        public bool CanHavePassport { get; private set; } = true;
+
+        /// <summary>
         /// Nyano/DV: For e.g. prisoners, they'll never use their latejoin spawner.
         /// </summary>
         [DataField("alwaysUseSpawner")]

--- a/Content.Shared/_EE/Contractors/CCVars/CCVars.Contractors.cs
+++ b/Content.Shared/_EE/Contractors/CCVars/CCVars.Contractors.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._EE.Contractors.CCVars;
+
+/// <summary>
+/// Contains all the CVars used by Contractors.
+/// </summary>
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Will CharacterNationalityRequirements, CharacterEmployerRequirements and CharacterLifepathRequirements restrict other things?
+    /// </summary>
+    public static readonly CVarDef<bool> ContractorsCharacterRequirementsEnabled =
+        CVarDef.Create("contractors.character_requirements", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Will CharacterNationalityRequirements, CharacterEmployerRequirements and CharacterLifepathRequirements execute their functions?
+    /// </summary>
+    public static readonly CVarDef<bool> ContractorsTraitFunctionsEnabled =
+        CVarDef.Create("contractors.trait_functions", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Will a chosen Nationality spawn the player with a Passport?
+    /// </summary>
+    public static readonly CVarDef<bool> ContractorsPassportEnabled =
+        CVarDef.Create("contractors.spawn_passports", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Master Switch for Contractors
+    /// </summary>
+    public static readonly CVarDef<bool> ContractorsEnabled =
+        CVarDef.Create("contractors.enabled", true, CVar.SERVER | CVar.REPLICATED);
+}

--- a/Content.Shared/_EE/Contractors/CCVars/CCVars.Contractors.cs
+++ b/Content.Shared/_EE/Contractors/CCVars/CCVars.Contractors.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.Configuration;
 
-namespace Content.Shared._EE.Contractors.CCVars;
+namespace Content.Shared.CCVar;
 
 /// <summary>
 /// Contains all the CVars used by Contractors.

--- a/Content.Shared/_EE/Contractors/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/_EE/Contractors/Systems/CharacterRequirements.Profile.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared._EE.Contractors.Prototypes;
+using Content.Shared.CCVar;
 using Content.Shared.Clothing.Loadouts.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
@@ -41,8 +42,8 @@ public sealed partial class CharacterNationalityRequirement : CharacterRequireme
         MindComponent? mind = null
     )
     {
-        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
-            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        if (!configManager.GetCVar(CCVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CCVars.ContractorsCharacterRequirementsEnabled))
         {
             reason = "";
             return true;
@@ -82,8 +83,8 @@ public sealed partial class CharacterEmployerRequirement : CharacterRequirement
         MindComponent? mind = null
     )
     {
-        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
-            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        if (!configManager.GetCVar(CCVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CCVars.ContractorsCharacterRequirementsEnabled))
         {
             reason = "";
             return true;
@@ -123,8 +124,8 @@ public sealed partial class CharacterLifepathRequirement : CharacterRequirement
         MindComponent? mind = null
     )
     {
-        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
-            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        if (!configManager.GetCVar(CCVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CCVars.ContractorsCharacterRequirementsEnabled))
         {
             reason = "";
             return true;

--- a/Content.Shared/_EE/Contractors/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/_EE/Contractors/Systems/CharacterRequirements.Profile.cs
@@ -9,6 +9,7 @@ using Content.Shared.Prototypes;
 using Content.Shared.Roles;
 using Content.Shared.Traits;
 using JetBrains.Annotations;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Physics;
@@ -40,6 +41,13 @@ public sealed partial class CharacterNationalityRequirement : CharacterRequireme
         MindComponent? mind = null
     )
     {
+        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        {
+            reason = "";
+            return true;
+        }
+
         var localeString = "character-nationality-requirement";
         const string color = "green";
         reason = Loc.GetString(
@@ -74,6 +82,13 @@ public sealed partial class CharacterEmployerRequirement : CharacterRequirement
         MindComponent? mind = null
     )
     {
+        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        {
+            reason = "";
+            return true;
+        }
+
         var localeString = "character-employer-requirement";
         const string color = "green";
         reason = Loc.GetString(
@@ -108,6 +123,13 @@ public sealed partial class CharacterLifepathRequirement : CharacterRequirement
         MindComponent? mind = null
     )
     {
+        if (!configManager.GetCVar(CVars.ContractorsEnabled) ||
+            !configManager.GetCVar(CVars.ContractorsCharacterRequirementsEnabled))
+        {
+            reason = "";
+            return true;
+        }
+
         var localeString = "character-lifepath-requirement";
         const string color = "green";
         reason = Loc.GetString(

--- a/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
@@ -12,6 +12,8 @@ using Content.Shared.Preferences;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared;
+using Content.Shared.CCVar;
+using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -67,7 +69,13 @@ public class SharedPassportSystem : EntitySystem
 
     private void OnPlayerLoadoutApplied(PlayerLoadoutAppliedEvent ev)
     {
-        if (Deleted(ev.Mob) || !Exists(ev.Mob) || !_configManager.GetCVar(CVars.ContractorsEnabled) || !_configManager.GetCVar(CVars.ContractorsPassportEnabled))
+        if (ev.JobId == null || !_prototypeManager.TryIndex(
+                ev.JobId,
+                out JobPrototype? jobPrototype)
+            || !jobPrototype.CanHavePassport
+            || Deleted(ev.Mob)
+            || !Exists(ev.Mob)
+            || !ShouldSpawnPassports)
             return;
 
         if (!_prototypeManager.TryIndex(
@@ -96,6 +104,10 @@ public class SharedPassportSystem : EntitySystem
             }
         }
     }
+
+    private bool ShouldSpawnPassports =>
+        _configManager.GetCVar(CCVar.CCVars.ContractorsEnabled) &&
+        _configManager.GetCVar(CCVar.CCVars.ContractorsPassportEnabled);
 
     public void UpdatePassportProfile(Entity<PassportComponent> passport, HumanoidCharacterProfile profile)
     {

--- a/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Item;
 using Content.Shared.Preferences;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
+using Robust.Shared;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -28,6 +30,7 @@ public class SharedPassportSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _sharedTransformSystem = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
 
     public override void Initialize()
     {
@@ -64,7 +67,7 @@ public class SharedPassportSystem : EntitySystem
 
     private void OnPlayerLoadoutApplied(PlayerLoadoutAppliedEvent ev)
     {
-        if (Deleted(ev.Mob) || !Exists(ev.Mob))
+        if (Deleted(ev.Mob) || !Exists(ev.Mob) || !_configManager.GetCVar(CVars.ContractorsEnabled) || !_configManager.GetCVar(CVars.ContractorsPassportEnabled))
             return;
 
         if (!_prototypeManager.TryIndex(

--- a/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
@@ -167,6 +167,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutOuter
+    - !type:CharacterEmployerRequirement
+        employers:
+        - CyberSun
 
 - type: loadout
   id: LoadoutOuterEeCorporateJacket
@@ -178,6 +181,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutOuter
+    - !type:CharacterEmployerRequirement
+        employers:
+        - EinsteinEngines
 
 - type: loadout
   id: LoadoutOuterHiCorporateJacket
@@ -189,6 +195,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutOuter
+    - !type:CharacterEmployerRequirement
+        employers:
+        - HephaestusIndustries
 
 - type: loadout
   id: LoadoutOuterHmCorporateJacket
@@ -209,6 +218,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutOuter
+    - !type:CharacterEmployerRequirement
+        employers:
+        - Interdyne
 
 - type: loadout
   id: LoadoutOuterBcCorporateJacket
@@ -260,6 +272,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutOuter
+    - !type:CharacterEmployerRequirement
+        employers:
+        - ZengHuPharmaceuticals
 
 - type: loadout
   id: LoadoutOuterDenimJacket

--- a/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
@@ -169,7 +169,7 @@
       group: LoadoutOuter
     - !type:CharacterEmployerRequirement
         employers:
-        - CyberSun
+        - Cybersun
 
 - type: loadout
   id: LoadoutOuterEeCorporateJacket

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
@@ -334,6 +334,9 @@
         - MedicalDoctor
         - Chemist
         - Paramedic
+    - !type:CharacterEmployerRequirement
+        employers:
+        - CyberSun
   items:
     - ClothingHeadHatSurgcapCybersun
 
@@ -413,6 +416,9 @@
         - MedicalDoctor
         - Chemist
         - Paramedic
+    - !type:CharacterEmployerRequirement
+        employers:
+        - CyberSun
   items:
     - ClothingOuterCoatCybersunWindbreaker
 
@@ -516,6 +522,9 @@
         - MedicalDoctor
         - Chemist
         - Paramedic
+    - !type:CharacterEmployerRequirement
+        employers:
+        - CyberSun
   items:
     - UniformScrubsColorCybersun
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
@@ -336,7 +336,7 @@
         - Paramedic
     - !type:CharacterEmployerRequirement
         employers:
-        - CyberSun
+        - Cybersun
   items:
     - ClothingHeadHatSurgcapCybersun
 
@@ -418,7 +418,7 @@
         - Paramedic
     - !type:CharacterEmployerRequirement
         employers:
-        - CyberSun
+        - Cybersun
   items:
     - ClothingOuterCoatCybersunWindbreaker
 
@@ -524,7 +524,7 @@
         - Paramedic
     - !type:CharacterEmployerRequirement
         employers:
-        - CyberSun
+        - Cybersun
   items:
     - UniformScrubsColorCybersun
 

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -11,6 +11,7 @@
   nameDataset: NamesAI
   spawnLoadout: false
   applyTraits: false
+  canHavePassport: false
 
 - type: job
   id: Borg
@@ -21,3 +22,4 @@
   icon: JobIconBorg
   supervisors: job-supervisors-rd
   jobEntity: PlayerBorgBattery
+  canHavePassport: false


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Some coats and scrubs in loadout are branded with specific corporation logo's.
This PR restricts specifically those items to the employers that they are from.

Note that we have coats from other companies currently not listed as available employers too. Perhaps we should consider adding them?

# Updated:
This PR now also includes CCVars that can disable a part, or the entirety, of Contractors for downstreams that prefer free-form RP over gameplay.
While I was at it, I made it so that AI and Borgs don't get Passports.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Restricted some corporate jackets and scrubs to that specific corporation.
- tweak: Downstreams can now disable Contractors entirely or partially if they prefer freeform-rp over gameplay facilitating RP
- tweak: Station AI and Borg are no longer people and don't get passports.
