### PR TITLE
Fire Actually Works but Shouldn't Ash People Instantly

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -282,10 +282,13 @@ namespace Content.Server.Atmos.EntitySystems
             flammable.FireStacks = MathF.Min(MathF.Max(flammable.MinimumFireStacks, stacks), flammable.MaximumFireStacks);
 
             if (flammable.FireStacks <= 0)
+            {
                 Extinguish(uid, flammable);
+                ignite = false;
+            }
             else
             {
-                flammable.OnFire = ignite;
+                ignite = true;
                 UpdateAppearance(uid, flammable);
             }
         }

--- a/Content.Server/EntityEffects/Effects/FlammableReaction.cs
+++ b/Content.Server/EntityEffects/Effects/FlammableReaction.cs
@@ -1,5 +1,6 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
 using Content.Shared.EntityEffects;
 using JetBrains.Annotations;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Exactly what the description says. There was some silly little jank in the code that caused [this issue](https://github.com/Simple-Station/Einstein-Engines/issues/2188), and I decided to fix it. People should get lit on fire, it shouldn't do stupid amounts of damage unless you *really* get lit on fire, all appears to be well in the world. The attached media is the approximate damage of 5u of splashed phlogiston.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/84a8757d-6a96-472f-a4f6-888cf53128ac)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: fire has been re-added to the game for more than about a half a second
- tweak: fire shouldn't ash people at tiny amounts
