### PR TITLE
Add Species Blacklists to Nukies/Ninja

### DIFF
--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -42,6 +42,9 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
         }
 
         args.Entity = Spawn(species.Prototype);
-        _humanoid.LoadProfile(args.Entity.Value, profile?.WithSpecies(species.ID));
+        if (profile != null)
+        {
+            _humanoid.LoadProfile(args.Entity.Value, profile.WithSpecies(species.ID));
+        }
     }
 }

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -31,19 +31,17 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
             ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
             : HumanoidCharacterProfile.RandomWithSpecies();
 
-
-        if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out var species))
+        SpeciesPrototype? species;
+        if (ent.Comp.SpeciesOverride != null)
+        {
+            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
+        }
+        else if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out species))
         {
             species = _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
         }
 
-        if (ent.Comp.SpeciesOverride != null
-            && (ent.Comp.SpeciesOverrideBlacklist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false))
-        {
-            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
-        }
-
         args.Entity = Spawn(species.Prototype);
-        _humanoid.LoadProfile(args.Entity.Value, profile!);
+        _humanoid.LoadProfile(args.Entity.Value, profile?.WithSpecies(species.ID));
     }
 }

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -34,7 +34,20 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
         SpeciesPrototype? species;
         if (ent.Comp.SpeciesOverride != null)
         {
-            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
+            // Only override if species is in blacklist
+            var useOverride = false;
+            if (ent.Comp.SpeciesOverrideBlacklist != null && 
+                profile?.Species is { } speciesId &&
+                ent.Comp.SpeciesOverrideBlacklist.Contains(speciesId))
+            {
+                useOverride = true;
+            }
+            
+            species = useOverride 
+                ? _proto.Index(ent.Comp.SpeciesOverride.Value)
+                : (profile?.Species is { } id && _proto.TryIndex(id, out SpeciesPrototype? profileSpecies))
+                    ? profileSpecies
+                    : _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
         }
         else if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out species))
         {

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -30,8 +30,18 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
         var profile = args.Session != null
             ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
             : HumanoidCharacterProfile.RandomWithSpecies();
-        if (profile?.Species is not {} speciesId || !_proto.TryIndex<SpeciesPrototype>(speciesId, out var species))
+
+
+        if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out var species))
+        {
             species = _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
+        }
+
+        if (ent.Comp.SpeciesOverride != null
+            && (ent.Comp.SpeciesOverrideBlacklist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false))
+        {
+            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
+        }
 
         args.Entity = Spawn(species.Prototype);
         _humanoid.LoadProfile(args.Entity.Value, profile!);

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -1,9 +1,20 @@
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server.GameTicking.Rules.Components;
 
 /// <summary>
 /// Makes this rules antags spawn a humanoid, either from the player's profile or a random one.
 /// </summary>
 [RegisterComponent]
+public sealed partial class AntagLoadProfileRuleComponent : Component
+{
+    /// <summary>
+    /// If specified, the profile loaded will be made into this species.
+    /// </summary>
+    [DataField]
+    public ProtoId<SpeciesPrototype>? SpeciesOverride;
+}
 public sealed partial class AntagLoadProfileRuleComponent : Component
 {
     /// <summary>

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -4,4 +4,17 @@ namespace Content.Server.GameTicking.Rules.Components;
 /// Makes this rules antags spawn a humanoid, either from the player's profile or a random one.
 /// </summary>
 [RegisterComponent]
-public sealed partial class AntagLoadProfileRuleComponent : Component;
+public sealed partial class AntagLoadProfileRuleComponent : Component
+{
+    /// <summary>
+    /// If specified, the profile loaded will be made into this species if the chosen species matches the blacklist.
+    /// </summary>
+    [DataField]
+    public ProtoId<SpeciesPrototype>? SpeciesOverride;
+
+    /// <summary>
+    /// List of species that trigger the override
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<SpeciesPrototype>>? SpeciesOverrideBlacklist;
+}

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -14,14 +14,6 @@ public sealed partial class AntagLoadProfileRuleComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<SpeciesPrototype>? SpeciesOverride;
-}
-public sealed partial class AntagLoadProfileRuleComponent : Component
-{
-    /// <summary>
-    /// If specified, the profile loaded will be made into this species if the chosen species matches the blacklist.
-    /// </summary>
-    [DataField]
-    public ProtoId<SpeciesPrototype>? SpeciesOverride;
 
     /// <summary>
     /// List of species that trigger the override

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -157,8 +157,7 @@
     speciesOverrideBlacklist:
     - IPC # Their EMP will hit themselves lol
     - Arachne # Cant wear suits
-    - Diona # Cant wear shoes, burn stupid fast, and move insanely slow
-    - Harpy # Cant wear shoes, have low base HP, and overall suck in combat
+    - Lamia # SNAKE WOMEN ARE NOT MADE FOR WAR
   - type: AntagObjectives
     objectives:
     - StealResearchObjective

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -155,7 +155,6 @@
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
-    - Vox # Obvious reasons
     - IPC # Their EMP will hit themselves lol
     - Arachne # Cant wear suits
     - Diona # Cant wear shoes, burn stupid fast, and move insanely slow

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -153,6 +153,13 @@
     minimumPlayers: 30
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
+    speciesOverride: Human
+    speciesOverrideBlacklist:
+    - Vox
+    - IPC
+    - Arachne
+    - Diona
+    - Harpy
   - type: AntagObjectives
     objectives:
     - StealResearchObjective

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -155,11 +155,11 @@
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
-    - Vox
-    - IPC
-    - Arachne
-    - Diona
-    - Harpy
+    - Vox # Obvious reasons
+    - IPC # Their EMP will hit themselves lol
+    - Arachne # Cant wear suits
+    - Diona # Cant wear shoes, burn stupid fast, and move insanely slow
+    - Harpy # Cant wear shoes, have low base HP, and overall suck in combat
   - type: AntagObjectives
     objectives:
     - StealResearchObjective

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -78,13 +78,9 @@
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
-    #Species that do not work with nukies should be included in this list.
-    #Once the issues are fixed the species should be removed from this list to be enabled.
-    #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
-    - IPC # Means the nukie team cant use EMPs, theres no good source of batteries, and theyre annoying for agent
+    - IPC # Their EMP will hit themselves lol
     - Arachne # Cant wear suits
-    - Diona # Cant wear shoes, burn stupid fast, and move insanely slow
-    - Harpy # Cant wear shoes, have low base HP, and overall suck in combat
+    - Lamia # SNAKE WOMEN ARE NOT MADE FOR WAR
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -14,7 +14,7 @@
     rules:
     - id: Thief
       prob: 0.5
-      
+
 - type: entity
   id: DeathMatch31
   parent: BaseGameRule
@@ -76,6 +76,16 @@
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule
+    speciesOverride: Human
+    speciesOverrideBlacklist:
+    #Species that do not work with nukies should be included in this list.
+    #Once the issues are fixed the species should be removed from this list to be enabled.
+    #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
+    - Vox
+    - IPC
+    - Arachne
+    - Diona
+    - Harpy
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -282,7 +292,7 @@
   components:
   - type: RampingStationEventScheduler
     chaosModifier: 5 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
-    startingChaosRatio: 0.1 
+    startingChaosRatio: 0.1
     shiftLengthModifier: 2.5
 
 - type: entity
@@ -332,4 +342,4 @@
 #      orGroup: puddleMess
     - id: SmugglerStashVariationPass
       prob: 0.90
-      
+

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -81,11 +81,11 @@
     #Species that do not work with nukies should be included in this list.
     #Once the issues are fixed the species should be removed from this list to be enabled.
     #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
-    - Vox
-    - IPC
-    - Arachne
-    - Diona
-    - Harpy
+    - Vox # Obvious reasons
+    - IPC # Means the nukie team cant use EMPs, theres no good source of batteries, and theyre annoying for agent
+    - Arachne # Cant wear suits
+    - Diona # Cant wear shoes, burn stupid fast, and move insanely slow
+    - Harpy # Cant wear shoes, have low base HP, and overall suck in combat
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -81,7 +81,6 @@
     #Species that do not work with nukies should be included in this list.
     #Once the issues are fixed the species should be removed from this list to be enabled.
     #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
-    - Vox # Obvious reasons
     - IPC # Means the nukie team cant use EMPs, theres no good source of batteries, and theyre annoying for agent
     - Arachne # Cant wear suits
     - Diona # Cant wear shoes, burn stupid fast, and move insanely slow


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Blacklists IPC, Arachne, and Lamia from Nukie/Ninja. 

IPC (Nukie): Means the nukie team can't use EMPs, there's no good source of batteries, their lack of a crit state means their acidifier will go off prematurely, and they're annoying for agent
IPC (Ninja): Their EMP will hit them
Arachne: Can't wear suits or shoes
Lamia: Obvious

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: IPCs, Arachne, and Lamia can no longer be nukies/ninja, instead theyll be forcibly set to human