### PR TITLE
Uncripple the Wall of Green (Accent Fixes)

### DIFF
--- a/Resources/Prototypes/DeltaV/Traits/neutral.yml
+++ b/Resources/Prototypes/DeltaV/Traits/neutral.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: ScottishAccent
-  slots: 0
-  itemGroupSlots: 0
+  # slots: 0
+  # itemGroupSlots: 0
   category: TraitsSpeechAccents
   points: 0
   requirements:

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -138,8 +138,8 @@
 
 - type: trait
   id: FrontalLisp
-  slots: 0
-  itemGroupSlots: 0
+  # slots: 0
+  # itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -25,8 +25,8 @@
 
 - type: trait
   id: Stutter
-  slots: 0
-  itemGroupSlots: 0
+  # slots: 0
+  # itemGroupSlots: 0
   category: TraitsSpeechAccents
   requirements:
     - !type:CharacterJobRequirement


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Yeah so last time I did an accent/language fix (https://github.com/Simple-Station/Einstein-Engines/pull/2212) I kinda forgot about the scottish, frontal lisp and stutter ones
so this PR does exactly the same thing as the PR linked, just for the missing accents. (Commenting out the lines that were supposed to let us make accents fully free as they don't work for now, which were the ones that specify how many trait slots and slots in the character item group the trait takes up)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/bd8a7e15-7f83-4330-b1d7-d3edd203b291


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed the scottish, stutter and frontal lisp accents not working.
