### PR TITLE
Various Bugfixes (Mostly Traits System)

### DIFF
--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -207,8 +207,11 @@ namespace Content.Client.Light
 
         public static Color GetCurrentRgbColor(TimeSpan curTime, TimeSpan offset, Entity<RgbLightControllerComponent> rgb)
         {
+            var delta = (float)(curTime - offset).TotalSeconds;
+            var entOffset = Math.Abs(rgb.Owner.Id * 0.09817f);
+            var hue = (delta * rgb.Comp.CycleRate + entOffset) % 1;
             return Color.FromHsv(new Vector4(
-                (float) (((curTime.TotalSeconds - offset.TotalSeconds) * rgb.Comp.CycleRate + Math.Abs(rgb.Owner.Id * 0.1)) % 1),
+                MathF.Abs(hue),
                 1.0f,
                 1.0f,
                 1.0f

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2635,9 +2635,10 @@ namespace Content.Client.Lobby.UI
                 selector.PreferenceChanged += preference =>
                 {
                     // Make sure they have enough loadout points
-                    var selected = preference.Selected
-                        ? CheckPoints(-selector.Loadout.Cost, preference.Selected)
-                        : CheckPoints(selector.Loadout.Cost, preference.Selected);
+                    var wasSelected = Profile?.LoadoutPreferences
+                        .FirstOrDefault(it => it.LoadoutName == selector.Loadout.ID)
+                        ?.Selected ?? false;
+                    var selected = preference.Selected && (wasSelected || CheckPoints(-selector.Loadout.Cost, true));
 
                     // Update Preferences
                     Profile = Profile?.WithLoadoutPreference(
@@ -2656,7 +2657,7 @@ namespace Content.Client.Lobby.UI
             bool CheckPoints(int points, bool preference)
             {
                 var temp = LoadoutPointsBar.Value + points;
-                return preference ? !(temp < 0) : temp < 0;
+                return preference ? temp >= 0 : temp < 0;
             }
         }
 

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -207,11 +207,17 @@ public sealed partial class LoadoutPreferenceSelector : Control
         });
         PreferenceButton.OnToggled += args =>
         {
+            if (args.Pressed == _preference.Selected)
+                return;
+
             _preference.Selected = args.Pressed;
             PreferenceChanged?.Invoke(Preference);
         };
         HeirloomButton.OnToggled += args =>
         {
+            if (args.Pressed == _preference.Selected)
+                return;
+
             _preference.CustomHeirloom = args.Pressed ? true : null;
             PreferenceChanged?.Invoke(Preference);
         };

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -63,15 +63,25 @@ public sealed class TraitSystem : EntitySystem
             return;
 
         var jobPrototypeToUse = _prototype.Index(jobId ?? _prototype.EnumeratePrototypes<JobPrototype>().First().ID);
+        var sortedTraits = new List<TraitPrototype>();
 
         foreach (var traitId in profile.TraitPreferences)
         {
-            if (!_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+            if (_prototype.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+            {
+                sortedTraits.Add(traitPrototype);
+            }
+            else
             {
                 DebugTools.Assert($"No trait found with ID {traitId}!");
                 return;
             }
+        }
 
+        sortedTraits.Sort();
+
+        foreach (var traitPrototype in sortedTraits)
+        {
             if (!_characterRequirements.CheckRequirementsValid(
                 traitPrototype.Requirements,
                 jobPrototypeToUse,

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Customization.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Traits;
 
@@ -10,7 +9,7 @@ namespace Content.Shared.Traits;
 ///     Describes a trait.
 /// </summary>
 [Prototype("trait")]
-public sealed partial class TraitPrototype : IPrototype
+public sealed partial class TraitPrototype : IPrototype, IComparable
 {
     [ViewVariables]
     [IdDataField]
@@ -34,6 +33,19 @@ public sealed partial class TraitPrototype : IPrototype
 
     [DataField(serverOnly: true)]
     public TraitFunction[] Functions { get; private set; } = Array.Empty<TraitFunction>();
+
+    /// <summary>
+    ///     Should this trait be loaded earlier/later than other traits?
+    /// </summary>
+    [DataField]
+    public int Priority = 0;
+    public int CompareTo(object? obj) // Compare function to allow for some traits to specify they need to load earlier than others
+    {
+        if (obj is not TraitPrototype other)
+            return -1;
+
+        return Priority.CompareTo(other.Priority); // No need for total ordering, only care about things that want to be loaded earlier or later.
+    }
 }
 
 /// This serves as a hook for trait functions to modify a player character upon spawning in.


### PR DESCRIPTION
# Description

![faridaiscute](https://github.com/user-attachments/assets/a251d7d5-b80c-4ba5-9d03-3071ffdb8c94)

Mfw a downstream fixes things only for themselves, leaving me to hear hundreds of complaints constantly about bugs that I don't have the time or manpower to fix upstream. 

# Changelog

:cl:
- fix: Fixed an issue that prevented players from saving item customizations if they didn't have enough loadout points to buy the item a second time. 
- add: Traits can now define the order in which they are applied. 
- fix: Fixed RGBee pushie not working.
