### PR TITLE
Flight Speed, Moff Trait Small Rebalance

### DIFF
--- a/Resources/Prototypes/Body/Parts/harpy.yml
+++ b/Resources/Prototypes/Body/Parts/harpy.yml
@@ -164,7 +164,7 @@
     toolName: "a right arm" # Shitmed Change
     onAdd:
     - type: Flight
-      speedModifier: 1.25
+      speedModifier: 1.3 # For harpies, it gives an effective ~60% (60.16%) increase over sprinting (as sprinting has a 10% increase for harpies) with base harpy weightless modifier
       isLayerAnimated: true
       layer: "/Textures/Mobs/Customization/Harpy/harpy_wings.rsi"
       animationKey: "Flap"

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -128,12 +128,12 @@
 - type: trait
   id: MothFlight
   category: Physical
-  points: -5
+  points: -2
   functions:
     - !type:TraitAddComponent
       components:
         - type: Flight
-          speedModifier: 1.2 # gives an effective 32% increase over walking with base moth weightless modifier
+          speedModifier: 1.19 # gives an effective ~31% (30.9%) increase over walking with base moth weightless modifier
           flapInterval: 0.75
           needsHands: false
   requirements:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Discussed with some harpy players and agreed upon on call where we talked about trait balance (for the cost reduction for the trait).
This PR makes true flight (the trait for moffs that you can take when under 60kg, gives you a modified version of harpy flight) cost 2 (from 5) and reduces the speed modifier for flying from 1.2 to 1.19. (effective 32% increase to 30.9%)
Also adjusts the speed modifier for harpy flight to 1.3. (from an effective speed increase of 54% to 60.16%)

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Adjusted moth and harpy flight to be more balanced. (Moth flight, ~30% speed increase, Harpy flight ~60% over sprinting, accounts for all modifiers, including harpies 10% sprint speed increase) Makes True Flight trait cost -2 instead of -5.

