### PR TITLE
Add Nanotrasen as an Employer for Every Job

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Command/administrative_assistant.yml
@@ -30,6 +30,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - IdrisIncorporated
+      - NanoTrasen
   startingGear: AdminAssistantGear
   icon: "JobIconAdminAssitant"
   supervisors: job-supervisors-command

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -13,6 +13,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - IdrisIncorporated
+      - NanoTrasen
   access:
   - Command
   - ChiefJustice

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
@@ -16,6 +16,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - IdrisIncorporated
+      - NanoTrasen
 
 
   startingGear: ClerkGear

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -24,6 +24,7 @@
       - Cybersun
       - Interdyne
       - PMCG
+      - NanoTrasen
   startingGear: CorpsmanGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
@@ -14,6 +14,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - OrionExpress
+      - NanoTrasen
 
 - type: startingGear
   id: MailCarrierGear

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -27,6 +27,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
 
 - type: startingGear
   id: PrisonGuardGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -16,6 +16,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - OrionExpress
+      - NanoTrasen
 
 - type: startingGear
   id: CargoTechGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,6 +13,7 @@
       employers:
       - OrionExpress
       - IdrisIncorporated
+      - NanoTrasen
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -11,6 +11,7 @@
       employers:
       - OrionExpress
       - PMCG
+      - NanoTrasen
   #  - !type:OverallPlaytimeRequirement #DeltaV
   #    time: 36000 #10 hrs
   icon: "JobIconShaftMiner"

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -26,11 +26,6 @@
     - type: Snoring # Necessary so SleepEmitSound sound effects play
   - !type:AddImplantSpecial
     implants: [ SadTromboneImplant ]
-  requirements:
-    - !type:CharacterEmployerRequirement
-      inverted: true
-      employers:
-      - Unemployed
 
 - type: startingGear
   id: ClownGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -14,11 +14,6 @@
   - !type:GiveItemOnHolidaySpecial
     holiday: GarbageDay
     prototype: WeaponRevolverInspector
-  requirements:
-    - !type:CharacterEmployerRequirement
-      inverted: true
-      employers:
-      - Unemployed
 
 - type: startingGear
   id: JanitorGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -15,11 +15,6 @@
     components:
     - type: MimePowers
     - type: FrenchAccent
-  requirements:
-    - !type:CharacterEmployerRequirement
-      inverted: true
-      employers:
-      - Unemployed
 
 - type: startingGear
   id: MimeGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -14,11 +14,6 @@
   - !type:GiveItemOnHolidaySpecial
     holiday: MikuDay
     prototype: BoxPerformer
-  requirements:
-    - !type:CharacterEmployerRequirement
-      inverted: true
-      employers:
-      - Unemployed
 
 - type: startingGear
   id: MusicianGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -11,6 +11,7 @@
       employers:
       - HephaestusIndustries
       - EinsteinEngines
+      - NanoTrasen
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -18,6 +18,7 @@
       - HephaestusIndustries
       - Cybersun
       - EinsteinEngines
+      - NanoTrasen
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -12,6 +12,7 @@
       - HephaestusIndustries
       - Cybersun
       - EinsteinEngines
+      - NanoTrasen
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -17,6 +17,7 @@
       - HephaestusIndustries
       - Cybersun
       - EinsteinEngines
+      - NanoTrasen
 
 - type: startingGear
   id: TechnicalAssistantGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -10,6 +10,8 @@
     - !type:CharacterEmployerRequirement
       employers:
       - ZengHuPharmaceuticals
+      - Interdyne
+      - NanoTrasen
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,6 +15,7 @@
       employers:
       - ZengHuPharmaceuticals
       - Interdyne
+      - NanoTrasen
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -11,6 +11,7 @@
       employers:
       - ZengHuPharmaceuticals
       - Interdyne
+      - NanoTrasen
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -12,6 +12,7 @@
       employers:
       - ZengHuPharmaceuticals
       - Interdyne
+      - NanoTrasen
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,6 +13,8 @@
     - !type:CharacterEmployerRequirement
       employers:
       - Interdyne
+      - NanoTrasen
+      - ZengHuPharmaceuticals
     # - !type:OverallPlaytimeRequirement # DeltaV - No playtime requirement
     #   time: 54000 # 15 hrs
   startingGear: ParamedicGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -17,6 +17,7 @@
       employers:
       - ZengHuPharmaceuticals
       - Interdyne
+      - NanoTrasen
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -10,6 +10,7 @@
   - !type:CharacterEmployerRequirement
       employers:
       - Cybersun
+      - NanoTrasen
   startingGear: RoboticistGear
   icon: "JobIconRoboticist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -20,6 +20,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -17,6 +17,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -17,6 +17,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -20,6 +20,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -30,6 +30,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -24,6 +24,7 @@
       employers:
       - Cybersun
       - PMCG
+      - NanoTrasen
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -16,6 +16,7 @@
     - !type:CharacterEmployerRequirement
       employers:
       - Interdyne
+      - NanoTrasen
 
 - type: startingGear
   id: PsychologistGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -24,8 +24,7 @@
         - BrittleBoneDisease
     - !type:CharacterEmployerRequirement
       employers:
-      - Cybersun
-      - PMCG
+      - NanoTrasen # BSO works directly for centcomm, they are not a contractor.
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconBlueshield"


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds Nanotrasen as an employer for every job, because you are on an NT station. Also makes it so unemployed people can take clown, mime, musician, and janitor.

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Nanotrasen employees can take every job again
