### PR TITLE
TCJ Makes A Rage Performance PR

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -572,9 +572,13 @@ namespace Content.Server.Atmos.EntitySystems
                 _currentRunAtmosphereIndex = 0;
                 _currentRunAtmosphere.Clear();
 
-                var query = EntityQueryEnumerator<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent>();
-                while (query.MoveNext(out var uid, out var atmos, out var overlay, out var grid))
+                var query = EntityQueryEnumerator<GridAtmosphereComponent>();
+                while (query.MoveNext(out var uid, out var atmos))
                 {
+                    if (!TryComp(uid, out GasTileOverlayComponent? overlay)
+                        || !TryComp(uid, out MapGridComponent? grid))
+                        continue;
+
                     _currentRunAtmosphere.Add((uid, atmos, overlay, grid, Transform(uid)));
                 }
             }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -114,9 +114,10 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
         if (_exposedTimer < ExposedUpdateDelay)
             return;
 
-        var query = EntityQueryEnumerator<AtmosExposedComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out _, out var transform))
+        var query = EntityQueryEnumerator<AtmosExposedComponent>();
+        while (query.MoveNext(out var uid, out _))
         {
+            var transform = Transform(uid);
             var air = GetContainingMixture((uid, transform));
 
             if (air == null)

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -84,22 +84,15 @@ namespace Content.Server.Body.Systems
         {
             base.Update(frameTime);
 
-            var metabolizers = new ValueList<(EntityUid Uid, MetabolizerComponent Component)>(Count<MetabolizerComponent>());
             var query = EntityQueryEnumerator<MetabolizerComponent>();
-
             while (query.MoveNext(out var uid, out var comp))
             {
-                metabolizers.Add((uid, comp));
-            }
-
-            foreach (var (uid, metab) in metabolizers)
-            {
                 // Only update as frequently as it should
-                if (_gameTiming.CurTime < metab.NextUpdate)
+                if (_gameTiming.CurTime < comp.NextUpdate)
                     continue;
 
-                metab.NextUpdate += metab.UpdateInterval;
-                TryMetabolize((uid, metab));
+                comp.NextUpdate += comp.UpdateInterval;
+                TryMetabolize((uid, comp));
             }
         }
 

--- a/Content.Server/CartridgeLoader/Cartridges/GlimmerMonitorCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/GlimmerMonitorCartridgeSystem.cs
@@ -28,8 +28,8 @@ public sealed class GlimmerMonitorCartridgeSystem : EntitySystem
     {
         if (args is not GlimmerMonitorSyncMessageEvent)
             return;
-        ;
-        UpdateUiState(uid, EntityManager.GetEntity( args.LoaderUid ), component);
+
+        UpdateUiState(uid, EntityManager.GetEntity(args.LoaderUid), component);
     }
 
     public void UpdateUiState(EntityUid uid, EntityUid loaderUid, GlimmerMonitorCartridgeComponent? component)

--- a/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -1,7 +1,7 @@
 using Content.Server.Chemistry.Components;
-using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Timing;
 
@@ -9,17 +9,18 @@ namespace Content.Server.Chemistry.EntitySystems;
 
 public sealed class SolutionRegenerationSystem : EntitySystem
 {
-    [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<SolutionRegenerationComponent, SolutionContainerManagerComponent>();
-        while (query.MoveNext(out var uid, out var regen, out var manager))
+        var query = EntityQueryEnumerator<SolutionRegenerationComponent>();
+        while (query.MoveNext(out var uid, out var regen))
         {
-            if (_timing.CurTime < regen.NextRegenTime)
+            if (_timing.CurTime < regen.NextRegenTime
+                || !TryComp(uid, out SolutionContainerManagerComponent? manager))
                 continue;
 
             // timer ignores if its full, it's just a fixed cycle

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -36,6 +36,8 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly SingletonDeviceNetServerSystem _singletonServerSystem = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!;
 
+    private readonly HashSet<Entity<SuitSensorComponent>> _wornSensors = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -56,21 +58,22 @@ public sealed class SuitSensorSystem : EntitySystem
         base.Update(frameTime);
 
         var curTime = _gameTiming.CurTime;
-        var sensors = EntityManager.EntityQueryEnumerator<SuitSensorComponent>();
-
-        while (sensors.MoveNext(out var uid, out var sensor))
+        foreach (var ent in _wornSensors)
         {
-            if (!TryComp(uid, out DeviceNetworkComponent? device))
+            var (uid, sensor) = ent;
+            if (!TryComp(uid, out DeviceNetworkComponent? device)
+                || device.TransmitFrequency is null
+                || sensor.User is null)
+            {
+                _wornSensors.Remove(ent); //Not a valid suit sensor array, cease all processing for it.
                 continue;
-
-            if (device.TransmitFrequency is null)
-                continue;
+            }
 
             // check if sensor is ready to update
             if (curTime < sensor.NextUpdate)
                 continue;
 
-            if (!CheckSensorAssignedStation(uid, sensor))
+            if (!CheckSensorAssignedStation(ent))
                 continue;
 
             // TODO: This would cause imprecision at different tick rates.
@@ -84,7 +87,10 @@ public sealed class SuitSensorSystem : EntitySystem
             // get sensor status
             var status = GetSensorState(uid, sensor);
             if (status == null)
+            {
+                _wornSensors.Remove(ent); //Someone turned the suit off, cease all checking.
                 continue;
+            }
 
             //Retrieve active server address if the sensor isn't connected to a server
             if (sensor.ConnectedServer == null)
@@ -114,8 +120,9 @@ public sealed class SuitSensorSystem : EntitySystem
     /// and tries to assign an unassigned sensor to a station if it's currently on a grid
     /// </summary>
     /// <returns>True if the sensor is assigned to a station or assigning it was successful. False otherwise.</returns>
-    private bool CheckSensorAssignedStation(EntityUid uid, SuitSensorComponent sensor)
+    private bool CheckSensorAssignedStation(Entity<SuitSensorComponent> ent)
     {
+        var (uid, sensor) = ent;
         var xform = Transform(uid);
         if (!sensor.StationId.HasValue && xform.GridUid is null)
             return false;
@@ -170,14 +177,16 @@ public sealed class SuitSensorSystem : EntitySystem
         }
     }
 
-    private void OnEquipped(EntityUid uid, SuitSensorComponent component, ref ClothingGotEquippedEvent args)
+    private void OnEquipped(Entity<SuitSensorComponent> ent, ref ClothingGotEquippedEvent args)
     {
-        component.User = args.Wearer;
+        ent.Comp.User = args.Wearer;
+        _wornSensors.Add(ent);
     }
 
-    private void OnUnequipped(EntityUid uid, SuitSensorComponent component, ref ClothingGotUnequippedEvent args)
+    private void OnUnequipped(Entity<SuitSensorComponent> ent, ref ClothingGotUnequippedEvent args)
     {
-        component.User = null;
+        ent.Comp.User = null;
+        _wornSensors.Remove(ent);
     }
 
     private void OnExamine(EntityUid uid, SuitSensorComponent component, ExaminedEvent args)
@@ -232,6 +241,7 @@ public sealed class SuitSensorSystem : EntitySystem
             return;
 
         component.User = args.Container.Owner;
+        _wornSensors.Add((uid, component));
     }
 
     private void OnRemove(EntityUid uid, SuitSensorComponent component, EntGotRemovedFromContainerMessage args)
@@ -240,6 +250,7 @@ public sealed class SuitSensorSystem : EntitySystem
             return;
 
         component.User = null;
+        _wornSensors.Remove((uid, component));
     }
 
     private void OnEmpPulse(EntityUid uid, SuitSensorComponent component, ref EmpPulseEvent args)
@@ -303,6 +314,9 @@ public sealed class SuitSensorSystem : EntitySystem
             return;
 
         component.Mode = mode;
+        if (mode == SuitSensorMode.SensorOff)
+            _wornSensors.Remove((uid, component));
+        else _wornSensors.Add((uid, component));
 
         if (userUid != null)
         {

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -56,10 +56,13 @@ public sealed class SuitSensorSystem : EntitySystem
         base.Update(frameTime);
 
         var curTime = _gameTiming.CurTime;
-        var sensors = EntityManager.EntityQueryEnumerator<SuitSensorComponent, DeviceNetworkComponent>();
+        var sensors = EntityManager.EntityQueryEnumerator<SuitSensorComponent>();
 
-        while (sensors.MoveNext(out var uid, out var sensor, out var device))
+        while (sensors.MoveNext(out var uid, out var sensor))
         {
+            if (!TryComp(uid, out DeviceNetworkComponent? device))
+                continue;
+
             if (device.TransmitFrequency is null)
                 continue;
 
@@ -113,10 +116,11 @@ public sealed class SuitSensorSystem : EntitySystem
     /// <returns>True if the sensor is assigned to a station or assigning it was successful. False otherwise.</returns>
     private bool CheckSensorAssignedStation(EntityUid uid, SuitSensorComponent sensor)
     {
-        if (!sensor.StationId.HasValue && Transform(uid).GridUid == null)
+        var xform = Transform(uid);
+        if (!sensor.StationId.HasValue && xform.GridUid is null)
             return false;
 
-        sensor.StationId = _stationSystem.GetOwningStation(uid);
+        sensor.StationId = _stationSystem.GetOwningStation(uid, xform);
         return sensor.StationId.HasValue;
     }
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -63,7 +63,7 @@ public sealed class SuitSensorSystem : EntitySystem
             var (uid, sensor) = ent;
             if (!TryComp(uid, out DeviceNetworkComponent? device)
                 || device.TransmitFrequency is null
-                || sensor.User is null)
+                || !Exists(sensor.User))
             {
                 _wornSensors.Remove(ent); //Not a valid suit sensor array, cease all processing for it.
                 continue;

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -36,7 +36,7 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly SingletonDeviceNetServerSystem _singletonServerSystem = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!;
 
-    private readonly HashSet<Entity<SuitSensorComponent>> _wornSensors = default!;
+    private readonly HashSet<Entity<SuitSensorComponent>> _wornSensors = new();
 
     public override void Initialize()
     {

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -316,7 +316,8 @@ public sealed class SuitSensorSystem : EntitySystem
         component.Mode = mode;
         if (mode == SuitSensorMode.SensorOff)
             _wornSensors.Remove((uid, component));
-        else _wornSensors.Add((uid, component));
+        else if (component.User != null)
+            _wornSensors.Add((uid, component));
 
         if (userUid != null)
         {

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -178,15 +178,15 @@ public sealed class HTNSystem : EntitySystem
     public void UpdateNPC(ref int count, int maxUpdates, float frameTime)
     {
         _planQueue.Process();
-        var query = EntityQueryEnumerator<ActiveNPCComponent, HTNComponent>();
+        var query = EntityQueryEnumerator<ActiveNPCComponent>();
 
-        while (query.MoveNext(out var uid, out _, out var comp))
+        while (query.MoveNext(out var uid, out _))
         {
             // If we're over our max count or it's not MapInit then ignore the NPC.
             if (count >= maxUpdates)
                 break;
 
-            if (!comp.Enabled)
+            if (!TryComp(uid, out HTNComponent? comp) || !comp.Enabled)
                 continue;
 
             if (comp.PlanningJob != null)

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -444,13 +444,13 @@ public sealed class StationSystem : EntitySystem
         if (!Resolve(entity, ref xform))
             throw new ArgumentException("Tried to use an abstract entity!", nameof(entity));
 
-        if (TryComp<StationDataComponent>(entity, out _))
+        if (HasComp<StationDataComponent>(entity))
         {
             // We are the station, just return ourselves.
             return entity;
         }
 
-        if (TryComp<MapGridComponent>(entity, out _))
+        if (HasComp<MapGridComponent>(entity))
         {
             // We are the station, just check ourselves.
             return CompOrNull<StationMemberComponent>(entity)?.Station;

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -61,9 +61,13 @@ public sealed class TemperatureSystem : EntitySystem
         base.Update(frameTime);
 
         // conduct heat from the surface to the inside of entities with internal temperatures
-        var query = EntityQueryEnumerator<InternalTemperatureComponent, TemperatureComponent>();
-        while (query.MoveNext(out var uid, out var comp, out var temp))
+        var query = EntityQueryEnumerator<InternalTemperatureComponent>();
+        while (query.MoveNext(out var uid, out var comp))
         {
+            if (!TryComp(uid, out TemperatureComponent? temp))
+                continue;
+            var tempEntity = (uid, temp);
+
             // don't do anything if they equalised
             var diff = Math.Abs(temp.CurrentTemperature - comp.Temperature);
             if (diff < 0.1f)
@@ -74,13 +78,13 @@ public sealed class TemperatureSystem : EntitySystem
 
             // convert to J then K
             var joules = q * comp.Area * frameTime;
-            var degrees = joules / GetHeatCapacity(uid, temp);
+            var degrees = joules / GetHeatCapacity(tempEntity);
             if (temp.CurrentTemperature < comp.Temperature)
                 degrees *= -1;
 
             // exchange heat between inside and surface
             comp.Temperature += degrees;
-            ForceChangeTemperature(uid, temp.CurrentTemperature - degrees, temp);
+            ForceChangeTemperature(tempEntity, temp.CurrentTemperature - degrees);
         }
 
         UpdateDamage(frameTime);
@@ -120,6 +124,15 @@ public sealed class TemperatureSystem : EntitySystem
         float delta = temperature.CurrentTemperature - temp;
         temperature.CurrentTemperature = temp;
         RaiseLocalEvent(uid, new OnTemperatureChangeEvent(temperature.CurrentTemperature, lastTemp, delta),
+            true);
+    }
+
+    public void ForceChangeTemperature(Entity<TemperatureComponent> ent, float temp)
+    {
+        float lastTemp = ent.Comp.CurrentTemperature;
+        float delta = ent.Comp.CurrentTemperature - temp;
+        ent.Comp.CurrentTemperature = temp;
+        RaiseLocalEvent(ent, new OnTemperatureChangeEvent(ent.Comp.CurrentTemperature, lastTemp, delta),
             true);
     }
 
@@ -168,6 +181,16 @@ public sealed class TemperatureSystem : EntitySystem
         if (physics.Mass < 1)
             return comp.SpecificHeat;
         else return comp.SpecificHeat * physics.FixturesMass;
+    }
+
+    public float GetHeatCapacity(Entity<TemperatureComponent> ent, PhysicsComponent? physics = null)
+    {
+        if (!Resolve(ent.Owner, ref physics, false) || physics.FixturesMass <= 0)
+            return Atmospherics.MinimumHeatCapacity;
+
+        if (physics.Mass < 1)
+            return ent.Comp.SpecificHeat;
+        else return ent.Comp.SpecificHeat * physics.FixturesMass;
     }
 
     private void OnInit(EntityUid uid, InternalTemperatureComponent comp, MapInitEvent args)

--- a/Content.Shared/Clothing/EntitySystems/EmitsSoundOnMoveSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/EmitsSoundOnMoveSystem.cs
@@ -21,10 +21,7 @@ public sealed class EmitsSoundOnMoveSystem : EntitySystem
 
     public override void Initialize()
     {
-
-
         base.Initialize();
-
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _clothingQuery = GetEntityQuery<ClothingComponent>();
         SubscribeLocalEvent<EmitsSoundOnMoveComponent, GotEquippedEvent>(OnEquipped);

--- a/Content.Shared/Clothing/EntitySystems/EmitsSoundOnMoveSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/EmitsSoundOnMoveSystem.cs
@@ -1,10 +1,9 @@
-using System.Numerics;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Gravity;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
@@ -14,22 +13,23 @@ namespace Content.Shared.Clothing.Systems;
 public sealed class EmitsSoundOnMoveSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedMapSystem _grid = default!;
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private EntityQuery<InputMoverComponent> _moverQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ClothingComponent> _clothingQuery;
 
     public override void Initialize()
     {
-        _moverQuery = GetEntityQuery<InputMoverComponent>();
+
+
+        base.Initialize();
+
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _clothingQuery = GetEntityQuery<ClothingComponent>();
-
         SubscribeLocalEvent<EmitsSoundOnMoveComponent, GotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<EmitsSoundOnMoveComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<EmitsSoundOnMoveComponent, InventoryRelayedEvent<MakeFootstepSoundEvent>>(OnFootstep);
     }
 
     private void OnEquipped(EntityUid uid, EmitsSoundOnMoveComponent component, GotEquippedEvent args)
@@ -42,30 +42,24 @@ public sealed class EmitsSoundOnMoveSystem : EntitySystem
         component.IsSlotValid = true;
     }
 
-    public override void Update(float frameTime)
+    private void OnFootstep(Entity<EmitsSoundOnMoveComponent> ent, ref InventoryRelayedEvent<MakeFootstepSoundEvent> args)
     {
-        var query = EntityQueryEnumerator<EmitsSoundOnMoveComponent>();
-        while (query.MoveNext(out var uid, out var comp))
-        {
-            UpdateSound(uid, comp);
-        }
-        query.Dispose();
-    }
+        var uid = ent.Owner;
+        var component = ent.Comp;
 
-    private void UpdateSound(EntityUid uid, EmitsSoundOnMoveComponent component)
-    {
         if (!_physicsQuery.TryGetComponent(uid, out var physics)
             || !_timing.IsFirstTimePredicted)
             return;
 
+        var xform = Transform(uid);
         // Space does not transmit sound
-        if (Transform(uid).GridUid == null)
+        if (xform.GridUid is null)
             return;
 
-        if (component.RequiresGravity && _gravity.IsWeightless(uid, physics, Transform(uid)))
+        if (component.RequiresGravity && _gravity.IsWeightless(uid, physics, xform))
             return;
 
-        var parent = Transform(uid).ParentUid;
+        var parent = xform.ParentUid;
 
         var isWorn = parent is { Valid: true } &&
                      _clothingQuery.TryGetComponent(uid, out var clothing)
@@ -74,22 +68,6 @@ public sealed class EmitsSoundOnMoveSystem : EntitySystem
 
         if (component.RequiresWorn && !isWorn)
             return;
-
-        // If this entity is worn by another entity, use that entity's coordinates
-        var coordinates = isWorn ? Transform(parent).Coordinates : Transform(uid).Coordinates;
-        var distanceNeeded = (isWorn && _moverQuery.TryGetComponent(parent, out var mover) && mover.Sprinting)
-            ? component.DistanceWalking // The parent is a mob that is currently sprinting
-            : component.DistanceSprinting; // The parent is not a mob or is not sprinting
-
-        if (!coordinates.TryDistance(EntityManager, component.LastPosition, out var distance) || distance > distanceNeeded)
-            component.SoundDistance = distanceNeeded;
-        else
-            component.SoundDistance += distance;
-
-        component.LastPosition = coordinates;
-        if (component.SoundDistance < distanceNeeded)
-            return;
-        component.SoundDistance -= distanceNeeded;
 
         var sound = component.SoundCollection;
         var audioParams = sound.Params

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -23,6 +23,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Overlays.Switchable;
 
 using Content.Shared.Stunnable;
+using Content.Shared.Movement.Events;
 
 namespace Content.Shared.Inventory;
 
@@ -46,6 +47,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, TargetBeforeHyposprayInjectsEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeGunShotEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeClimbEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, MakeFootstepSoundEvent>(RelayInventoryEvent);
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/Movement/Events/GetFootstepSoundEvent.cs
+++ b/Content.Shared/Movement/Events/GetFootstepSoundEvent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Audio;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Movement.Events;
 
@@ -14,4 +15,9 @@ public record struct GetFootstepSoundEvent(EntityUid User)
     /// Set the sound to specify a footstep sound and mark as handled.
     /// </summary>
     public SoundSpecifier? Sound;
+}
+
+public record struct MakeFootstepSoundEvent : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots => SlotFlags.WITHOUT_POCKET;
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -465,8 +465,10 @@ namespace Content.Shared.Movement.Systems
             if (mobMover.StepSoundDistance < distanceNeeded)
                 return false;
 
-            mobMover.StepSoundDistance -= distanceNeeded;
+            var soundEv = new MakeFootstepSoundEvent();
+            RaiseLocalEvent(uid, soundEv);
 
+            mobMover.StepSoundDistance -= distanceNeeded;
             if (TryComp<FootstepModifierComponent>(uid, out var moverModifier))
             {
                 sound = moverModifier.FootstepSoundCollection;

--- a/Content.Shared/Projectiles/EmbedEvent.cs
+++ b/Content.Shared/Projectiles/EmbedEvent.cs
@@ -6,26 +6,10 @@ namespace Content.Shared.Projectiles;
 /// Raised directed on an entity when it embeds in another entity.
 /// </summary>
 [ByRefEvent]
-public readonly record struct EmbedEvent(EntityUid? Shooter, EntityUid Embedded, TargetBodyPart? BodyPart)
-{
-    public readonly EntityUid? Shooter = Shooter;
-
-    /// <summary>
-    /// Entity that is embedded in.
-    /// </summary>
-    public readonly EntityUid Embedded = Embedded;
-
-    /// <summary>
-    ///   Body part that has the embedded entity.
-    /// </summary>
-    public readonly TargetBodyPart? BodyPart = BodyPart;
-}
+public readonly record struct EmbedEvent(EntityUid? Shooter, EntityUid Embedded, TargetBodyPart? BodyPart);
 
 /// <summary>
 /// Raised on an entity when it stops embedding in another entity.
 /// </summary>
 [ByRefEvent]
-public readonly record struct RemoveEmbedEvent(EntityUid? Remover)
-{
-    public readonly EntityUid? Remover = Remover;
-}
+public readonly record struct RemoveEmbedEvent(EntityUid? Remover);

--- a/Content.Shared/Projectiles/EmbedPassiveDamageSystem.cs
+++ b/Content.Shared/Projectiles/EmbedPassiveDamageSystem.cs
@@ -1,12 +1,9 @@
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Mobs;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs.Components;
-using Content.Shared.FixedPoint;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Projectiles;
@@ -15,6 +12,8 @@ public sealed class EmbedPassiveDamageSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+
+    private readonly HashSet<EmbedPassiveDamageComponent> _activeEmbeds = new();
 
     public override void Initialize()
     {
@@ -63,6 +62,7 @@ public sealed class EmbedPassiveDamageSystem : EntitySystem
         component.EmbeddedBodyPart = args.BodyPart;
         component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f);
 
+        _activeEmbeds.Add(component);
         Dirty(uid, component);
     }
 
@@ -74,6 +74,7 @@ public sealed class EmbedPassiveDamageSystem : EntitySystem
         component.EmbeddedBodyPart = null;
         component.NextDamage = TimeSpan.Zero;
 
+        _activeEmbeds.Remove(component);
         Dirty(uid, component);
     }
 
@@ -106,22 +107,23 @@ public sealed class EmbedPassiveDamageSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        base.Update(frameTime);
         var curTime = _timing.CurTime;
-
-        var query = EntityQueryEnumerator<EmbedPassiveDamageComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        foreach (var ent in _activeEmbeds)
         {
-            if (comp.Embedded is null ||
-                comp.EmbeddedDamageable is null ||
-                comp.NextDamage > curTime || // Make sure they're up for a damage tick
-                comp.EmbeddedMobState is null ||
-                comp.EmbeddedMobState.CurrentState == MobState.Dead) // Don't damage dead mobs, they've already gone through too much
+            if (ent.Embedded is null || !Exists(ent.Embedded)
+                || ent.EmbeddedDamageable is null
+                || ent.EmbeddedMobState is null
+                || ent.EmbeddedMobState.CurrentState == MobState.Dead)
+            {
+                _activeEmbeds.Remove(ent);
+                continue;
+            }
+
+            if (ent.NextDamage > curTime)
                 continue;
 
-            comp.NextDamage = curTime + TimeSpan.FromSeconds(1f);
-
-            _damageable.TryChangeDamage(comp.Embedded, comp.Damage, false, false, comp.EmbeddedDamageable, targetPart: comp.EmbeddedBodyPart);
+            ent.NextDamage = curTime + TimeSpan.FromSeconds(1f);
+            _damageable.TryChangeDamage(ent.Embedded, ent.Damage, false, false, ent.EmbeddedDamageable, targetPart: ent.EmbeddedBodyPart);
         }
     }
 }


### PR DESCRIPTION
# Description

I got baited by Ectoplasm, so I then spent 3 hours shaving off a sizeable chunk of this game's performance cost, including by taking 3 of the "Top 10 frametime consumers", and reducing their performance costs by 99% each. Along with various examples of slimming down some of the worst EQE's. 

Oh, and I fixed EmitSoundOnMove being desynced with actual movement. As part of making EmitSoundOnMove use 99% less CPU time, it was also synchronized with the MoverController. 

# Changelog

:cl:
- fix: Fixed items such as tactical webbing, bell collars, and hardsuits being desynced with character movement. 
- tweak: Made various large performance improvements.