### PR TITLE
Container Manager Changed to Container System [Obsolete Fix]

### DIFF
--- a/Content.Server/Construction/Completions/EmptyAllContainers.cs
+++ b/Content.Server/Construction/Completions/EmptyAllContainers.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Construction.Completions
             HandsComponent? hands = null;
             var pickup = Pickup && entityManager.TryGetComponent(userUid, out hands);
 
-            foreach (var container in containerManager.GetAllContainers())
+            foreach (var container in containerSys.GetAllContainers(uid, containerManager))
             {
                 foreach (var ent in containerSys.EmptyContainer(container, true, reparent: !pickup))
                 {

--- a/Content.Server/Construction/Completions/EmptyAllContainers.cs
+++ b/Content.Server/Construction/Completions/EmptyAllContainers.cs
@@ -31,22 +31,22 @@ namespace Content.Server.Construction.Completions
             if (!entityManager.TryGetComponent(uid, out ContainerManagerComponent? containerManager))
                 return;
 
-            var containerSys = entityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
-            var handSys = entityManager.EntitySysManager.GetEntitySystem<HandsSystem>();
-            var transformSys = entityManager.EntitySysManager.GetEntitySystem<TransformSystem>();
+            var containerSystem = entityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
+            var handSystem = entityManager.EntitySysManager.GetEntitySystem<HandsSystem>();
+            var transformSystem = entityManager.EntitySysManager.GetEntitySystem<TransformSystem>();
 
             HandsComponent? hands = null;
             var pickup = Pickup && entityManager.TryGetComponent(userUid, out hands);
 
-            foreach (var container in containerSys.GetAllContainers(uid, containerManager))
+            foreach (var container in containerSystem.GetAllContainers(uid, containerManager))
             {
-                foreach (var ent in containerSys.EmptyContainer(container, true, reparent: !pickup))
+                foreach (var ent in containerSystem.EmptyContainer(container, true, reparent: !pickup))
                 {
                     if (EmptyAtUser && userUid is not null)
-                        transformSys.DropNextTo(ent, (EntityUid) userUid);
+                        transformSystem.DropNextTo(ent, (EntityUid) userUid);
 
                     if (pickup)
-                        handSys.PickupOrDrop(userUid, ent, handsComp: hands);
+                        handSystem.PickupOrDrop(userUid, ent, handsComp: hands);
                 }
             }
         }

--- a/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
@@ -10,10 +10,11 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
     {
         public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
         {
+            var containerSys = system.EntityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
             if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
                 return;
 
-            foreach (var container in containerManager.GetAllContainers())
+            foreach (var container in containerSys.GetAllContainers(owner))
             {
                 system.ContainerSystem.EmptyContainer(container, true, system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates);
             }

--- a/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
@@ -1,3 +1,4 @@
+using Robust.Server.Containers;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors
@@ -8,15 +9,17 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
     [DataDefinition]
     public sealed partial class EmptyAllContainersBehaviour : IThresholdBehavior
     {
-        public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+        public void Execute(EntityUid owner, DestructibleSystem destructibleSystem, EntityUid? cause = null)
         {
-            var containerSys = system.EntityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
-            if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
-                return;
-
-            foreach (var container in containerSys.GetAllContainers(owner))
+            var entityManager = destructibleSystem.EntityManager;
+            if (!entityManager.EntitySysManager.TryGetEntitySystem<ContainerSystem>(out var containerSystem))
             {
-                system.ContainerSystem.EmptyContainer(container, true, system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates);
+                return;
+            }
+
+            foreach (var container in containerSystem.GetAllContainers(owner))
+            {
+                destructibleSystem.ContainerSystem.EmptyContainer(container, true, entityManager.GetComponent<TransformComponent>(owner).Coordinates);
             }
         }
     }

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -476,8 +476,9 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         var drop_container = args.Container;
         if (drop_container is null)
             _containerSystem.TryGetContainingContainer((uid, null, null), out drop_container);
+        var containerSys = EntityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
 
-        foreach (var container in comp.GetAllContainers())
+        foreach (var container in containerSys.GetAllContainers(uid))
         {
             ConsumeEntitiesInContainer(args.EventHorizonUid, container, args.EventHorizon, drop_container);
         }

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -26,12 +26,12 @@ namespace Content.Server.Singularity.EntitySystems;
 public sealed class EventHorizonSystem : SharedEventHorizonSystem
 {
     #region Dependencies
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IMapManager _mapMan = default!;
-    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookupSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogManager = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
@@ -63,7 +63,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
 
     private void OnHorizonMapInit(EntityUid uid, EventHorizonComponent component, MapInitEvent args)
     {
-        component.NextConsumeWaveTime = _timing.CurTime;
+        component.NextConsumeWaveTime = _gameTiming.CurTime;
     }
 
     public override void Shutdown()
@@ -83,7 +83,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         var query = EntityQueryEnumerator<EventHorizonComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var eventHorizon, out var xform))
         {
-            var curTime = _timing.CurTime;
+            var curTime = _gameTiming.CurTime;
             if (eventHorizon.NextConsumeWaveTime <= curTime)
                 Update(uid, eventHorizon, xform);
         }
@@ -133,7 +133,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
             || _tagSystem.HasTag(morsel, "HighRiskItem")
             || HasComp<ContainmentFieldGeneratorComponent>(morsel))
         {
-            _adminLogger.Add(LogType.EntityDelete, LogImpact.Extreme, $"{ToPrettyString(morsel)} entered the event horizon of {ToPrettyString(hungry)} and was deleted");
+            _adminLogManager.Add(LogType.EntityDelete, LogImpact.Extreme, $"{ToPrettyString(morsel)} entered the event horizon of {ToPrettyString(hungry)} and was deleted");
         }
 
         EntityManager.QueueDeleteEntity(morsel);
@@ -175,13 +175,13 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
             return;
 
         // TODO: Should be sundries + static-sundries but apparently this is load-bearing for SpawnAndDeleteAllEntitiesInTheSameSpot so go figure.
-        foreach (var entity in _lookup.GetEntitiesInRange(uid, range, flags: LookupFlags.Uncontained))
+        foreach (var entity in _entityLookupSystem.GetEntitiesInRange(uid, range, flags: LookupFlags.Uncontained))
         {
             if (entity == uid)
                 continue;
 
             // See TODO above
-            if (_physicsQuery.TryComp(entity, out var otherBody) && !_physics.IsHardCollidable((uid, null, body), (entity, null, otherBody)))
+            if (_physicsQuery.TryComp(entity, out var otherBody) && !_physicsSystem.IsHardCollidable((uid, null, body), (entity, null, otherBody)))
                 continue;
 
             AttemptConsumeEntity(uid, entity, eventHorizon);
@@ -306,7 +306,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         var box = Box2.CenteredAround(mapPos.Position, new Vector2(range, range));
         var circle = new Circle(mapPos.Position, range);
         var grids = new List<Entity<MapGridComponent>>();
-        _mapMan.FindGridsIntersecting(mapPos.MapId, box, ref grids);
+        _mapManager.FindGridsIntersecting(mapPos.MapId, box, ref grids);
 
         foreach (var grid in grids)
         {
@@ -353,7 +353,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         eventHorizon.TargetConsumePeriod = value;
         eventHorizon.NextConsumeWaveTime += diff;
 
-        var curTime = _timing.CurTime;
+        var curTime = _gameTiming.CurTime;
         if (eventHorizon.NextConsumeWaveTime < curTime)
             Update(uid, eventHorizon);
     }
@@ -476,10 +476,10 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         var drop_container = args.Container;
         if (drop_container is null)
             _containerSystem.TryGetContainingContainer((uid, null, null), out drop_container);
-        var containerSys = EntityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
 
-        foreach (var container in containerSys.GetAllContainers(uid))
+        foreach (var container in _containerSystem.GetAllContainers(uid, comp))
         {
+
             ConsumeEntitiesInContainer(args.EventHorizonUid, container, args.EventHorizon, drop_container);
         }
     }


### PR DESCRIPTION

# Description

Removed references to obsolete function in the Container manager, replaced them with the recommended ContainerSystem function calls.
Might have unified/verbosed a few variable names while at it.

- [x] remove container manager references
- [x] add container system refences
- [x] run tests to look for warnings.
- [x] run game looking for clear errors from things changed
- [ ] Scream about all the unnecessary changes compare to whats needed to fix the actual warnings. 

# Changelog

:cl:
- remove: ContainerManager references
- add: ContainerSystem references
- tweak: some variable naming
