### PR TITLE
Psionically insulates the Elite, Juggernaut, & Dreadnought suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -549,6 +549,7 @@
         Heat: 0.9
   - type: FlashImmunity # Goobstation
   - type: FlashSoundSuppression # Goobstation
+  - type: TinfoilHat
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -601,6 +602,7 @@
         Heat: 0.9
   - type: FlashImmunity # Goobstation
   - type: FlashSoundSuppression # Goobstation
+  - type: TinfoilHat
 
 #Wizard Hardsuit
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -84,3 +84,4 @@
         Piercing: 0.89
         Heat: 0.89
   - type: FlashImmunity
+  - type: TinfoilHat


### PR DESCRIPTION
# Description

Not much to explain here that isn't explained in the title?
As said in the suggestion that caused me to make this PR; "It is... hilarious how easily you can lock down what was supposedly to be a major threat with something like a Mass Sleep or Mind Swap."
So now, given the nukies are willing to splurge a little, not anymore.

---

# TODO

- [x] Insulate the suits
- [ ] Make sure it works

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

:cl:
- add: Elite, Juggernaut, & Dreadnought hardsuits now have psionic insulation.
