### PR TITLE
Bug Languages Accesibility + a Smol Fix

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -635,3 +635,14 @@ trait-description-BionicPryArm =
     Your arms have been reinforced with steel and hydraulics. You can force your way out of some unpleasant situations.
     This trait gives you cybernetic DX-1 Pryarms, which let you pry open unpowered doors easily.
     (They essentially function like a crowbar)
+
+trait-name-Moffic = Moffic
+trait-description-Moffic =
+    The language of the mothpeople borders on complete unintelligibility.
+    Some species with compatible mouthparts (IPC's speakers, Harpies' Larynx, and Chitinid's buzzing) are able to learn it.
+
+trait-name-Chittin = Chittin
+trait-description-Chittin =
+    A language consisting of clicks, buzzes, and some variety of harsh insect sounds.
+    Most of what makes up their speech comes from their antennae, making it a near-impossible language for those without to learn.
+    However, some species with compatible mouthparts (IPC's speakers, Harpies' Larynx, and Mothpeople's buzzing and antennae) are still able to learn it.

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -111,6 +111,10 @@
       inverted: true
       nationalities:
         - Valyrian
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:

--- a/Resources/Prototypes/_EE/Traits/languages.yml
+++ b/Resources/Prototypes/_EE/Traits/languages.yml
@@ -97,3 +97,45 @@
         - Delvahii
       languagesUnderstood:
         - Delvahii
+
+- type: trait
+  id: Moffic
+  category: TraitsSpeechLanguages
+  points: -1
+  # slots: 1
+  # itemGroupSlots: 0
+  requirements:
+    # - !type:CharacterItemGroupRequirement
+    #   group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Harpy
+        - Chitinid
+        - IPC
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Moffic
+      languagesUnderstood:
+        - Moffic
+
+- type: trait
+  id: Chittin
+  category: TraitsSpeechLanguages
+  points: -1
+  # slots: 1
+  # itemGroupSlots: 0
+  requirements:
+    # - !type:CharacterItemGroupRequirement
+    #   group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Harpy
+        - Moth
+        - IPC
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - Chittin
+      languagesUnderstood:
+        - Chittin


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR adds 2 language traits: One for Moffic, one for Chittin. Both can be taken by IPC and Harpy, and Moths can take Chittin, Chitinids can take Moffic. These three are the only ones that can take those traits, which cost 1 point. 
Additionally, it prevents Harpies from taking the Valyrian language trait, as they already start with that language so no need for them to waste a point.

---


<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Zrzut ekranu 2025-04-25 213816](https://github.com/user-attachments/assets/aa8de365-a703-4fcc-8e73-8f7d40e9aabe)
![Zrzut ekranu 2025-04-25 213942](https://github.com/user-attachments/assets/25d0a826-ec9d-4da0-8bf7-7a8d1f31c2cb)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Moffic (moff lang) and Chittin (chitinid lang) as languages traits. Available for IPCs and Harpies for 1 point, as well as Moths for Chittin and Chitinids for Moffic.
- fix: Harpies can no longer waste a point on the Valyrian standard language trait, which they already start with.
