### PR TITLE
Hive Bugfix

### DIFF
--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -179025,8 +179025,6 @@ entities:
       pos: 126.5,-6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 21069
   - uid: 9728
@@ -179036,8 +179034,6 @@ entities:
       pos: 130.5,-6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 21069
   - uid: 12070


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

There was some invalid configurators left behind in the YML and I was only made aware of them shortly beforehand. They crash the server pretty hard. God, I love mapping issues.


