### PR TITLE
Crew Monitor Map Fixes

### DIFF
--- a/Resources/Maps/anchor.yml
+++ b/Resources/Maps/anchor.yml
@@ -79974,6 +79974,9 @@ entities:
     - type: Transform
       pos: 68.5,16.5
       parent: 2
+    - type: SingletonDeviceNetServer
+      active: False
+      available: False
 - proto: Crowbar
   entities:
   - uid: 12421

--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -27614,9 +27614,9 @@ entities:
     - type: Transform
       pos: 46.5,-4.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
+    - type: SingletonDeviceNetServer
+      active: False
+      available: False
 - proto: CrewMonitoringServerMachineCircuitboard
   entities:
   - uid: 4406

--- a/Resources/Maps/core.yml
+++ b/Resources/Maps/core.yml
@@ -63487,6 +63487,9 @@ entities:
     - type: Transform
       pos: 54.5,-35.5
       parent: 2
+    - type: SingletonDeviceNetServer
+      active: False
+      available: False
 - proto: CrewsimovCircuitBoard
   entities:
   - uid: 14925

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -62752,6 +62752,9 @@ entities:
     - type: Transform
       pos: 129.5,10.5
       parent: 1
+    - type: SingletonDeviceNetServer
+      active: False
+      available: False
 - proto: Crowbar
   entities:
   - uid: 2132

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -30257,6 +30257,9 @@ entities:
     - type: Transform
       pos: -12.5,-50.5
       parent: 2
+    - type: SingletonDeviceNetServer
+      active: False
+      available: False
 - proto: CrowbarRed
   entities:
   - uid: 3873


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

---
This doesn't address the root issue which is that this doesn't happen automatically, but this will make it so that players don't have to fix the crew monitor themselves round start.



<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/71fa4cb7-b6d1-487f-8efd-8f31eea8d2a1)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: The Crew Monitor server now works on Anchor, Asterisk, Core, Hive, Lambda, and Pebble roundstart.
