### PR TITLE
Fix EmptyAllContainersBehaviour Test Fail

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/EmptyAllContainersBehaviour.cs
@@ -1,26 +1,22 @@
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 
-namespace Content.Server.Destructible.Thresholds.Behaviors
-{
-    /// <summary>
-    ///     Drop all items from all containers
-    /// </summary>
-    [DataDefinition]
-    public sealed partial class EmptyAllContainersBehaviour : IThresholdBehavior
-    {
-        public void Execute(EntityUid owner, DestructibleSystem destructibleSystem, EntityUid? cause = null)
-        {
-            var entityManager = destructibleSystem.EntityManager;
-            if (!entityManager.EntitySysManager.TryGetEntitySystem<ContainerSystem>(out var containerSystem))
-            {
-                return;
-            }
+namespace Content.Server.Destructible.Thresholds.Behaviors;
 
-            foreach (var container in containerSystem.GetAllContainers(owner))
-            {
-                destructibleSystem.ContainerSystem.EmptyContainer(container, true, entityManager.GetComponent<TransformComponent>(owner).Coordinates);
-            }
-        }
+/// <summary>
+///     Drop all items from all containers
+/// </summary>
+[DataDefinition]
+public sealed partial class EmptyAllContainersBehaviour : IThresholdBehavior
+{
+    public void Execute(EntityUid owner, DestructibleSystem destructibleSystem, EntityUid? cause = null)
+    {
+        var entityManager = destructibleSystem.EntityManager;
+        if (!entityManager.EntitySysManager.TryGetEntitySystem<ContainerSystem>(out var containerSystem)
+            || !entityManager.HasComponent<ContainerManagerComponent>(owner))
+            return;
+
+        foreach (var container in containerSystem.GetAllContainers(owner))
+            destructibleSystem.ContainerSystem.EmptyContainer(container, true, entityManager.GetComponent<TransformComponent>(owner).Coordinates);
     }
 }


### PR DESCRIPTION
# Description

During a previous "Routine Cleanup", this system lost its ability to tell the difference between a Powered Light and an AlwaysPoweredLight, due to no longer checking if the entity has a ContainerManagerComponent. This was essential for the function it passes the "Forced" keyword into. The fix for this is pretty simple, just check for the component and exit if it's not there.

Fixes this:

![image](https://github.com/user-attachments/assets/7aa9e2e3-fceb-4fdd-b55b-1cceac087ad2)


# Changelog

no CL this isn't player facing.
