### PR TITLE
Fix Thief Failing to Spawn Error

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -321,6 +321,11 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             antagEnt = Spawn(def.SpawnerPrototype);
             isSpawner = true;
         }
+        else
+        {
+            Log.Warning($"Attempted to create an antag for gamerule {ToPrettyString(ent)}, but a valid session was not found, and either no prototype could be spawned for it or spawners were disabled. Skipping.");
+            return;
+        }
 
         if (!antagEnt.HasValue)
         {

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -10,6 +10,8 @@
   parent: BaseGameRule
   id: SubGamemodesRule
   components:
+  - type: GameRule
+    minPlayers: 5
   - type: SubGamemodes
     rules:
     - id: Thief


### PR DESCRIPTION
# Description

This PR is an attempt to fix an error in Build & Test Debug when the game attempts to spawn a Thief gamerule.
I have reason to believe the gamerule is trying to activate with 0 players, in which case it's not exactly strange that it fails to find one.

## The test results indicate my success. If the test still fails, this fix does NOT work and should NOT be merged.

---

# TODO

- [ ] Await 100% successful test completion

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

No media possible. Check the Build and Test Debug test in this PR.

</p>
</details>

---

# Changelog

no changelog, not player-facing
