### PR TITLE
RA0032 Warning Fix. Reference to Type Already Exist.

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -74,7 +74,6 @@ namespace Content.Client.Entry
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly JoinQueueManager _joinQueue = default!;
         [Dependency] private readonly DiscordAuthManager _discordAuth = default!;
-        [Dependency] private readonly ContentReplayPlaybackManager _replayMan = default!;
         [Dependency] private readonly DebugMonitorManager _debugMonitorManager = default!;
 
         public override void Init()

--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -39,7 +39,6 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IResourceCache _resourceCache = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
-    [Dependency] private readonly JobRequirementsManager _requirements = default!;
     [Dependency] private readonly MarkingManager _markings = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly JobRequirementsManager _jobRequirements = default!;
@@ -66,7 +65,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
 
         _prototypeManager.PrototypesReloaded += OnPrototypesReloaded;
         _preferencesManager.OnServerDataLoaded += PreferencesDataLoaded;
-        _requirements.Updated += OnRequirementsUpdated;
+        _jobRequirements.Updated += OnRequirementsUpdated;
 
         _configurationManager.OnValueChanged(CCVars.FlavorText, _ => _profileEditor?.RefreshFlavorText());
         _configurationManager.OnValueChanged(CCVars.GameRoleTimers, _ => RefreshProfileEditor());
@@ -207,7 +206,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
             _dialogManager,
             _playerManager,
             _prototypeManager,
-            _requirements,
+            _jobRequirements,
             _markings,
             _random);
 

--- a/Content.Client/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Client/Nyanotrasen/Mail/MailSystem.cs
@@ -26,7 +26,6 @@ namespace Content.Client.Mail;
 public sealed class MailJobVisualizerSystem : VisualizerSystem<MailComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly SpriteSystem _stateManager = default!;
     [Dependency] private readonly SpriteSystem _spriteSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
 


### PR DESCRIPTION
# Description

Removed RA0032 warnings, 
They triggered when a dependency already exist with a different name in a parent class.

---

# Changelog


:cl:
- add: removed references where a reference already existed
- tweak: Tweaked the names of old refences to match the existing reference.
