### PR TITLE
Nerf The Shit Out Of Darkswap

### DIFF
--- a/Content.Shared/Shadowkin/EtherealComponent.cs
+++ b/Content.Shared/Shadowkin/EtherealComponent.cs
@@ -30,6 +30,15 @@ public sealed partial class EtherealComponent : Component
     [DataField]
     public bool CanBeStunned = true;
 
+    /// <summary>
+    ///     How much stamina damage does the user take each second they are in the dark realm?
+    /// </summary>
+    [DataField]
+    public float StaminaPerSecond = 1;
+
+    [DataField]
+    public float StaminaDamageOnFlash = 200f;
+
     public List<EntityUid> DarkenedLights = new();
 
     public float DarkenAccumulator;


### PR DESCRIPTION
# Description

Darkswap no longer makes you noninteractive with a ton of different things, like *breathing*, or *gravity*, or *space*. It also now has an enforced time limit via continuous stamina damage. Additionally it has now picked up a notable weakness/counterplay in the form of a unique flash vulnerability. When exposed to a flash effect, you immediately take a ton of stamina damage and are dropped out of the dark realm

# TODO

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/e9c061a4-d310-4ff0-8917-86ddc492fa0b

</p>
</details>

# Changelog

:cl:
- add: Added a "Flash" weakness to DarkSwap. Being hit by any flash, even if you have flash protection, causes you to instantly drop out of the dark realm and take a massive amount of stamina damage.
- add: DarkSwap users now take continuous stamina damage while in the dark realm.
- remove: DarkSwap no longer makes its user immune to Space, Gravity, and Vacuums. 
