### PR TITLE
Requires that a Character Not Be Mute to Be in Command

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,6 +9,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - Muted
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -10,6 +10,7 @@
         - Foreigner
         - ForeignerLight
         - Pacifist
+        - Muted
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -9,6 +9,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - Muted
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -11,6 +11,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - Muted
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -15,15 +15,10 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
-        - !type:CharacterTraitRequirement
-          inverted: true
-          traits:
-            - Foreigner
-            - ForeignerLight
-            - Muted
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
+        - Muted
         - Foreigner
         - ForeignerLight
     - !type:CharacterEmployerRequirement

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -15,6 +15,12 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
+        - !type:CharacterTraitRequirement
+          inverted: true
+          traits:
+            - Foreigner
+            - ForeignerLight
+            - Muted
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
@@ -15,6 +15,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - Muted
     - !type:CharacterEmployerRequirement
       inverted: true
       employers:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -12,6 +12,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - Muted
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Command staff are the backbone of communication aboard the station. Whether issuing orders during a crisis, coordinating departments, or resolving station-wide issues, their ability to clearly and quickly speak is not optional — it is essential.

A Command officer who cannot speak, even by choice, undermines the very purpose of the role. Silence in an emergency is a liability. Muted Captains or Heads of Staff cannot effectively lead, respond to crew inquiries, or de-escalate tense situations. The trait is flavourful, yes — but flavour cannot come at the cost of function.

Some players argue that disallowing the Muted trait in Command roles limits their character expression or agency. But Command is not a solo storytelling position — it is a public-facing, high-responsibility job that directly affects the experience of everyone on the station. If a Head of Personnel cannot answer questions over command radio, if a Captain must mime their way through a nuclear threat, or if a Chief Engineer cannot brief their team, it’s not just their roleplay being limited — it’s the entire round’s cohesion and clarity that suffers.

By choosing to play Command, you’re accepting the responsibility of being a communicator. Taking the Muted trait in that context isn’t just a personal choice — it’s a deliberate hampering of the station’s ability to function, and of every player who needs leadership to be audible, decisive, and present.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Command members can no longer take the Muted trait
