### PR TITLE
Abductor Eye Visibility Flag Change and Invisble Organ Removal

### DIFF
--- a/Content.Shared/Eye/VisibilityFlags.cs
+++ b/Content.Shared/Eye/VisibilityFlags.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Eye
         Ghost = 1 << 1,
         PsionicInvisibility = 1 << 2, //Nyano - Summary: adds Psionic Invisibility as a visibility layer. Currently does nothing.
         Ethereal = 1 << 3,
-        Abductor  = 1 << 4,
         TelegnosticProjection = 5,
+        Abductor  = 1 << 10, // I HATE BITWISE OPERATIONS!! GRAAAAH
     }
 }

--- a/Resources/Prototypes/_Shitmed/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Markers/Spawners/Random/dubious.yml
@@ -7,7 +7,7 @@
       weight: 50
       children:
       - id: OrganDubiousHealth
-      - id: OrganDubiousInvisible
+     # - id: OrganDubiousInvisible
       - id: OrganDubiousSpaceAdaptation
       - id: OrganDubiousScrambleDna
       - id: OrganDubiousScrambleLocation

--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Computers/computers.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Computers/computers.yml
@@ -74,7 +74,7 @@
   - type: Eye
     pvsScale: 1.5
   - type: Visibility
-    layer: 4
+    layer: 10
   - type: Sprite
     sprite: _Shitmed/Structures/Machines/abductor_camera_console.rsi
     layers:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Abductor Eye was visible to people other than the Abductor. That was obviously bad. Alongside that, the invisibility organ had issues revolving deleting items from the inventory. Also obviously bad.

---


<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/043c0f7f-48c7-449e-ba87-e9ebac50ff21)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Abductor Eye is now no longer visible for the inferior organisms.
- remove: Invisibility Organs were removed for being turbo-borked.
