### PR TITLE
Material Arbitrage Test Error Fix.

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Objects/Specific/Medical/syringecase.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Specific/Medical/syringecase.yml
@@ -34,7 +34,7 @@
     - CigPack # so it can be placed in things that whitelist cigarette packs
   - type: PhysicalComposition
     materialComposition:
-      Plastic: 100
+      Plastic: 62
   - type: Item
     size: Tiny
     shape:


### PR DESCRIPTION

# Description
Reduced the material composition of the syringe case to be the same as the of the lowest material use of the upgraded lathe, to avoid possibility to generate plastic by repeated crafting / dismantling.

# Changelog
:cl:
- tweak: resource composition
