### PR TITLE
Fix Minor Psionics Bugs

### DIFF
--- a/Content.Server/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Psionics/PsionicsSystem.cs
@@ -263,7 +263,7 @@ public sealed class PsionicsSystem : EntitySystem
     public void RollPsionics(EntityUid uid, PsionicComponent component, bool applyGlimmer = true, float rollEventMultiplier = 1f)
     {
         if (!_cfg.GetCVar(CCVars.PsionicRollsEnabled)
-            || !component.Removable)
+            || !component.Roller)
             return;
 
         // Calculate the initial odds based on the innate potential

--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -118,10 +118,8 @@ public sealed class GlimmerSystem : EntitySystem
         if (!_enabled || delta == 0)
             return;
 
-        var x = GlimmerInput;
-
         GlimmerInput += delta;
-        GlimmerOutput = 2000 / (1 + Math.Pow(Math.E, -0.0022 * x)) - 1000;
+        GlimmerOutput = 2000 / (1 + Math.Pow(Math.E, -0.0022 * GlimmerInput)) - 1000;
     }
 
     /// <summary>
@@ -134,10 +132,8 @@ public sealed class GlimmerSystem : EntitySystem
         if (!_enabled || delta == 0)
             return;
 
-        var y = GlimmerOutput;
-
         GlimmerOutput += delta;
-        GlimmerInput = Math.Log((y + 1000) / (1000 - y)) / 0.0022;
+        GlimmerInput = Math.Log((GlimmerOutput + 1000) / (1000 - GlimmerOutput)) / 0.0022;
     }
 
     /// <summary>
@@ -150,10 +146,8 @@ public sealed class GlimmerSystem : EntitySystem
         if (!_enabled || set == 0)
             return;
 
-        var y = GlimmerOutput;
-
         GlimmerOutput = Math.Clamp(set, 0, 999.999);
-        GlimmerInput = Math.Log((y + 1000) / (1000 - y)) / 0.0022;
+        GlimmerInput = Math.Log((GlimmerOutput + 1000) / (1000 - GlimmerOutput)) / 0.0022;
     }
 
     /// <summary>
@@ -165,7 +159,6 @@ public sealed class GlimmerSystem : EntitySystem
     {
         if (!_enabled || set < 0)
             return;
-
 
         GlimmerInput = set;
         GlimmerOutput = 2000 / (1 + Math.Pow(Math.E, -.0022 * set)) - 1000;


### PR DESCRIPTION
# Description

Fixes two bugs with Psionics, namely that the "Roller Exempt" psionic variants were infact still able to roll new powers. Now the Roller Exemption cuts them off completely from generating Potentia. I'll probably revisit this exit at a later date if I come up with some alternative uses for Potentia.

I also fixed a bug where probers would lock glimmer into one place, rather than cause glimmer to steadily increase towards a given equilibrium point(vs. the current linear decay rate).

# Changelog

:cl:
- fix: Fixed a bug where Probers were locking glimmer at a set number.
- fix: Fixed a bug where Elementalists could still roll for new powers. 
