### PR TITLE
makes it so limes, lemons, and oranges can't mutate into each other

### DIFF
--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -210,8 +210,6 @@
     - FoodLemon
   mutationPrototypes:
     - lemoon
-    - lime
-    - orange
   harvestRepeat: Repeat
   lifespan: 55
   maturation: 6
@@ -264,9 +262,6 @@
   packetPrototype: LimeSeeds
   productPrototypes:
     - FoodLime
-  mutationPrototypes:
-    - orange
-    - lemon
   harvestRepeat: Repeat
   lifespan: 55
   maturation: 6
@@ -295,8 +290,6 @@
     - FoodOrange
   mutationPrototypes:
     - extradimensionalOrange
-    - lemon
-    - lime
   harvestRepeat: Repeat
   lifespan: 55
   maturation: 6


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Removes the mutations that make limes, lemons, and oranges mutate into each other because it makes lemoons and dimensional oranges annoying to obtain by diluting the mutation pool.

Yes, the ability for them to mutate into each other is somewhat realistic because all those plants are crossbred anyways, however, I do not care, and they were crossbred, not mutated with funny magic liquid.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Lemons, Limes, and Oranges can no longer mutate into each other
