### PR TITLE
Buff mechs

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -85,7 +85,7 @@
     - DoorBumpOpener
     - FootstepSound
     - RipleyMkII
-    
+
 - type: entity
   id: MechRipley2Battery
   parent: MechRipley2
@@ -204,7 +204,7 @@
         Blunt: 25
         Structural: 180
   - type: CanMoveInAir
-  - type: MovementAlwaysTouching        
+  - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 2.6
@@ -352,7 +352,7 @@
   - type: ContainerFill
     containers:
       mech-battery-slot:
-      - PowerCellHyper
+      - PowerCageMedium
 
 - type: entity
   id: MechMarauderFilled
@@ -501,7 +501,7 @@
   - type: ContainerFill
     containers:
       mech-battery-slot:
-      - PowerCellHyper
+      - PowerCageMedium
 
 - type: entity
   id: MechGygaxSyndieFilled
@@ -541,7 +541,7 @@
     brokenState: mauler-broken
     mechToPilotDamageMultiplier: 0.1
     airtight: true
-    maxIntegrity: 500
+    maxIntegrity: 1000
     maxEquipmentAmount: 5
     pilotWhitelist:
       components:
@@ -562,7 +562,7 @@
   - type: MovementAlwaysTouching
   - type: Repairable
     fuelCost: 50
-    doAfterDelay: 25
+    doAfterDelay: 30
   - type: StaticPrice
     price: 30000 # Some respect if you steal one of these.
 
@@ -574,7 +574,7 @@
   - type: ContainerFill
     containers:
       mech-battery-slot:
-      - PowerCellHyper
+      - PowerCageHigh
 
 - type: entity
   id: MechMaulerSyndieFilled


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

All this PR does is switch out some mech batteries for power cages since power cages exist for mechs. This is a significant energy upgrade to the mauler and a more moderate change to the other mechs. The PR also doubles the mauler's integrity (it's meant to be a walking tank) but increases its repair time by five seconds.

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Most prefilled mechs have been given power cages rather then power cells
- tweak: The mauler has had its health doubled, but its repair time extended
