### PR TITLE
Fix some Cvars Using Double as Their Type

### DIFF
--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -31,15 +31,15 @@ public sealed partial class CCVars
     /// <summary>
     ///     The amount of days before the note starts fading. It will slowly lose opacity until it reaches stale. Set to 0 to disable.
     /// </summary>
-    public static readonly CVarDef<double> NoteFreshDays =
-        CVarDef.Create("admin.note_fresh_days", 91.31055, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+    public static readonly CVarDef<float> NoteFreshDays =
+        CVarDef.Create("admin.note_fresh_days", 91.31055f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
     /// <summary>
     ///     The amount of days before the note completely fades, and can only be seen by admins if they press "see more notes". Set to 0
     ///     if you want the note to immediately disappear without fading.
     /// </summary>
-    public static readonly CVarDef<double> NoteStaleDays =
-        CVarDef.Create("admin.note_stale_days", 365.2422, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
+    public static readonly CVarDef<float> NoteStaleDays =
+        CVarDef.Create("admin.note_stale_days", 365.2422f, CVar.ARCHIVE | CVar.REPLICATED | CVar.SERVER);
 
     /// <summary>
     ///     How much time does the user have to wait in seconds before confirming that they saw an admin message?

--- a/Content.Shared/CCVar/CCVars.GhostRespawn.cs
+++ b/Content.Shared/CCVar/CCVars.GhostRespawn.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.CCVar;
 
 public sealed partial class CCVars
 {
-    public static readonly CVarDef<double> GhostRespawnTime =
-        CVarDef.Create("ghost.respawn_time", 15d, CVar.SERVERONLY);
+    public static readonly CVarDef<float> GhostRespawnTime =
+        CVarDef.Create("ghost.respawn_time", 15f, CVar.SERVERONLY);
 
     public static readonly CVarDef<int> GhostRespawnMaxPlayers =
         CVarDef.Create("ghost.respawn_max_players", 40, CVar.SERVERONLY);


### PR DESCRIPTION
# Description

The engine [does not technically support](https://github.com/user-attachments/assets/9cb5645b-b767-4f1e-aa43-6fae3ee4e9c8) the `double` type, but it seems some system was converting the interpreted string into a double so CVars worked fine when defined by a config file or when using defaults, but the `cvar` *command* doesn't work with it. I'd add support for it, but we haven't switched engines yet.

---

<details><summary><h1>Media</h1></summary>
<p>

Before
![image](https://github.com/user-attachments/assets/c2f760a9-705f-4e68-a9da-5c837abac40c)

After
![image](https://github.com/user-attachments/assets/e7f73ac3-9adb-4440-8667-52b41c5bdbc2)

</p>
</details>
