### PR TITLE
Surgery Experience Traits + CPR Trait Tweak

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -617,3 +617,15 @@ trait-description-RestrictedGear =
     Either through personal ownership or theft, you have access to equipment that isn't particularly standard issue.
     Note that starting with an item [color=red]doesn't certify its legality[/color]. Conceal it or justify it.
     (You equip other jobs' items in the loadouts menu)
+
+trait-name-SurgeryTraining = Surgery Training
+trait-description-SurgeryTraining =
+    At some point in your life you acquired the knowledge and experience necessary for performing surgery effectively. 
+    This trait boosts your surgery speed to 1.6, and is intended for non-medical characters, as medical jobs already have faster surgery. 
+    (This is slightly faster than a medical intern (1.5) but slower than a normal doctor (1.75))
+
+trait-name-ExperiencedSurgeon = Experienced Surgeon
+trait-description-ExperiencedSurgeon =
+    Surgery is your specialty. You are faster than most at your craft.
+    This trait boosts your surgery speed to 2.5, which is the same as the innate boost CMO gets.
+    (This is either a boost from 1.75 or 2 depending on your job)

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: CPRTraining
   category: Mental
-  points: -4
+  points: -3
   functions:
     - !type:TraitAddComponent
       components:
@@ -17,6 +17,7 @@
         - ChiefMedicalOfficer
         - Brigmedic
         - SeniorPhysician
+        - BlueshieldOfficer
 
 - type: trait
   id: SelfAware
@@ -283,3 +284,43 @@
     - !type:TraitModifyFactions
       addFactions:
         - AnimalFriend
+
+- type: trait
+  id: SurgeryTraining
+  category: Mental
+  points: -3
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: SurgerySpeedModifier
+          speedModifier: 1.6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - MedicalDoctor
+        - Chemist
+        - MedicalIntern
+        - Paramedic
+        - ChiefMedicalOfficer
+        - Brigmedic
+        - SeniorPhysician
+
+- type: trait
+  id: ExperiencedSurgeon
+  category: Mental
+  points: -3
+  functions:
+    - !type:TraitReplaceComponent
+      components:
+      - type: SurgerySpeedModifier
+        speedModifier: 2.5
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+      - MedicalDoctor
+      - Chemist
+      - Paramedic
+      - Brigmedic
+      - SeniorPhysician
+


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR adds 2 new surgery related traits to the game (surgery training which boosts your surgery speed to 1.6, only available for non-medical jobs, as well as experienced surgeon, which boosts your surgery speed to 2.5, available only to medical jobs + corpsman, without intern. They both cost 3 points.) while also tweaking and fixing the CPR training one. (reduces cost from 4 to 3 and adds BSO to the blacklist as BSO already has CPR training innately) 

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![surgon](https://github.com/user-attachments/assets/282730f8-5579-492b-b6c8-96a4a8e02e25)

![surgon2](https://github.com/user-attachments/assets/d77244af-64d5-49b0-b18e-fb52840657bc)

![base surgery speed](https://github.com/user-attachments/assets/f20c9a6a-b46b-44eb-88d9-419daa984444)

![Surgery Training speed](https://github.com/user-attachments/assets/6f13f277-c17a-44e4-a72f-b0c67d2d4d70)

![Experienced Surgeon speed](https://github.com/user-attachments/assets/90a10192-c825-4659-a310-3ca4d5ed048d)

</p>

</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Traits that increase your surgery speed, Surgery Training (1.6, between intern and standard doc) for non-medical, and Experienced Surgeon (2.5, same as CMO) for medical w/o intern and with corpsman
- tweak: CPR Training cost 4 -> 3
- fix: BSO can no longer take the CPR trait as they already have it innately