### PR TITLE
Magboots Refactor

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
@@ -15,6 +15,9 @@ public sealed partial class ClothingSpeedModifierComponent : Component
 
     [DataField]
     public float SprintModifier = 1.0f;
+
+    [DataField]
+    public bool RequiresToggle;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -59,8 +59,10 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 
     private void OnRefreshMoveSpeed(EntityUid uid, ClothingSpeedModifierComponent component, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
-        if (_toggle.IsActivated(uid))
-            args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+        if (component.RequiresToggle && !_toggle.IsActivated(uid))
+            return;
+
+        args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
     }
 
     private void OnClothingVerbExamine(EntityUid uid, ClothingSpeedModifierComponent component, GetVerbsEvent<ExamineVerb> args)

--- a/Content.Shared/Clothing/MagbootsComponent.cs
+++ b/Content.Shared/Clothing/MagbootsComponent.cs
@@ -5,7 +5,6 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Clothing;
 
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedMagbootsSystem))]
 public sealed partial class MagbootsComponent : Component
 {
     [DataField]
@@ -22,4 +21,40 @@ public sealed partial class MagbootsComponent : Component
     /// </summary>
     [DataField]
     public string Slot = "shoes";
+
+    /// <summary>
+    ///     Whether or not activating the magboots changes a sprite.
+    /// </summary>
+    [DataField]
+    public bool ChangeClothingVisuals;
+
+    /// <summary>
+    ///     Whether or not the magboots are currently Active.
+    /// </summary>
+    [DataField]
+    public bool Active;
+
+    /// <summary>
+    ///     Walk speed modifier to use while the magnets are active.
+    /// </summary>
+    [DataField]
+    public float ActiveWalkModifier = 0.85f;
+
+    /// <summary>
+    ///     Sprint speed modifier to use while the magnets are active.
+    /// </summary>
+    [DataField]
+    public float ActiveSprintModifier = 0.80f;
+
+    /// <summary>
+    ///     Walk speed modifier to use while the magnets are off.
+    /// </summary>
+    [DataField]
+    public float InactiveWalkModifier = 1f;
+
+    /// <summary>
+    ///     Sprint speed modifier to use while the magnets are off.
+    /// </summary>
+    [DataField]
+    public float InactiveSprintModifier = 1f;
 }

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Actions;
 using Content.Shared.Alert;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Clothing.EntitySystems;
@@ -7,6 +6,8 @@ using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Slippery;
 using Robust.Shared.Containers;
 
 namespace Content.Shared.Clothing;
@@ -30,33 +31,51 @@ public sealed class SharedMagbootsSystem : EntitySystem
         SubscribeLocalEvent<MagbootsComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
         SubscribeLocalEvent<MagbootsComponent, IsWeightlessEvent>(OnIsWeightless);
         SubscribeLocalEvent<MagbootsComponent, InventoryRelayedEvent<IsWeightlessEvent>>(OnIsWeightless);
+        SubscribeLocalEvent<MagbootsComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshMoveSpeed);
+        SubscribeLocalEvent<MagbootsComponent, SlipAttemptEvent>(OnSlipAttempt);
     }
 
     private void OnToggled(Entity<MagbootsComponent> ent, ref ItemToggledEvent args)
     {
         var (uid, comp) = ent;
+        comp.Active = args.Activated;
         // only stick to the floor if being worn in the correct slot
         if (_container.TryGetContainingContainer((uid, null, null), out var container) &&
             _inventory.TryGetSlotEntity(container.Owner, comp.Slot, out var worn)
             && uid == worn)
-        {
             UpdateMagbootEffects(container.Owner, ent, args.Activated);
+
+        if (comp.ChangeClothingVisuals)
+        {
+            var prefix = args.Activated ? "on" : null;
+            _item.SetHeldPrefix(ent, prefix);
+            _clothing.SetEquippedPrefix(ent, prefix);
         }
-
-        var prefix = args.Activated ? "on" : null;
-        _item.SetHeldPrefix(ent, prefix);
-        _clothing.SetEquippedPrefix(ent, prefix);
     }
 
-    private void OnGotUnequipped(Entity<MagbootsComponent> ent, ref ClothingGotUnequippedEvent args)
+    private void OnRefreshMoveSpeed(EntityUid uid, MagbootsComponent component, ref InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
+        var walkModifier = component.Active ? component.ActiveWalkModifier : component.InactiveWalkModifier;
+        var sprintModifier = component.Active ? component.ActiveSprintModifier : component.InactiveSprintModifier;
+        args.Args.ModifySpeed(walkModifier, sprintModifier);
+    }
+
+    private void OnSlipAttempt(EntityUid uid, MagbootsComponent component, SlipAttemptEvent args)
+    {
+        if (!component.Active)
+            return;
+
+        args.Cancel();
+    }
+
+    private void OnGotUnequipped(Entity<MagbootsComponent> ent, ref ClothingGotUnequippedEvent args) =>
         UpdateMagbootEffects(args.Wearer, ent, false);
-    }
 
-    private void OnGotEquipped(Entity<MagbootsComponent> ent, ref ClothingGotEquippedEvent args)
-    {
+    private void OnGotEquipped(Entity<MagbootsComponent> ent, ref ClothingGotEquippedEvent args) =>
         UpdateMagbootEffects(args.Wearer, ent, _toggle.IsActivated(ent.Owner));
-    }
+
+    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args) =>
+        OnIsWeightless(ent, ref args.Args);
 
     public void UpdateMagbootEffects(EntityUid user, Entity<MagbootsComponent> ent, bool state)
     {
@@ -72,7 +91,7 @@ public sealed class SharedMagbootsSystem : EntitySystem
 
     private void OnIsWeightless(Entity<MagbootsComponent> ent, ref IsWeightlessEvent args)
     {
-        if (args.Handled || !_toggle.IsActivated(ent.Owner))
+        if (args.Handled || !ent.Comp.Active)
             return;
 
         // do not cancel weightlessness if the person is in off-grid.
@@ -81,10 +100,5 @@ public sealed class SharedMagbootsSystem : EntitySystem
 
         args.IsWeightless = false;
         args.Handled = true;
-    }
-
-    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args)
-    {
-        OnIsWeightless(ent, ref args.Args);
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -6,9 +6,6 @@
   components:
     - type: ToggleClothing
       action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
     - type: Magboots
       slot: outerClothing
     - type: ItemToggle
@@ -67,9 +64,9 @@
     components:
     - type: NoSlip
   - type: Magboots
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.8
+    activeWalkModifier: 0.85
+    activeSprinModifier: 0.8
+    changeClothingVisuals: true
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -98,9 +95,9 @@
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-advanced.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+  - type: Magboots
+    activeWalkModifier: 1
+    activeSprintModifier: 1
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -121,9 +118,9 @@
   name: magboots of blinding speed
   description: These would look fetching on a fetcher like you.
   components:
-  - type: ClothingSpeedModifier
-    walkModifier: 1.10 #PVS isn't too much of an issue when you are blind...
-    sprintModifier: 1.10
+  - type: Magboots
+    activeWalkModifier: 1.10
+    activeSprintModifier: 1.10
   - type: StaticPrice
     price: 3000
 
@@ -138,9 +135,9 @@
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.9
+  - type: Magboots
+    activeWalkModifier: 0.95
+    activeSprintModifier: 0.9
   - type: GasTank
     outputPressure: 42.6
     air:
@@ -186,9 +183,9 @@
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.9
+  - type: Magboots
+    activeWalkModifier: 0.95
+    activeSprintModifier: 0.9
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -211,9 +208,9 @@
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-combat.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.82 # Slightly slower then normal magboots
-    sprintModifier: 0.77 # Slightly slower then normal magboots|
+  - type: Magboots
+    activeWalkModifier: 0.82
+    activeSprintModifier: 0.77
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -65,7 +65,7 @@
     - type: NoSlip
   - type: Magboots
     activeWalkModifier: 0.85
-    activeSprinModifier: 0.8
+    activeSprintModifier: 0.8
     changeClothingVisuals: true
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
@@ -134,15 +134,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
@@ -113,15 +113,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
 
 # Filled Kit Variants
 - type: entity

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/apocryphal.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/apocryphal.yml
@@ -166,15 +166,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/corporate.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/corporate.yml
@@ -162,15 +162,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/engineering-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/engineering-responsory.yml
@@ -154,15 +154,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/inquisitory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/inquisitory.yml
@@ -148,15 +148,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/janitorial-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/janitorial-responsory.yml
@@ -151,15 +151,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/leader-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/leader-responsory.yml
@@ -155,15 +155,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/medical-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/medical-responsory.yml
@@ -151,15 +151,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
@@ -149,15 +149,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/security-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/security-responsory.yml
@@ -151,15 +151,6 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
-    - type: ToggleClothing
-      action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
-    - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:
         shoes:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitSecurity
+  parent: [ClothingOuterHardsuitSecurity, BaseIntegratedMagboot]
   id: ClothingOuterHardsuitBlueshield
   name: blueshield's hardsuit
   description: A special security hardsuit made for the Blueshield Officer, has extra armor yet somehow feels lighter.
@@ -35,7 +35,7 @@
 # cybersun stealth
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitCybersunStealth
   suffix: stealth
   name: cybersun stealth hardsuit
@@ -98,7 +98,7 @@
 # cybersun dreadnought
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBaseHeavy, BaseIntegratedMagboot, BaseIntegratedManeuveringThrusters]
   id: ClothingOuterHardsuitCybersunDreadnought
   name: CSA-105UA "Xíngtiān" tacsuit # https://en.wikipedia.org/wiki/Xingtian in case you were wondering where the name comes from.
   description: A rare and exotic horror from the minds of Sol's finest engineers. This suit is worn as a punishment for crimes against Mother Sol.

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Shoes/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Shoes/modsuit.yml
@@ -23,9 +23,9 @@
   - type: SealableClothing
     sealUpPopup: sealable-clothing-seal-up-boots
     sealDownPopup: sealable-clothing-seal-down-boots
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+  - type: ToggleClothing
+    action: ActionToggleMagboots
+  - type: Magboots
   - type: SealableClothingVisuals
     visualLayers:
       shoes:

--- a/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
+++ b/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
@@ -131,14 +131,8 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-    - type: ClothingSpeedModifier
-      walkModifier: 1
-      sprintModifier: 1
     - type: ToggleClothing
       action: ActionToggleMagboots
-    - type: ComponentToggler
-      components:
-        - type: NoSlip
     - type: Magboots
     - type: SealableClothingVisuals
       visualLayers:


### PR DESCRIPTION
# Description

Yea so it turns out that magboots were previously extremely dependent on having other components work with them to do the "Magboot" ability. This doesn't at all comply with ECS standards, since the expectation I have is that the MagbootComponent ALONE should be sufficient to make an item into "Magboots". This PR addresses this issue by refactoring Magboots(and also ClothingSpeedModifier) to no longer depend on each other for this behavior. MagbootsComponent is now responsible for handling its own NoSlip, Gravity Immunity, and Movement Speed. This behavior will also be extremly useful for supporting things such as Modsuits and Hardsuit/Tacsuit upgrades, as well as Clothing Attachments in general(which is another thing I'm working on).

I have attached a video demonstrating that I have tested this PR and verified that it works.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/f4b602ff-54b9-4df2-a0a0-e3f691c45bf2

</p>
</details>

# Changelog

:cl:
- fix: Fixed various bugs related to Magboots and Integrated Magboots on hardsuits.
- tweak: All Modsuits as well as tacsuits contributed by Goobstation now also include Integrated Magsuits.
