### PR TITLE
Stop Ectoplasms Complaining

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -117,5 +117,11 @@ namespace Content.Server.Atmos.Components
             {
                 Params = AudioParams.Default.WithVolume(-5f),
             };
+
+        /// <summary>
+        ///     For things like jetpacks and integrated thrusters that you're not meant to be drinking/probably aren't connected to your breath supply anyways.
+        /// </summary>
+        [DataField]
+        public bool IsInternals = true;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -182,6 +182,9 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void ToggleInternals(Entity<GasTankComponent> ent)
         {
+            if (!ent.Comp.IsInternals)
+                return;
+
             if (ent.Comp.IsConnected)
             {
                 DisconnectFromInternals(ent);
@@ -220,7 +223,7 @@ namespace Content.Server.Atmos.EntitySystems
         public bool CanConnectToInternals(GasTankComponent component)
         {
             var internals = GetInternalsComponent(component, component.User);
-            return internals != null && internals.BreathTools.Count != 0 && !component.IsValveOpen;
+            return component.IsInternals && internals != null && internals.BreathTools.Count != 0 && !component.IsValveOpen;
         }
 
         public void ConnectToInternals(Entity<GasTankComponent> ent)
@@ -251,7 +254,7 @@ namespace Content.Server.Atmos.EntitySystems
         public void DisconnectFromInternals(Entity<GasTankComponent> ent)
         {
             var (owner, component) = ent;
-            if (component.User == null)
+            if (component.User == null || !ent.Comp.IsInternals)
                 return;
 
             var internals = GetInternalsComponent(component);

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -269,14 +269,14 @@ public sealed class InternalsSystem : EntitySystem
             return null;
 
         if (_inventory.TryGetSlotEntity(user, "back", out var backEntity, user.Comp2, user.Comp3) &&
-            TryComp<GasTankComponent>(backEntity, out var backGasTank) &&
+            TryComp<GasTankComponent>(backEntity, out var backGasTank) && backGasTank.IsInternals &&
             _gasTank.CanConnectToInternals(backGasTank))
         {
             return (backEntity.Value, backGasTank);
         }
 
         if (_inventory.TryGetSlotEntity(user, "suitstorage", out var entity, user.Comp2, user.Comp3) &&
-            TryComp<GasTankComponent>(entity, out var gasTank) &&
+            TryComp<GasTankComponent>(entity, out var gasTank) && gasTank.IsInternals &&
             _gasTank.CanConnectToInternals(gasTank))
         {
             return (entity.Value, gasTank);
@@ -284,7 +284,7 @@ public sealed class InternalsSystem : EntitySystem
 
         foreach (var item in _inventory.GetHandOrInventoryEntities((user.Owner, user.Comp1, user.Comp2)))
         {
-            if (TryComp(item, out gasTank) && _gasTank.CanConnectToInternals(gasTank))
+            if (TryComp(item, out gasTank) && gasTank.IsInternals && _gasTank.CanConnectToInternals(gasTank))
                 return (item, gasTank);
         }
 

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -464,12 +464,13 @@ public sealed class ToggleableClothingSystem : EntitySystem
             return;
 
         var prototypes = comp.ClothingPrototypes;
-
+        EntityUid? iconEntity = null;
         foreach (var prototype in prototypes)
         {
             var spawned = Spawn(prototype.Value, xform.Coordinates);
             var attachedClothing = EnsureComp<AttachedClothingComponent>(spawned);
             attachedClothing.AttachedUid = toggleable;
+            iconEntity = spawned;
             EnsureComp<ContainerManagerComponent>(spawned);
 
             comp.ClothingUids.Add(spawned, prototype.Key);
@@ -481,7 +482,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         Dirty(toggleable, comp);
 
         if (_actionContainer.EnsureAction(toggleable, ref comp.ActionEntity, out var action, comp.Action))
-            _actionsSystem.SetEntityIcon(comp.ActionEntity.Value, toggleable, action);
+            _actionsSystem.SetEntityIcon(comp.ActionEntity.Value, iconEntity, action);
     }
 
     // Checks status of all attached clothings toggle status

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,6 +1,6 @@
 # Standard Combat Hardsuits
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitCombatStandard
   name: combat hardsuit
   description: A purpose-built combat suit designed to protect its user against all manner of enemy combatants in low pressure environments.
@@ -45,7 +45,7 @@
 
 # Medical Combat Hardsuits
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitCombatMedical
   name: medical combat hardsuit
   description: A purpose-built combat suit designed to allow its user greater mobility for superior support of friendly units in active combat zones.
@@ -90,7 +90,7 @@
 
 # Riot Combat Hardsuits
 - type: entity
-  parent: ClothingOuterHardsuitBaseHeavy
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitCombatRiot
   name: riot combat hardsuit
   description: A purpose-built combat suit designed for crowd control against armed combatants in low pressure environments.
@@ -135,7 +135,7 @@
 
 # Advanced Combat Hardsuits
 - type: entity
-  parent: ClothingOuterHardsuitBaseHeavy
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitCombatAdvanced
   name: advanced combat hardsuit
   description: A purpose-built combat suit of second-generation design, providing unparalleled protection against all manner of kinetic forces in low pressure environments.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -30,7 +30,7 @@
 
 #Atmospherics Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitAtmos
   name: atmos hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has thermal shielding.
@@ -72,7 +72,7 @@
 
 #Engineering Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitEngineering
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitEngineeringUnpainted
   name: engineering hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has radiation shielding.
@@ -90,7 +90,7 @@
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringUnpainted
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitEngineering
   name: engineering hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has radiation shielding.
@@ -135,7 +135,7 @@
 
 #Spationaut Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitSpatio
   name: spationaut hardsuit
   description: A lightweight hardsuit designed for industrial EVA in zero gravity.
@@ -166,7 +166,7 @@
 
 #Salvage Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitSalvage
   name: mining hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters.
@@ -199,7 +199,7 @@
 
 #Paramedic Voidsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitVoidParamed
   name: paramedic hardsuit
   description: A hardsuit made for paramedics.
@@ -232,7 +232,7 @@
 
 
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitMaxim
   name: salvager maxim hardsuit
   description: Fire. Heat. These things forge great weapons, they also forge great salvagers.
@@ -364,7 +364,7 @@
 
 #Captain's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitCap
   name: captain's armored spacesuit
   description: A formal armored spacesuit, made for the station's captain.
@@ -400,7 +400,7 @@
 
 #Chief Engineer's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitEngineeringWhite
   name: chief engineer's hardsuit
   description: A special hardsuit that protects against hazardous, low pressure environments, made for the chief engineer of the station.
@@ -448,7 +448,7 @@
 
 #Chief Medical Officer's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitMedical
   name: chief medical officer's hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Built with lightweight materials for easier movement.
@@ -557,8 +557,8 @@
 
 #Luxury Mining Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
-  id: ClothingOuterHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
+  id: ClothingOuterHardsuitLuxury
   name: luxury mining hardsuit
   description: A refurbished mining hardsuit, fashioned after the Logistics Officer's colors. Graphene lining provides less protection, but is much easier to move. # DeltaV - Logistics Department replacing Cargo
   components:
@@ -609,7 +609,7 @@
     clothingPrototype: ClothingHeadHelmetHardsuitShanlinUnpainted
 
 - type: entity
-  parent: ClothingOuterHardsuitBaseMedium
+  parent: [ClothingOuterHardsuitBaseMedium, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitSyndie
   name: blood-red hardsuit
   description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
@@ -700,7 +700,7 @@
     clothingPrototype: ClothingHeadHelmetHardsuitShiweiUnpainted
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit
   description: An elite version of the blood-red hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders.
@@ -745,7 +745,7 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBaseHeavy
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
@@ -786,7 +786,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBaseHeavy
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit made by the cutting edge R&D department at cybersun to be hyper resilient.
@@ -1075,7 +1075,7 @@
 
 #Deathsquad
 - type: entity
-  parent: ClothingOuterHardsuitBaseHeavy
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitDeathsquad
   name: death squad hardsuit
   description: An advanced hardsuit favored by commandos for use in special operations.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -1,4 +1,53 @@
 - type: entity
+  id: BaseIntegratedMagboot
+  name: integrated magboots
+  description: A set of magnetic locks integrated into a suit.
+  abstract: true
+  components:
+    - type: ToggleClothing
+      action: ActionToggleMagboots
+    - type: ComponentToggler
+      components:
+        - type: NoSlip
+    - type: Magboots
+      slot: outerClothing
+    - type: ItemToggle
+      onUse: false # can't really wear it like that
+
+- type: entity
+  id: BaseIntegratedManeuveringThrusters
+  name: integrated maneuvering thrusters
+  description: A set of maneuvering thrusters integrated into a suit.
+  abstract: true
+  components:
+    - type: GasTank
+      outputPressure: 42.6
+      air:
+        # 10 minutes of thrust
+        volume: 3.75
+        temperature: 293.15
+        moles:
+          - 0.769267145 # oxygen
+          - 0.769267145 # nitrogen
+      isInternals: false # So you don't suck on your integrated thrusters
+    - type: ActivatableUI
+      key: enum.SharedGasTankUiKey.Key
+      verbOnly: true
+    - type: UserInterface
+      interfaces:
+        enum.SharedGasTankUiKey.Key:
+          type: GasTankBoundUserInterface
+    - type: Jetpack
+      moleUsage: 0.00085
+    - type: CanMoveInAir
+    - type: InputMover
+      toParent: true
+    - type: MovementSpeedModifier
+      weightlessAcceleration: 1
+      weightlessFriction: 0.3
+      weightlessModifier: 1.2
+
+- type: entity
   parent: [ClothingShoesBase, BaseToggleClothing]
   id: ClothingShoesBootsMagBase
   name: magboots

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -250,6 +250,8 @@
     - DoorBumpOpener
   - type: Targeting
   - type: SurgeryTarget
+  - type: MovedByPressure
+    cutoffTime: 1.0
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description

This PR adds a mechanic to various hardsuits and tacsuits, which can now include optional features such as Integrated Thrusters, or Integrated Magboots. All the syndicate tacsuits and "Advanced" crew tacsuits have both. Hardsuits typically have one or the other, rarely both. Vacsuits never have either, get a jetpack nerd. 

While I was at it, I fixed various bugs making these features obnoxious to interact with, such as hardsuits helmet toggles not showing the helmet, or turning on your integrated magboots also causing you to start sucking the air out of your integrated thrusters. 

Finally to address players incessantly complaining that "waaah space wind is too unfair it keeps me in the air too long", I lowered the maximum time player characters can go without being updated by space wind to 1 second, down from 2. Base items are untouched, so they'll remain in the air as per normal.

# Changelog

:cl:
- add: Added "Integrated Thrusters" and "Integrated Magboots" as features that hardsuits and tacsuits can sometimes have. Hardsuits rarely have both, and sometimes have neither, while the more "Advanced" Tacsuits such as the CSA series of suits will always have both. 
- tweak: Reduced the maximum amount of time player characters can remain in the air without being touched by space wind again to 1 second, down from 2. This does nothing if you're actively being thrown. 
- fix: Fixed a bug where the hardsuit action to toggle your helmet wasn't displaying the helmet icon.
