### PR TITLE
Fix Slime Core Surgery

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -441,6 +441,15 @@
     slotId: posibrain
 
 - type: entity
+  parent: SurgeryInsertBrainTorso
+  id: SurgeryInsertSlimeCore
+  name: Insert Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOrganCondition
+    slotId: core
+
+- type: entity
   parent: SurgeryBase
   id: SurgeryRemoveHeart
   name: Remove Heart


### PR DESCRIPTION
# Description

Fixes the inability to surgically insert a slime core.

---

<details><summary><h1>Media</h1></summary>
<p>

![A slime core is removed and reinserted](https://github.com/user-attachments/assets/4cfc8ab0-48b3-488d-aa2a-079b9c0e7acb)

</p>
</details>

---

# Changelog

:cl:
- fix: Slimes can now have cores surgically inserted