### PR TITLE
Bonus Traits

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using Content.Client.Administration.UI;
-using Content.Client.Guidebook;
 using Content.Client.Humanoid;
 using Content.Client.Message;
 using Content.Client.Players.PlayTimeTracking;
@@ -31,7 +30,6 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Client.Utility;
 using Robust.Client.Player;
-using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
@@ -2048,6 +2046,10 @@ namespace Content.Client.Lobby.UI
         private void UpdateTraitPreferences()
         {
             var points = _cfgManager.GetCVar(CCVars.GameTraitsDefaultPoints);
+            var maxTraits = _cfgManager.GetCVar(CCVars.GameTraitsMax);
+            if (Profile is not null && _prototypeManager.TryIndex<SpeciesPrototype>(Profile.Species, out var speciesPrototype))
+                points += speciesPrototype.BonusTraitPoints;
+
             _traitCount = 0;
 
             foreach (var preferenceSelector in _traitPreferences)
@@ -2067,7 +2069,7 @@ namespace Content.Client.Lobby.UI
             TraitPointsBar.Value = points;
             TraitPointsLabel.Text = Loc.GetString("humanoid-profile-editor-traits-header",
                 ("points", points), ("traits", _traitCount),
-                ("maxTraits", _cfgManager.GetCVar(CCVars.GameTraitsMax)));
+                ("maxTraits", maxTraits));
 
             // Set the remove unusable button's label to have the correct amount of unusable traits
             TraitsRemoveUnusableButton.Text = Loc.GetString("humanoid-profile-editor-traits-remove-unusable-button",

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -14,13 +14,12 @@ using Content.Shared.Roles;
 using Content.Shared.Traits;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
-using Content.Shared.Whitelist;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Humanoid.Prototypes;
 
 namespace Content.Server.Traits;
 
@@ -61,6 +60,9 @@ public sealed class TraitSystem : EntitySystem
         if (jobId is not null && !_prototype.TryIndex(jobId, out var jobPrototype)
             && jobPrototype is not null && !jobPrototype.ApplyTraits)
             return;
+
+        if (_prototype.TryIndex<SpeciesPrototype>(profile.Species, out var speciesProto))
+            pointsTotal += speciesProto.BonusTraitPoints;
 
         var jobPrototypeToUse = _prototype.Index(jobId ?? _prototype.EnumeratePrototypes<JobPrototype>().First().ID);
         var sortedTraits = new List<TraitPrototype>();

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -180,6 +180,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// </summary>
     [DataField]
     public float AverageWidth = 40f;
+
+    /// <summary>
+    ///     How many bonus trait points this species has. Our default is that only human "should" use this. But I'm not your mother,
+    ///     so do whatever you want with this. This can even be a negative number, meaning that your species can have less trait points.
+    /// </summary>
+    [DataField]
+    public int BonusTraitPoints;
 }
 
 public enum SpeciesNaming : byte

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -8,6 +8,7 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobHumanDummy
   skinColoration: HumanToned
+  bonusTraitPoints: 2
 
 # The lack of a layer means that
 # this person cannot have round-start anything


### PR DESCRIPTION
# Description

Adds a datafield for Species to define having bonus trait points or penalty trait points. Currently only used by Human because they have literally nothing. But you could for example make a particularly "powerful' species such as Oni have negative bonus trait points.

# TODO

<details><summary><h1>Media</h1></summary>
<p>
Felinid(Default 10 points):

![image](https://github.com/user-attachments/assets/1fe4ba3d-f8f5-4bb9-903e-23db534cef5b)

Human: (+2 trait points)

![image](https://github.com/user-attachments/assets/cba0c006-b059-4f7f-b461-ed40fdc94576)

</p>
</details>

# Changelog

:cl:
- add: Humans now have +2 bonus trait points. It's also possible now for "overpowered" species to have fewer trait points, although this is not currently used.