### PR TITLE
Smaller Survival Box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvival
   description: It's a box with basic internals inside.
   components:
@@ -20,7 +20,7 @@
 
 - type: entity
   name: extended-capacity survival box
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvivalEngineering
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
@@ -40,7 +40,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvivalSecurity
   description: It's a box with basic internals inside.
   suffix: Security
@@ -61,7 +61,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvivalBrigmedic
   description: It's a box with basic internals inside.
   suffix: MedSec
@@ -82,7 +82,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvivalMedical
   description: It's a box with basic internals inside.
   suffix: Medical
@@ -103,7 +103,7 @@
 
 - type: entity
   name: box of hugs
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxHug
   description: A special box for sensitive people.
   suffix: Emergency
@@ -176,7 +176,7 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: BoxSurvivalSyndicate
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:

--- a/Resources/Prototypes/_EE/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_EE/Catalog/Fills/Boxes/general.yml
@@ -1,0 +1,25 @@
+- type: entity
+  name: cardboard box small
+  parent: BoxBase
+  id: BoxCardboardSmall
+  description: A cardboard box for storing things.
+  components:
+  - type: Item
+    size: Normal
+    shape:
+    - 0,0,1,1
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,2,2
+  - type: Sprite
+    state: box
+  - type: EmitSoundOnPickup
+    sound: /Audio/SimpleStation14/Items/Handling/cardboardbox_pickup.ogg
+  - type: EmitSoundOnDrop
+    sound: /Audio/SimpleStation14/Items/Handling/cardboardbox_drop.ogg
+  - type: EmitSoundOnLand
+    sound: /Audio/SimpleStation14/Items/Handling/cardboardbox_drop.ogg
+  - type: Tag
+    tags:
+    - BoxCardboard


### PR DESCRIPTION
# Description

Make survival box smaller. Currently, survival box are large—they occupy a 3x3 slot in the backpack and have a 4x4 storage space. This PR changes them to occupy a 2x2 slot in the backpack and have a 3x3 storage space. The main reason I’m making this PR is that whenever I spawn, an item drops to the ground. I often don’t notice the dropped item and end up losing it (Looking at the player spawn areas, there are often items on the ground most of the time. It doesn’t seem to be just my case.).

---

<details><summary><h1>Media</h1></summary>
<p>

![Captura de tela 2025-04-05 190031](https://github.com/user-attachments/assets/9057876b-42ea-4efb-ac57-c1206c6deba1)

</p>
</details>

---

# Changelog

:cl:
- tweak: Make survival box smaller
