### PR TITLE
The Creation Of John Language (Removal of Language Limit)

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -1,5 +1,6 @@
 - type: characterItemGroup
   id: TraitsLanguagesBasic
+  maxItems: 1
   items:
     - type: trait
       id: SignLanguage

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -2,6 +2,8 @@
   id: SignLanguage
   category: TraitsSpeechLanguages
   points: -1
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -20,6 +22,8 @@
   id: SolCommon
   category: TraitsSpeechLanguages
   points: 0
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -42,6 +46,8 @@
   id: Tradeband
   category: TraitsSpeechLanguages
   points: 0
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -60,6 +66,8 @@
   id: Freespeak
   category: TraitsSpeechLanguages
   points: 0
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -74,6 +82,8 @@
   id: Elyran
   category: TraitsSpeechLanguages
   points: 0
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -92,6 +102,8 @@
   id: ValyrianStandard
   category: TraitsSpeechLanguages
   points: -1
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -110,6 +122,8 @@
   id: NovuNederic
   category: TraitsSpeechLanguages
   points: 0
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -128,6 +142,8 @@
   id: Azaziba
   category: TraitsSpeechLanguages
   points: -1
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/_EE/Traits/languages.yml
+++ b/Resources/Prototypes/_EE/Traits/languages.yml
@@ -2,6 +2,8 @@
   id: SiikMaas
   category: TraitsSpeechLanguages
   points: -1
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -24,6 +26,8 @@
   id: NalRasan
   category: TraitsSpeechLanguages
   points: -1
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -41,6 +45,8 @@
   id: SiikTajr
   category: TraitsSpeechLanguages
   points: -2
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -58,6 +64,8 @@
   id: YaSsa
   category: TraitsSpeechLanguages
   points: -2
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
@@ -75,6 +83,8 @@
   id: Delvahii
   category: TraitsSpeechLanguages
   points: -2
+  slots: 1
+  itemGroupSlots: 0
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR Redefines the max items from the basic language item group (1) BUT makes it so that EVERY SINGLE LANGUAGE TRAIT takes up 0 slots in that item group, letting you effectively take all the languages if you have enough space.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Made every single language trait take up no slots in their defined max items limit, effectively letting you take unlimited languages,  so you can become the man himself, John Language. (FOR REAL THIS TIME.)

