### PR TITLE
Loadout And Trait Slot Cost

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2061,7 +2061,7 @@ namespace Content.Client.Lobby.UI
                     continue;
 
                 points += preferenceSelector.Trait.Points;
-                _traitCount += 1;
+                _traitCount += preferenceSelector.Trait.Slots;
             }
 
             TraitPointsBar.Value = points;
@@ -2283,8 +2283,9 @@ namespace Content.Client.Lobby.UI
                 {
                     // Make sure they have enough trait points
                     preference = CheckPoints(preference ? selector.Trait.Points : -selector.Trait.Points, preference);
+
                     // Make sure they have enough trait slots
-                    preference = preference ? _traitCount < _cfgManager.GetCVar(CCVars.GameTraitsMax) : preference;
+                    preference = CheckSlots(preference ? selector.Trait.Slots : -selector.Trait.Slots, preference);
 
                     // Update Preferences
                     Profile = Profile?.WithTraitPreference(selector.Trait.ID, preference);
@@ -2298,6 +2299,13 @@ namespace Content.Client.Lobby.UI
             {
                 var temp = TraitPointsBar.Value + points;
                 return preference ? !(temp < 0) : temp < 0;
+            }
+
+            bool CheckSlots(int slots, bool preference)
+            {
+                var temp = _traitCount + slots;
+                var max = _cfgManager.GetCVar(CCVars.GameTraitsMax);
+                return preference ? !(temp > max) : temp > max;
             }
         }
 

--- a/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
+++ b/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
@@ -25,6 +25,12 @@ public sealed partial class LoadoutPrototype : IPrototype
     [DataField]
     public int Cost = 1;
 
+    /// <summary>
+    ///     How many item group selections this uses. Defaulted to 1:1, but can be any number.
+    /// </summary>
+    [DataField]
+    public int Slots = 1;
+
     /// Should this item override other items in the same slot
     [DataField]
     public bool Exclusive;

--- a/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
@@ -408,9 +408,16 @@ public sealed partial class CharacterItemGroupRequirement : CharacterRequirement
             .ToList();
         var count = items.Count;
 
-        // If prototype is selected, remove one from the count
+        // If prototype is selected, decrease the count. Or increase it via negative number. Not my monkey, not my circus.
         if (items.ToList().Contains(prototype.ID))
-            count--;
+        {
+            // This disgusting ELIF nest requires an engine PR to make less terrible.
+            if (prototypeManager.TryIndex<LoadoutPrototype>(prototype.ID, out var loadoutPrototype))
+                count -= loadoutPrototype.Slots;
+            else if (prototypeManager.TryIndex<TraitPrototype>(prototype.ID, out var traitPrototype))
+                count -= traitPrototype.Slots;
+            else count--;
+        }
 
         reason = Loc.GetString(
             "character-item-group-requirement",

--- a/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Profile.cs
@@ -415,7 +415,7 @@ public sealed partial class CharacterItemGroupRequirement : CharacterRequirement
             if (prototypeManager.TryIndex<LoadoutPrototype>(prototype.ID, out var loadoutPrototype))
                 count -= loadoutPrototype.Slots;
             else if (prototypeManager.TryIndex<TraitPrototype>(prototype.ID, out var traitPrototype))
-                count -= traitPrototype.Slots;
+                count -= traitPrototype.ItemGroupSlots;
             else count--;
         }
 

--- a/Content.Shared/Prototypes/CharacterItemGroupPrototype.cs
+++ b/Content.Shared/Prototypes/CharacterItemGroupPrototype.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Clothing.Loadouts.Prototypes;
 using Content.Shared.Clothing.Loadouts.Systems;
-using Content.Shared.Customization.Systems;
 using Content.Shared.Preferences;
 using Content.Shared.Traits;
 using Robust.Shared.Prototypes;

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -33,6 +33,13 @@ public sealed partial class TraitPrototype : IPrototype, IComparable
     [DataField]
     public int Slots = 1;
 
+    /// <summary>
+    ///     Traits share their item group implementation with Loadouts, but have a separate use for their normal Slots.
+    ///     Thus, they can optionally be split, otherwise the behavior defaults to their standard slots.
+    /// </summary>
+    [DataField]
+    public int ItemGroupSlots => Slots;
+
 
     [DataField]
     public List<CharacterRequirement> Requirements = new();

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -25,7 +25,13 @@ public sealed partial class TraitPrototype : IPrototype, IComparable
     ///     How many points this will give the character
     /// </summary>
     [DataField]
-    public int Points = 0;
+    public int Points;
+
+    /// <summary>
+    ///     How many trait selections this uses. Defaulted to 1:1, but can be any number.
+    /// </summary>
+    [DataField]
+    public int Slots = 1;
 
 
     [DataField]

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -38,7 +38,7 @@ public sealed partial class TraitPrototype : IPrototype, IComparable
     ///     Thus, they can optionally be split, otherwise the behavior defaults to their standard slots.
     /// </summary>
     [DataField]
-    public int ItemGroupSlots => Slots;
+    public int ItemGroupSlots = 1;
 
 
     [DataField]

--- a/Resources/Prototypes/DeltaV/Traits/neutral.yml
+++ b/Resources/Prototypes/DeltaV/Traits/neutral.yml
@@ -1,5 +1,6 @@
 - type: trait
   id: ScottishAccent
+  slots: 0
   category: TraitsSpeechAccents
   points: 0
   requirements:

--- a/Resources/Prototypes/DeltaV/Traits/neutral.yml
+++ b/Resources/Prototypes/DeltaV/Traits/neutral.yml
@@ -1,6 +1,7 @@
 - type: trait
   id: ScottishAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   points: 0
   requirements:

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -138,6 +138,7 @@
 
 - type: trait
   id: FrontalLisp
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -139,6 +139,7 @@
 - type: trait
   id: FrontalLisp
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -26,6 +26,7 @@
 - type: trait
   id: Stutter
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -25,6 +25,7 @@
 
 - type: trait
   id: Stutter
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -1,5 +1,6 @@
 - type: trait
   id: PirateAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -12,7 +13,7 @@
 - type: trait
   id: Accentless
   category: TraitsSpeechAccents
-  points: -1
+  slots: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -33,6 +34,7 @@
 
 - type: trait
   id: Southern
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -41,9 +43,10 @@
     - !type:TraitAddComponent
       components:
         - type: SouthernAccent
-        
+
 - type: trait
   id: GermanAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -52,9 +55,10 @@
     - !type:TraitAddComponent
       components:
         - type: GermanAccent
-        
+
 - type: trait
   id: RussianAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -63,9 +67,10 @@
     - !type:TraitAddComponent
       components:
         - type: RussianAccent
-        
+
 - type: trait
   id: FrenchAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -74,9 +79,10 @@
     - !type:TraitAddComponent
       components:
         - type: FrenchAccent
-        
+
 - type: trait
   id: ItalianAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -85,9 +91,10 @@
     - !type:TraitAddComponent
       components:
         - type: MobsterAccent
-        
+
 - type: trait
   id: SpanishAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -99,6 +106,7 @@
 
 - type: trait
   id: SkeletonAccent
+  slots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -1,6 +1,7 @@
 - type: trait
   id: PirateAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -14,6 +15,7 @@
   id: Accentless
   category: TraitsSpeechAccents
   slots: 0
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -35,6 +37,7 @@
 - type: trait
   id: Southern
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -47,6 +50,7 @@
 - type: trait
   id: GermanAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -59,6 +63,7 @@
 - type: trait
   id: RussianAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -71,6 +76,7 @@
 - type: trait
   id: FrenchAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -83,6 +89,7 @@
 - type: trait
   id: ItalianAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -95,6 +102,7 @@
 - type: trait
   id: SpanishAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -107,6 +115,7 @@
 - type: trait
   id: SkeletonAccent
   slots: 0
+  itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterItemGroupRequirement


### PR DESCRIPTION
# Description

This PR gently reworks the traits and loadouts system to where both systems have a new Datafield for "Slots", which declares how many selections the trait/loadout occupies. The actual implementation of these differs between the two, since Traits has an actual selection limit, while Loadouts do not(but instead respect CharacterItemGroups). In both cases, Slots are defaulted to 1, and can be omitted in most cases.

Where this shines particularly is in Traits, where it serves as a new second line for trait balancing. Traits such as Accents, which are completely worthless, otherwise would never be taken at all since they compete with other traits for Opportunity Cost. Conversely, there's only so many points we can increase a powerful trait to, (literally, they cannot cost more than the current trait maximum). So traits can be made to occupy >1 slot selections. 

Slots can be defined for Item Groups as well, which is what this datafield does on Loadouts, which both of these share. But since Traits have two different places that their slots are used, I've opted to create a split slot datafield for Traits. To simplify things, their ItemGroupSlots defaults to their Slots datafield, but can be independently changed as desired. 

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/99dddfe1-76d2-445a-a94a-1998d3d39c51

</p>
</details>

# Changelog

:cl:
- tweak: Accents no longer cost trait slots. 
