### PR TITLE
Cooler More Readable Loadout Tooltips

### DIFF
--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -252,15 +252,19 @@ public sealed partial class LoadoutPreferenceSelector : Control
 
         if (!string.IsNullOrEmpty(desc))
             tooltip.SetMessage(FormattedMessage.FromMarkupPermissive(desc));
-        toolBox.AddChild(new Label
+        if (loadout.Requirements.Any())
         {
-            Text = Loc.GetString("character-requirement-desc"),
-            StyleClasses = { StyleBase.StyleClassLabelHeading, },
-            Margin = new(0, 8, 0, 4),
-        });
+            toolBox.AddChild(
+                new Label
+                {
+                    Text = Loc.GetString("character-requirement-desc"),
+                    StyleClasses = { StyleBase.StyleClassLabelHeading, },
+                    Margin = new(0, 8, 0, 4),
+                });
 
-        MakeTooltipTree(toolBox, loadout.Requirements);
-        toolBox.AddChild(new() { Margin = new(0, 2), });
+            MakeTooltipTree(toolBox, loadout.Requirements);
+            toolBox.AddChild(new() { Margin = new(0, 2), });
+        }
 
         return;
 

--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -188,7 +188,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
                     MinWidth = 32,
                     MaxWidth = 32,
                     ClipText = true,
-                    Margin = new Thickness(0, 0, 8, 0),
+                    Margin = new(0, 0, 8, 0),
                 },
                 new PanelContainer
                 {
@@ -201,7 +201,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
                 new Label
                 {
                     Text = loadoutName,
-                    Margin = new Thickness(8, 0, 0, 0),
+                    Margin = new(8, 0, 0, 0),
                 },
             },
         });
@@ -238,35 +238,68 @@ public sealed partial class LoadoutPreferenceSelector : Control
         ColorEdit.OnColorChanged += _ =>
         {
             _preference.CustomColorTint = SpecialColorTintToggle.Pressed ? ColorEdit.Color.ToHex() : null;
-            UpdatePaint(new Entity<PaintedComponent>(dummyLoadoutItem, paint), entityManager);
+            UpdatePaint(new(dummyLoadoutItem, paint), entityManager);
         };
 
+        var desc = Loc.GetString(loadoutDesc);
         NameEdit.PlaceHolder = loadoutName;
-        DescriptionEdit.Placeholder = new Rope.Leaf(Loc.GetString(loadoutDesc));
+        DescriptionEdit.Placeholder = new Rope.Leaf(desc);
 
 
-        var tooltip = new StringBuilder();
-        // Add the loadout description to the tooltip if there is one
-        if (!string.IsNullOrEmpty(loadoutDesc))
-            tooltip.Append($"{Loc.GetString(loadoutDesc)}");
+        var tooltip = new Tooltip();
+        PreferenceButton.TooltipSupplier = _ => tooltip;
+        var toolBox = (BoxContainer) tooltip.Children.First();
 
-        // Get requirement reasons
-        characterRequirementsSystem.CheckRequirementsValid(
-            loadout.Requirements, highJob, profile, new Dictionary<string, TimeSpan>(),
-            jobRequirementsManager.IsWhitelisted(), loadout,
-            entityManager, prototypeManager, configManager,
-            out var reasons);
-
-        // Add requirement reasons to the tooltip
-        foreach (var reason in reasons)
-            tooltip.Append($"\n{reason}");
-
-        // Combine the tooltip and format it in the checkbox supplier
-        if (tooltip.Length > 0)
+        if (!string.IsNullOrEmpty(desc))
+            tooltip.SetMessage(FormattedMessage.FromMarkupPermissive(desc));
+        toolBox.AddChild(new Label
         {
-            var formattedTooltip = new Tooltip();
-            formattedTooltip.SetMessage(FormattedMessage.FromMarkupPermissive(tooltip.ToString()));
-            PreferenceButton.TooltipSupplier = _ => formattedTooltip;
+            Text = Loc.GetString("character-requirement-desc"),
+            StyleClasses = { StyleBase.StyleClassLabelHeading, },
+            Margin = new(0, 8, 0, 4),
+        });
+
+        MakeTooltipTree(toolBox, loadout.Requirements);
+        toolBox.AddChild(new() { Margin = new(0, 2), });
+
+        return;
+
+        void MakeTooltipTree(BoxContainer box, List<CharacterRequirement> requirements)
+        {
+            foreach (var requirement in requirements)
+            {
+                if (requirement is CharacterLogicRequirement logicRequirement)
+                {
+                    requirement.IsValid(
+                        highJob, profile, new(), jobRequirementsManager.IsWhitelisted(), loadout,
+                        entityManager, prototypeManager, configManager, out var reason);
+                    box.AddChild(new RichTextLabel { Text = reason?.Split("\n")[0], Margin = new(8, 2), });
+                    var newBox = new BoxContainer { Orientation = BoxContainer.LayoutOrientation.Vertical, };
+                    box.AddChild(new PanelContainer
+                        {
+                            PanelOverride = new StyleBoxFlat
+                            {
+                                BackgroundColor = Color.FromHex("#1B1B1C"),
+                                BorderColor = Color.FromHex("#3A3A3D"),
+                                BorderThickness = new(1),
+                            },
+                            Margin = new(8, 2),
+                            Children = { newBox, },
+                        });
+                    MakeTooltipTree(newBox, logicRequirement.Requirements);
+                }
+                else
+                {
+                    requirement.IsValid(
+                        highJob, profile, new(), jobRequirementsManager.IsWhitelisted(), loadout,
+                        entityManager, prototypeManager, configManager, out var reason);
+                    box.AddChild(new RichTextLabel
+                    {
+                        Text = reason,
+                        Margin = new(8, 2),
+                    });
+                }
+            }
         }
     }
 

--- a/Content.Client/Lobby/UI/TraitPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/TraitPreferenceSelector.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using Content.Client.Players.PlayTimeTracking;
 using Content.Client.Stylesheets;
@@ -65,41 +66,74 @@ public sealed partial class TraitPreferenceSelector : Control
                     MinWidth = 32,
                     MaxWidth = 32,
                     ClipText = true,
-                    Margin = new Thickness(0, 0, 8, 0),
+                    Margin = new(0, 0, 8, 0),
                 },
                 new Label
                 {
                     Text = Loc.GetString($"trait-name-{trait.ID}"),
-                    Margin = new Thickness(8, 0, 0, 0),
+                    Margin = new(8, 0, 0, 0),
                 },
             },
         });
         PreferenceButton.OnToggled += OnPrefButtonToggled;
 
-        var tooltip = new StringBuilder();
+
+        var tooltip = new Tooltip();
+        PreferenceButton.TooltipSupplier = _ => tooltip;
+        var toolBox = (BoxContainer) tooltip.Children.First();
+
         // Add the loadout description to the tooltip if there is one
         var desc = Loc.GetString($"trait-description-{trait.ID}");
         if (!string.IsNullOrEmpty(desc) && desc != $"trait-description-{trait.ID}")
-            tooltip.Append(desc);
-
-
-        // Get requirement reasons
-        characterRequirementsSystem.CheckRequirementsValid(
-            trait.Requirements, highJob, profile, new Dictionary<string, TimeSpan>(),
-            jobRequirementsManager.IsWhitelisted(), trait,
-            entityManager, prototypeManager, configManager,
-            out var reasons);
-
-        // Add requirement reasons to the tooltip
-        foreach (var reason in reasons)
-            tooltip.Append($"\n{reason}");
-
-        // Combine the tooltip and format it in the checkbox supplier
-        if (tooltip.Length > 0)
+            tooltip.SetMessage(FormattedMessage.FromMarkupPermissive(desc));
+        toolBox.AddChild(new Label
         {
-            var formattedTooltip = new Tooltip();
-            formattedTooltip.SetMessage(FormattedMessage.FromMarkupPermissive(tooltip.ToString()));
-            PreferenceButton.TooltipSupplier = _ => formattedTooltip;
+            Text = Loc.GetString("character-requirement-desc"),
+            StyleClasses = { StyleBase.StyleClassLabelHeading, },
+            Margin = new(0, 8, 0, 4),
+        });
+
+        MakeTooltipTree(toolBox, trait.Requirements);
+        toolBox.AddChild(new() { Margin = new(0, 2), });
+
+        return;
+
+        void MakeTooltipTree(BoxContainer box, List<CharacterRequirement> requirements)
+        {
+            foreach (var requirement in requirements)
+            {
+                if (requirement is CharacterLogicRequirement logicRequirement)
+                {
+                    requirement.IsValid(
+                        highJob, profile, new(), jobRequirementsManager.IsWhitelisted(), trait,
+                        entityManager, prototypeManager, configManager, out var reason);
+                    box.AddChild(new RichTextLabel { Text = reason?.Split("\n")[0], Margin = new(8, 2), });
+                    var newBox = new BoxContainer { Orientation = BoxContainer.LayoutOrientation.Vertical, };
+                    box.AddChild(new PanelContainer
+                        {
+                            PanelOverride = new StyleBoxFlat
+                            {
+                                BackgroundColor = Color.FromHex("#1B1B1C"),
+                                BorderColor = Color.FromHex("#3A3A3D"),
+                                BorderThickness = new(1),
+                            },
+                            Margin = new(8, 2),
+                            Children = { newBox, },
+                        });
+                    MakeTooltipTree(newBox, logicRequirement.Requirements);
+                }
+                else
+                {
+                    requirement.IsValid(
+                        highJob, profile, new(), jobRequirementsManager.IsWhitelisted(), trait,
+                        entityManager, prototypeManager, configManager, out var reason);
+                    box.AddChild(new RichTextLabel
+                    {
+                        Text = reason,
+                        Margin = new(8, 2),
+                    });
+                }
+            }
         }
     }
 

--- a/Content.Client/Lobby/UI/TraitPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/TraitPreferenceSelector.xaml.cs
@@ -86,15 +86,19 @@ public sealed partial class TraitPreferenceSelector : Control
         var desc = Loc.GetString($"trait-description-{trait.ID}");
         if (!string.IsNullOrEmpty(desc) && desc != $"trait-description-{trait.ID}")
             tooltip.SetMessage(FormattedMessage.FromMarkupPermissive(desc));
-        toolBox.AddChild(new Label
+        if (trait.Requirements.Any())
         {
-            Text = Loc.GetString("character-requirement-desc"),
-            StyleClasses = { StyleBase.StyleClassLabelHeading, },
-            Margin = new(0, 8, 0, 4),
-        });
+            toolBox.AddChild(
+                new Label
+                {
+                    Text = Loc.GetString("character-requirement-desc"),
+                    StyleClasses = { StyleBase.StyleClassLabelHeading, },
+                    Margin = new(0, 8, 0, 4),
+                });
 
-        MakeTooltipTree(toolBox, trait.Requirements);
-        toolBox.AddChild(new() { Margin = new(0, 2), });
+            MakeTooltipTree(toolBox, trait.Requirements);
+            toolBox.AddChild(new() { Margin = new(0, 2), });
+        }
 
         return;
 

--- a/Content.Shared/Customization/Systems/CharacterRequirements.Logic.cs
+++ b/Content.Shared/Customization/Systems/CharacterRequirements.Logic.cs
@@ -12,16 +12,21 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Customization.Systems;
 
 
+[ImplicitDataDefinitionForInheritors, MeansImplicitUse]
+[Serializable, NetSerializable]
+public abstract partial class CharacterLogicRequirement : CharacterRequirement
+{
+    [DataField]
+    public List<CharacterRequirement> Requirements { get; private set; } = new();
+}
+
 /// <summary>
 ///    Requires all of the requirements to be true
 /// </summary>
 [UsedImplicitly]
 [Serializable, NetSerializable]
-public sealed partial class CharacterLogicAndRequirement : CharacterRequirement
+public sealed partial class CharacterLogicAndRequirement : CharacterLogicRequirement
 {
-    [DataField]
-    public List<CharacterRequirement> Requirements { get; private set; } = new();
-
     public override bool IsValid(JobPrototype job,
         HumanoidCharacterProfile profile,
         Dictionary<string, TimeSpan> playTimes,
@@ -60,11 +65,8 @@ public sealed partial class CharacterLogicAndRequirement : CharacterRequirement
 /// </summary>
 [UsedImplicitly]
 [Serializable, NetSerializable]
-public sealed partial class CharacterLogicOrRequirement : CharacterRequirement
+public sealed partial class CharacterLogicOrRequirement : CharacterLogicRequirement
 {
-    [DataField]
-    public List<CharacterRequirement> Requirements { get; private set; } = new();
-
     public override bool IsValid(JobPrototype job,
         HumanoidCharacterProfile profile,
         Dictionary<string, TimeSpan> playTimes,
@@ -116,11 +118,8 @@ public sealed partial class CharacterLogicOrRequirement : CharacterRequirement
 /// </summary>
 [UsedImplicitly]
 [Serializable, NetSerializable]
-public sealed partial class CharacterLogicXorRequirement : CharacterRequirement
+public sealed partial class CharacterLogicXorRequirement : CharacterLogicRequirement
 {
-    [DataField]
-    public List<CharacterRequirement> Requirements { get; private set; } = new();
-
     public override bool IsValid(JobPrototype job,
         HumanoidCharacterProfile profile,
         Dictionary<string, TimeSpan> playTimes,

--- a/Resources/Locale/en-US/customization/character-requirements.ftl
+++ b/Resources/Locale/en-US/customization/character-requirements.ftl
@@ -1,3 +1,5 @@
+character-requirement-desc = Requirements:
+
 ## Job
 character-job-requirement = You must{$inverted ->
     [true]{" "}not


### PR DESCRIPTION
# Description

I like doing stupid stuff with UI

---

<details><summary><h1>Media</h1></summary>
<p>

I can't take a picture of tooltip, so I got this through a video

![image](https://github.com/user-attachments/assets/3bcee967-2626-4d79-9a03-e32cca219d62)

</p>
</details>

---

# Changelog

:cl:
- tweak: Loadouts' and traits' tooltips are much easier to read and look better (and cooler of course)
