### PR TITLE
Fix Mining Voucher

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -344,10 +344,6 @@
   categories: [ HideSpawnMenu ]
   parent: ClothingBackpackSalvage
   id: ClothingBackpackSalvageFilled
-  components:
-    - type: StorageFill
-      contents:
-        - id: MiningVoucher
 
 # Pirate
 

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1559,6 +1559,8 @@
         type: ShopVendorBoundUserInterface
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
+      enum.MiningVoucherUiKey.Key:
+        type: MiningVoucherBoundUserInterface
   - type: Wires # DeltaV: Use shop vendor wires layout
     layoutId: ShopVendor
   - type: AccessReader

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -32,6 +32,7 @@
     shoes: ClothingShoesBootsSalvage
     id: SalvagePDA
     ears: ClothingHeadsetCargo
+    pocket1: MiningVoucher
   satchel: ClothingBackpackSatchelSalvageFilled
   duffelbag: ClothingBackpackDuffelSalvageFilled
 
@@ -43,3 +44,4 @@
     head: ClothingHeadEnvirohelmSalvage
     gloves: ClothingHandsGlovesEnviroglovesSalvage
     mask: ClothingMaskGasExplorer
+    pocket1: MiningVoucher


### PR DESCRIPTION

# Description

Fix mining voucher not allowing the selection of the initial kit and not appearing when selecting a backpack other than Salvage in the loadout.

---

<details><summary><h1>Media</h1></summary>
<p>

![Captura de tela 2025-04-10 204541](https://github.com/user-attachments/assets/3f55b525-3024-4756-b3ad-dde68ef6bf5e)
![Captura de tela 2025-04-10 204617](https://github.com/user-attachments/assets/99525597-3b19-43bc-af49-a2d826682707)

</p>
</details>

---

:cl:
- fix: Fix mining voucher not allowing the selection of the initial kit
- fix: Fix mining voucher not appearing when selecting a backpack other than Salvage in the loadout
