### PR TITLE
Fix Office Chairs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -104,7 +104,7 @@
   - type: Vehicle
     requiredHands: 0
     engineRunning: true
-    renderOver: North, NorthEast, NorthWest
+    renderOver: South, SouthEast, SouthWest
   - type: MovementSpeedModifier
     acceleration: 10
     friction: 3.5


### PR DESCRIPTION

# Description

Fix the office chair sprite overlapping the character when facing south.

---

<details><summary><h1>Media</h1></summary>
<p>

![Captura de tela 2025-04-06 154654](https://github.com/user-attachments/assets/fbd02e14-0c95-4c27-8da1-4b8b308617cd)

</p>
</details>

---

# Changelog

:cl:
- fix: Fix the office chair sprite overlapping the character when facing south
