### PR TITLE
Mosin Nerf & Chester Buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -68,7 +68,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
   - type: Gun
-    fireRate: 0.75
+    fireRate: 0.2 # If this thing is do 50 damage a shot im gutting its fire rate so its only scary when used by a group of people
     damageModifier: 2.625 # OORAH. You have to manually cycle each shot. So each shot deals 42 damage. For the Red Orchestra enthusiasts.
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -68,8 +68,8 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
   - type: Gun
-    fireRate: 0.2 # If this thing is do 50 damage a shot im gutting its fire rate so its only scary when used by a group of people
-    damageModifier: 2.625 # OORAH. You have to manually cycle each shot. So each shot deals 42 damage. For the Red Orchestra enthusiasts.
+    fireRate: 0.75 
+    damageModifier: 1.5 
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -80,7 +80,7 @@
     range: 1.75
     damage:
       types:
-        Piercing: 5
+        Piercing: 7
         Slash: 3.5
     wideAnimationRotation: -135
     soundHit:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Lever/lever.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Lever/lever.yml
@@ -32,6 +32,7 @@
           - CartridgeMagnum
   - type: Gun
     fireRate: 0.8
+    damageModifier: 1.65 # BSO exclusive rifle shooting .45 magnum rounds
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
   - type: ChamberMagazineAmmoProvider
@@ -46,7 +47,7 @@
     soundBoltClosed:
       path: /Audio/Weapons/Guns/Bolt/lever_bolt_closed.ogg
       params:
-        volume: -3  
+        volume: -3
     soundBoltOpened:
       path: /Audio/Weapons/Guns/Bolt/lever_bolt_opened.ogg
       params:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

NERF MOSIN BUFF CHESTER

https://discord.com/channels/1218698320155906090/1218698321053356060/1360055663426015233 message link for media

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Mosin damage buff nerfed to 1.5x, and melee damage buffed slightly too (it has a bayonet)
- tweak: Chester now does 1.65x damage 
