### PR TITLE
Possible Fix for Test DeleteAllThenGhost in Debug.

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
@@ -26,13 +26,13 @@ public sealed partial class MindTests
         var conHost = pair.Server.ResolveDependency<IConsoleHost>();
         await pair.Server.WaitPost(() => conHost.ExecuteCommand("entities delete"));
 
-        int resonableTicksForRelease = 5;
+        int reasonableTicksForRelease = 5;
 #if DEBUG
-        int resonableFactorForDebug = 30;
-        resonableTicksForRelease *= resonableFactorForDebug;
+        int reasonableFactorForDebug = 30;
+        reasonableTicksForRelease *= reasonableFactorForDebug;
 #endif
 
-        await pair.RunTicksSync(resonableTicksForRelease);
+        await pair.RunTicksSync(reasonableTicksForRelease);
 
         Assert.That(pair.Server.EntMan.EntityCount, Is.EqualTo(0));
 

--- a/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTest.DeleteAllThenGhost.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Robust.Shared.Console;
 using Robust.Shared.Map;
 
@@ -25,7 +25,14 @@ public sealed partial class MindTests
         // Delete **everything**
         var conHost = pair.Server.ResolveDependency<IConsoleHost>();
         await pair.Server.WaitPost(() => conHost.ExecuteCommand("entities delete"));
-        await pair.RunTicksSync(5);
+
+        int resonableTicksForRelease = 5;
+#if DEBUG
+        int resonableFactorForDebug = 30;
+        resonableTicksForRelease *= resonableFactorForDebug;
+#endif
+
+        await pair.RunTicksSync(resonableTicksForRelease);
 
         Assert.That(pair.Server.EntMan.EntityCount, Is.EqualTo(0));
 


### PR DESCRIPTION

# Description

Type, on source branch should be DeleteAllThenGhost, but got name DeleteAllWhenGhost by misstake.

Added a multiplication for the number of ticks needed for the system to DeleteAll, was 5 in release, will be 150 in debug. 
Should still add minimal impact to the test runtime. 5 ticks was to slow when running debug. with a longer wait the test passes even in debug.

:cl:
- tweak: Tweaked the ticks in the test for DeleteAllThenGhost
