### PR TITLE
Clarifies Salvage Law

### DIFF
--- a/Resources/Locale/en-US/weapons/extenddescriptions/descriptions.ftl
+++ b/Resources/Locale/en-US/weapons/extenddescriptions/descriptions.ftl
@@ -1,5 +1,5 @@
 # Legality Notices
-gun-legality-salvage = This weapon is licensed for use in planetary expeditions. It is unlawful to brandish this weapon aboard NanoTrasen stations, and may be confiscated by Security if removed from the station's Salvage Department.
+gun-legality-salvage = This weapon is licensed solely for use in planetary expeditions. Possession of this weapon anywhere aboard a NanoTrasen station, outside of authorized Salvage operations, is illegal and may result in confiscation and criminal prosecution.
 
 # Weapon Modifiers
 gun-suppressed = This weapon comes with a built-in suppressor. It will be impossible to hear at a distance.

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedWeapons.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedWeapons.xml
@@ -4,9 +4,9 @@
   # Space Law: Restricted Weapons
 
 - [color=#cb0000]\[Security\][/color] Lethal firearms (excluding unmarked weapons, specialty tools like proto-kinetic accelerators)
-- [color=#cb0000]\[Security/Salvage\][/color] Specialty mining tools such as proto-kinetic accelerators, glaives, daggers, and crushers. (Salvage must use these tools off-station or in authorized operations only)
+- [color=#cb0000]\[Security/Salvage\][/color] Specialty mining tools (e.g., proto-kinetic accelerators, crusher*) are restricted to Salvage or expeditions for Salvage personnel. Unauthorized possession may result in confiscation and charges.
 - [color=#cb0000]\[Security/Command\][/color] Command-approved antique weapons (e.g., antique laser gun)
-- [color=#cb0000]\[Bartender\][/color] Civilian firearms, limited to less-than-lethal ammunition only
+- [color=#cb0000]\[Bartender\][/color] Civilian firearms (less-than-lethal only) must be kept and used within the Bar. Possession elsewhere is prohibited.
 - [color=#cb0000]\[None\][/color] Unlicensed firearms
 - [color=#cb0000]\[None\][/color] Exotic weapons (e.g., swords)
 - [color=#cb0000]\[None\][/color] Improvised weapons (e.g., baseball bats, pipe tools)


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

There were previously some inconsistencies in lawbook and restricted weapons about salvage. Now they are limited to using weapons only in salvage areas as originally meant to. Barkeep as well is unable to use his gun outside of bar anymore as well. 
Security will now no longer run into OOC complainhell when they grab a salvager with the entirey armory on him running around the station carefree.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Simple text-change, it looks as it reads.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Spacelaw gun restrictions
