### PR TITLE
Fix Passport Visuals Not Matching Actual Opened Status

### DIFF
--- a/Resources/Prototypes/_EE/Contractors/passports.yml
+++ b/Resources/Prototypes/_EE/Contractors/passports.yml
@@ -6,8 +6,6 @@
   description: A passport denoting an individual's nationality and identity.
   components:
     - type: Passport
-    - type: UseDelay
-      delay: 0.5
     - type: Sprite
       sprite: _EE/Contractors/Passport.rsi
       layers:


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR should fix passports being closed while appearing open, and vice-versa

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/abcc2769-9965-416d-b826-15a13bd87a6b)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed passport sometimes being closed while appearing open, and vice-versa
