### PR TITLE
Request by ODJ to Add IPC to to the Permited List of the Trait Lyre Bird

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -540,7 +540,7 @@ trait-description-ShadowkinBlackeye =
 
 trait-name-LyreBird = Lyre Bird
 trait-description-LyreBird =
-    Your natural talent for mimicry vastly exceeds that of other Harpies. You have the ability to perfectly imitate songs in their entirety.
+    Your talent for mimicry vastly exceeds the norms of others. You have the ability to perfectly imitate songs in their entirety.
     Be your own full symphony orchestra, jazz group, or metal band.
 
 trait-name-NaniteAutoRepairBots = Nanite Auto-Repair Bots

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -198,6 +198,7 @@
     - !type:CharacterSpeciesRequirement
       species:
         - Harpy
+        - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
# Description

IPCs have vocoder/voicechips to talk, they can resonable be extended altered used to produce a larger range of sound.

<details><summary><h1>The trait avalible on a IPC in character create</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0466c989-69a7-4823-87d1-45fcafbe1542)

:cl:
- add: Added IPC to permitted for Lyre Bird.
- altered: description to make it more neutral and less harpy specific.

