### PR TITLE
Medipen case + old bruiz recipe restoration

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -441,7 +441,7 @@
     Bicaridine: # Bicaridine is a conflicting brute medication and if mixed incorrectly will make Razorium. This is intended.
       amount: 1
     Lithium:
-      amount: 1
+      amount: 0.9
     Sugar:
       amount: 1
   products:

--- a/Resources/Prototypes/_EE/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/Belt/belts.yml
@@ -13,5 +13,5 @@
         amount: 2
       - id: Bloodpack
         amount: 2
-      - id: MedipenCigPack
+      - id: MedipenCase
       - id: OmnizineChemistryBottle

--- a/Resources/Prototypes/_EE/Entities/Objects/Misc/misc.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Misc/misc.yml
@@ -1,8 +1,8 @@
 - type: entity
-  id: MedipenCigPack
-  parent: CigPackBlue
-  name: medipen box
-  description: An AcmeCo cigarette box repurposed as medipen storage.
+  id: MedipenCase
+  parent: SyringeCase
+  name: medipen case
+  description: A syringe case stocked with an organized supply of medipens.
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Smol PR that replaces the medipen box in CMO's (filled) webbing with the medipen case. (Same thing but now uses the syringe case as the parent entity, and has a new name n description)
Also reverts the bruizine recipe back to the old one because it's supposed to be harder to make :godo:

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Base Profile Screenshot 2025 04 16 - 19 49 52 67](https://github.com/user-attachments/assets/c524e061-6976-4622-9be3-81f187846ce2)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Changed the medipen box used in the CMO's filled webbing into the medipen case.
- tweak: Reverted bruizine recipe back to the old one.
