### PR TITLE
Woe, Cybernetic Appendage Trait Balancing Be upon Ye.

### DIFF
--- a/Resources/Locale/en-US/traits/misc.ftl
+++ b/Resources/Locale/en-US/traits/misc.ftl
@@ -5,3 +5,4 @@ examine-bionic-leg-message = {CAPITALIZE(POSS-ADJ($entity))} legs emit an ever p
 examine-thermal-vision-message = {CAPITALIZE(POSS-ADJ($entity))} eyes periodically pulse with a menacing red glare.
 examine-featherweight-message = {CAPITALIZE(THE($entity))} appears noticably thin for a member of their species.
 examine-bodybuilder-message = An impressive amount of muscle is visible on {POSS-ADJ($entity)} frame.
+examine-bionic-pryarm-message = {CAPITALIZE(POSS-ADJ($entity))} arms have a distinct look to them, as if they were a strange machine.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -629,3 +629,9 @@ trait-description-ExperiencedSurgeon =
     Surgery is your specialty. You are faster than most at your craft.
     This trait boosts your surgery speed to 2.5, which is the same as the innate boost CMO gets.
     (This is either a boost from 1.75 or 2 depending on your job)
+
+trait-name-BionicPryArm = Prybar Prosthetics
+trait-description-BionicPryArm =
+    Your arms have been reinforced with steel and hydraulics. You can force your way out of some unpleasant situations.
+    This trait gives you cybernetic DX-1 Pryarms, which let you pry open unpowered doors easily.
+    (They essentially function like a crowbar)

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -516,15 +516,24 @@
 - type: trait
   id: BionicArm
   category: Physical
-  points: -10
+  points: -8
   requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterJobRequirement
+        jobs:
+         - Paramedic
+      - !type:CharacterDepartmentRequirement
+          departments:
+          - Security
+          - Command
+          - Dignitary
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicPryArm
   functions:
     - !type:TraitCyberneticLimbReplacement
       removeBodyPart: Arm
@@ -896,33 +905,33 @@
               Brute: -0.6
               Burn: -0.6
 
-- type: trait
-  id: BionicLeg
-  category: Physical
-  points: -8
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bionic-leg-message
-          fontSize: 12
-          requireDetailRange: true
-    - !type:TraitCyberneticLimbReplacement
-      removeBodyPart: Leg
-      partSymmetry: Left
-      protoId: SpeedLeftLeg
-      slotId: "left leg"
-    - !type:TraitCyberneticLimbReplacement
-      removeBodyPart: Leg
-      partSymmetry: Right
-      protoId: SpeedRightLeg
-      slotId: "right leg"
+# - type: trait
+#   id: BionicLeg
+#   category: Physical
+#   points: -8
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+#     - !type:CharacterItemGroupRequirement
+#       group: TraitsMind
+#   functions:
+#     - !type:TraitPushDescription
+#       descriptionExtensions:
+#         - description: examine-bionic-leg-message
+#           fontSize: 12
+#           requireDetailRange: true
+#     - !type:TraitCyberneticLimbReplacement
+#       removeBodyPart: Leg
+#       partSymmetry: Left
+#       protoId: SpeedLeftLeg
+#       slotId: "left leg"
+#     - !type:TraitCyberneticLimbReplacement
+#       removeBodyPart: Leg
+#       partSymmetry: Right
+#       protoId: SpeedRightLeg
+#       slotId: "right leg"
 
 
 # - type: trait
@@ -1213,3 +1222,35 @@
           - Pill
           - Crayon
           - Paper
+
+- type: trait
+  id: BionicPryArm
+  category: Physical
+  points: -3
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicArm
+  functions:
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Left
+      protoId: CrowbarLeftArm
+      slotId: "left arm"
+    - !type:TraitCyberneticLimbReplacement
+      removeBodyPart: Arm
+      partSymmetry: Right
+      protoId: CrowbarRightArm
+      slotId: "right arm"
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-pryarm-message
+          fontSize: 12
+          requireDetailRange: true

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -181,3 +181,25 @@
         - Shard
         - Mousetrap
         - SlipEntity
+
+- type: entity
+  parent: LeftArmCybernetic
+  id: CrowbarLeftArm
+  name: DX-1 left Pryarm
+  description: A cybernetic left arm that can easily pry open unpowered doors.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 2
+
+- type: entity
+  parent: RightArmCybernetic
+  id: CrowbarRightArm
+  name: DX-1 right Pryarm
+  description: A cybernetic right arm that can easily pry open unpowered doors.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 2


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR tries to better balance bionic arms and comments out speed legs FOR NOW. 

For Bionic arms, it restricts them to only be accessible to security, command, dignitaries and paramedics, while also knocking down the cost back to 8, as it used to be. (this is because it is now only available to a select few and not everyone)
On top of that, I added a new trait, Prybar Prosthetics, which are cybernetic arms that can pry open UNPOWERED doors (so it's a crowbar). This one is much cheaper than bionic arm (3 points) and is available to everyone besides prisoners. (Yes it replaces your limbs with a new cybernetic arm with this function, the DX-1 Pryarms)

For speed legs, like previously stated, they're getting commented out. This is only temporary, until someone can figure out a way to rebalance them (speed legs as a whole I mean, not the trait itself.) so they aren't just a permament increase to speed. Speed is too good, look at what harpies pay for a 10% increase while sprinting.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Base Profile Screenshot 2025 04 16 - 17 49 18 97](https://github.com/user-attachments/assets/ac8d502c-249b-401a-baf0-01904c7da1d5)
![Base Profile Screenshot 2025 04 16 - 17 49 30 79](https://github.com/user-attachments/assets/8ef903e5-1377-48a9-8847-90f16cf07ef5)
![Prybar Prosthetics working](https://github.com/user-attachments/assets/d397da9e-33e5-452d-aefd-a3eb90f55a98)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added the Pryarm Prosthetics trait, that replaces your arms with the DX-1 Pryarms, which let you pry open unpowered doors just as you would with a crowbar.
- tweak: Made bionic arm cost 8 points again and be restricted to command, security, dignitaries and paramedics only.
- remove: Speed legs trait go bye bye for now.
