### PR TITLE
Make the Corporate Liaison Not Able to Be an Antagonist

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -23,7 +23,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   supervisors: job-supervisors-centcom
-  canBeAntag: true
+  canBeAntag: false
   access:
   - CentralCommand
   - Brig


### PR DESCRIPTION
# Description

Corporate Liaison is no longer antag-eligible

---

# Changelog

:cl:
- remove: Removed antag eligibility for Corporate Liaison
