### PR TITLE
Buff Moth Flight Speed

### DIFF
--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -133,7 +133,7 @@
     - !type:TraitAddComponent
       components:
         - type: Flight
-          speedModifier: 1.09 # gives an effective 20% increase over walking with base moth weightless modifier
+          speedModifier: 1.2 # gives an effective 32% increase over walking with base moth weightless modifier
           flapInterval: 0.75
           needsHands: false
   requirements:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR changes the speed modifier for Moth Flight from 1.09 to 1.2 (adding up to an effective ~30% increase over walking with the base moth weightless modifier, over the 20% from before) 

Moths have a trait called true flight which costs 5 points
to take it in the first place you need to be at most 60kg
It essentially gives you harpy flight (moth version)
A PR was made some time ago that changed both the moth flight and harpy flight
What you need to know is that harpies get an effective ~60% speed boost while flying, and handslots taken
Moths however, can use their handslots and also get some friction for sharper turns BUT their effective movement speed increase is only ~20% (By effective increase I mean combining weightless speed buff, flying speed buff, and in the case of harpies, their innate movement speed buff of like 15%) 

While playing around I noticed the moth flight is barely noticable when used (the movement speed IS there of course, but it's barely noticable) 
I do understand that speed is a very big thing and a powerful tool, with flying having no slips and all, and moths being able to use their hands while flying BUT
it really feels like it barely does anything
So because to even get moth flight you need to:
- Be light enough
- Invest a trait slot and 5 points
- And flight itself being an active which rapidly drains stamina
So I made this PR to slightly increase the speed moth flight gives you


---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: 
- tweak: Increased the moth flight speed modifier from 1.09 to 1.2
