### PR TITLE
Remove Pulse Pistol From Loadouts

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -337,24 +337,6 @@
     startingCharge: 2000
 
 - type: entity
-  name: antique pulse pistol
-  parent: WeaponPulsePistol
-  id: WeaponPulsePistolHoS
-  description: One of the many weapons belonging to the Head of Security's private collection. This pistol is engraved with the words, "Forgive Us, Mother Sol'"
-  components:
-  - type: StealTarget
-    stealGroup: HoSAntiqueWeapon
-
-- type: entity
-  name: captain's pulse pistol
-  parent: WeaponPulsePistol
-  id: WeaponPulsePistolCaptain
-  description: A rare and exotic handgun gifted to the station's Captain. Its ivory grip has been engraved with the words, "Glory to the Company, Glory to Mother Sol. Phoron will make us all rich."
-  components:
-  - type: StealTarget
-    stealGroup: WeaponCaptain
-
-- type: entity
   name: pulse carbine
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseCarbine

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -172,22 +172,6 @@
     - WeaponAntiqueLaser
 
 - type: loadout
-  id: LoadoutCaptainPulsePistol
-  category: JobsCommandCaptain
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponPulsePistolCaptain
-
-- type: loadout
   id: LoadoutCaptainTerminus
   category: JobsCommandCaptain
   cost: 0

--- a/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -11,22 +11,6 @@
 # Or are weapons that fit a similar theme of "Rare weapons not normally seen by Security"
 
 - type: loadout
-  id: LoadoutCommandHoSPulsePistol
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponPulsePistolHoS
-
-- type: loadout
   id: LoadoutCommandHoSWt550
   category: JobsSecurityHeadOfSecurity
   cost: 0


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Some psychopath gave the pulse pistol as a loadout option to captain and HoS, for reference, the pulse pistol is a gun made for use by DEATHSQUAD and is INSANELY OVERTUNED as a consequence.

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Captain and HoS no longer get the pulse pistol
