### PR TITLE
Add Crude Check to See if Your Profile Is Valid when Pressing Ready

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -6,11 +6,14 @@ using Content.Client.Message;
 using Content.Client.ReadyManifest;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.Voting;
+using Content.Shared.Preferences;
 using Robust.Client;
 using Robust.Client.Console;
+using Robust.Client.Player;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Lobby
@@ -24,6 +27,10 @@ namespace Content.Client.Lobby
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IVoteManager _voteManager = default!;
+        [Dependency] private readonly IClientPreferencesManager _preferencesManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IDependencyCollection _dependencies = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         private ISawmill _sawmill = default!;
         private ClientGameTicker _gameTicker = default!;
@@ -106,7 +113,12 @@ namespace Content.Client.Lobby
 
         private void OnReadyToggled(BaseButton.ButtonToggledEventArgs args)
         {
-            SetReady(args.Pressed);
+            var pressed = args.Pressed;
+            var character = _preferencesManager.Preferences?.SelectedCharacter;
+            if (character is not HumanoidCharacterProfile humanoid || !humanoid.IsValid(_playerManager.LocalSession!, _dependencies))
+                pressed = false;
+
+            SetReady(pressed);
         }
 
         private void OnManifestPressed(BaseButton.ButtonEventArgs args)

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -604,7 +604,6 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
 
     public bool IsValid(ICommonSession session, IDependencyCollection collection)
     {
-        var configManager = collection.Resolve<IConfigurationManager>();
         var prototypeManager = collection.Resolve<IPrototypeManager>();
         var cfgManager = collection.Resolve<IConfigurationManager>();
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This adds a crude check to the HumanoidCharacterProfile to validate it. When you have an invalid profile, you will not be able to ready up.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Also check CharacterRequirements when validating the profile
- [ ] Display an error message explaining why you are unable to ready up

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/d5c618f3-cc8f-42f9-8af0-fd340c5cf9fc

More of a proof of concept--it's still pretty crude.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed being able to ready up for a round with invalid loadouts or traits
