### PR TITLE
Turret Access Group and Access Level Changes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -95,12 +95,16 @@
     - Captain
     - HeadOfSecurity
     - Security
+    - NanotrasenRepresentative #EE
+    - BlueshieldOfficer #EE
+    - Magistrate #EE
     - Borg
     - BasicSilicon
   - type: DeployableTurretController
     accessGroups:
     - Cargo
     - Command
+    - Dignitary #EE
     - Engineering
     - General
     - Medical
@@ -113,6 +117,8 @@
     - Atmospherics
     - Bar
     - BasicSilicon
+    - BlueshieldOfficer #EE
+    - Boxer #EE
     - Borg
     - Brig
     - Detective
@@ -122,7 +128,9 @@
     - Chemistry
     - ChiefEngineer
     - ChiefMedicalOfficer
+    - Clown #EE
     - Command
+    - Corpsman #EE
     - Cryogenics
     - Engineering
     - External
@@ -132,9 +140,18 @@
     - Janitor
     - Kitchen
     - Lawyer
+    - Mail #EE
     - Maintenance
+    - Mantis #EE
+    - Magistrate #EE
     - Medical
+    - Mime #EE
+    - Musician #EE
+    - NanotrasenRepresentative #EE
+    - Paramedic #EE
+    - Psychologist #EE
     - Quartermaster
+    - Reporter #EE
     - Research
     - ResearchDirector
     - Salvage
@@ -204,6 +221,9 @@
     exemptAccessLevels:
     - Captain
     - ResearchDirector
+    - NanotrasenRepresentative #EE
+    - BlueshieldOfficer #EE
+    - Magistrate #EE
     - BasicSilicon
     - Borg
   - type: DeviceNetwork

--- a/Resources/Prototypes/_Goobstation/Access/centcomm.yml
+++ b/Resources/Prototypes/_Goobstation/Access/centcomm.yml
@@ -9,3 +9,10 @@
 - type: accessLevel
   id: Magistrate
   name: id-card-access-level-mag
+
+- type: accessGroup
+  id: Dignitary
+  tags:
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
+  - Magistrate


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description


---

Adds more access groups and levels to the turret controls so that you don't lethal the BSO because you were literally unable to set them as safe. I may have over-included some access levels so feel free to discuss that.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/142b3d07-8fe1-45fa-84fe-fcfc45ed6bce)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Turret controls are more modular and can target dignitary access.

