### PR TITLE
Tweak Language Stuff

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -1,6 +1,5 @@
 - type: characterItemGroup
   id: TraitsLanguagesBasic
-  maxItems: 1
   items:
     - type: trait
       id: SignLanguage

--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -46,3 +46,13 @@
       id: ScottishAccent
     - type: trait
       id: SkeletonAccent
+    - type: trait
+      id: GermanAccent
+    - type: trait
+      id: RussianAccent
+    - type: trait
+      id: FrenchAccent
+    - type: trait
+      id: ItalianAccent
+    - type: trait
+      id: SpanishAccent

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: SignLanguage
   category: TraitsSpeechLanguages
-  points: -2
+  points: -1
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR removes the limit to how many basic language traits you can take, reduces the cost of sign language from -2 to -1 and ensures that you cannot take more than 1 accent from the accent traits. (Previosly, when new accents got added, the bunch with german, french, spanish, italian and russian, they weren't added to the character item group that makes it so you can only take 1, so I added them)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Reduced sign language cost from -2 to -1
- tweak: Removed the limit on how many language traits you can take
- fix: Made sure that you cannot take more than 1 accent trait

