### PR TITLE
Disable Lavaland Worldgen In Debug

### DIFF
--- a/Content.Shared/_Lavaland/CCVar/CCVars.Lavaland.cs
+++ b/Content.Shared/_Lavaland/CCVar/CCVars.Lavaland.cs
@@ -9,8 +9,11 @@ public sealed partial class CCVars
     ///     Should the Lavaland roundstart generation be enabled.
     /// </summary>
     public static readonly CVarDef<bool> LavalandEnabled =
+#if RELEASE
         CVarDef.Create("lavaland.enabled", true, CVar.SERVERONLY);
-
+#else //Lavaland murders our test times. If you wanna test lavaland yourself, turn the CVar on manually.
+        CVarDef.Create("lavaland.enabled", false, CVar.SERVERONLY);
+#endif //Don't worry, this is JUST the worldgen, map tests and grid tests still run just fine.
     public static readonly CVarDef<bool> AllowDuplicatePkaModules =
         CVarDef.Create("modkit.dupes_enabled", true, CVar.REPLICATED | CVar.SERVER);
 }


### PR DESCRIPTION
# Description

This ONLY prevents the tests from inappropriately generating lavaland constantly, which lags them the hell out and kills them constantly. Consider it the same reason why Worldgen is also disabled on Debug. This notably also doesn't prevent the Lavaland test from running, nor does it prevent the tests from verifying that the lavaland related grids don't have issues. It just prevents the stupid lavaland map itself from generating in completely unrelated tests. If you don't believe me, go watch the test timer and enjoy it not taking 45 minutes anymore.

# Changelog

No CL this isn't player facing.
