### PR TITLE
More Random Code Optimizations

### DIFF
--- a/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -59,14 +59,12 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         base.Update(frameTime);
 
         // Update card references for any cartridges that need it
-        var query = EntityQueryEnumerator<NanoChatCartridgeComponent, CartridgeComponent>();
-        while (query.MoveNext(out var uid, out var nanoChat, out var cartridge))
+        var query = EntityQueryEnumerator<NanoChatCartridgeComponent>();
+        while (query.MoveNext(out var uid, out var nanoChat))
         {
-            if (cartridge.LoaderUid == null)
-                continue;
-
-            // Check if we need to update our card reference
-            if (!TryComp<PdaComponent>(cartridge.LoaderUid, out var pda))
+            if (!TryComp(uid, out CartridgeComponent? cartridge)
+                || cartridge.LoaderUid == null
+                || !TryComp(cartridge.LoaderUid, out PdaComponent? pda))
                 continue;
 
             var newCard = pda.ContainedId;

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.Disposal.Tube;
 using Content.Server.Disposal.Tube.Components;
 using Content.Server.Disposal.Unit.Components;
 using Content.Server.Popups;
-using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Atmos;
@@ -34,7 +33,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
-using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Disposal.Unit.EntitySystems;
@@ -210,10 +208,10 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<DisposalUnitComponent, MetaDataComponent>();
-        while (query.MoveNext(out var uid, out var unit, out var metadata))
+        var query = EntityQueryEnumerator<DisposalUnitComponent>();
+        while (query.MoveNext(out var uid, out var unit))
         {
-            Update(uid, unit, metadata, frameTime);
+            Update(uid, unit);
         }
     }
 
@@ -395,8 +393,9 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
     /// <summary>
     /// Work out if we can stop updating this disposals component i.e. full pressure and nothing colliding.
     /// </summary>
-    private void Update(EntityUid uid, SharedDisposalUnitComponent component, MetaDataComponent metadata, float frameTime)
+    private void Update(EntityUid uid, SharedDisposalUnitComponent component)
     {
+        var metadata = MetaData(uid);
         var state = GetState(uid, component, metadata);
 
         // Pressurizing, just check if we need a state update.

--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -1,9 +1,8 @@
-using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.DoAfter;
-using Content.Server.Fluids.Components;
 using Content.Server.Popups;
 using Content.Shared.Audio;
 using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -25,7 +24,7 @@ namespace Content.Server.Fluids.EntitySystems;
 public sealed class DrainSystem : SharedDrainSystem
 {
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
@@ -153,7 +152,7 @@ public sealed class DrainSystem : SharedDrainSystem
             }
 
             // Remove a bit from the buffer
-            _solutionContainerSystem.SplitSolution(drain.Solution.Value, (drain.UnitsDestroyedPerSecond * drain.DrainFrequency));
+            _solutionContainerSystem.SplitSolution(drain.Solution.Value, drain.UnitsDestroyedPerSecond * drain.DrainFrequency);
 
             // This will ensure that UnitsPerSecond is per second...
             var amount = drain.UnitsPerSecond * drain.DrainFrequency;
@@ -163,7 +162,8 @@ public sealed class DrainSystem : SharedDrainSystem
 
             puddles.Clear();
 
-            foreach (var entity in _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(uid, xform), drain.Range))
+            var coords = _transform.GetMapCoordinates(uid, xform);
+            foreach (var entity in _lookup.GetEntitiesInRange(coords.MapId, coords.Position, drain.Range, LookupFlags.Static))
             {
                 // No InRangeUnobstructed because there's no collision group that fits right now
                 // and these are placed by mappers and not buildable/movable so shouldnt really be a problem...

--- a/Content.Shared/Light/Components/ActiveExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/ActiveExpendableLightComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Light.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveExpendableLightComponent : Component;

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -16,44 +16,39 @@ public sealed partial class HungerComponent : Component
     /// <summary>
     /// The current hunger amount of the entity
     /// </summary>
-    [DataField("currentHunger"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float CurrentHunger;
 
     /// <summary>
     /// The base amount at which <see cref="CurrentHunger"/> decays.
     /// </summary>
-    [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float BaseDecayRate = 0.01666666666f;
 
     /// <summary>
     /// The actual amount at which <see cref="CurrentHunger"/> decays.
     /// Affected by <seealso cref="CurrentThreshold"/>
     /// </summary>
-    [DataField("actualDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float ActualDecayRate;
 
     /// <summary>
     /// The last threshold this entity was at.
     /// Stored in order to prevent recalculating
     /// </summary>
-    [DataField("lastThreshold"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public HungerThreshold LastThreshold;
 
     /// <summary>
     /// The current hunger threshold the entity is at
     /// </summary>
-    [DataField("currentThreshold"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public HungerThreshold CurrentThreshold;
 
     /// <summary>
     /// A dictionary relating HungerThreshold to the amount of <see cref="CurrentHunger"/> needed for each one
     /// </summary>
-    [DataField("thresholds", customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>))]
-    [AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>)), AutoNetworkedField]
     public Dictionary<HungerThreshold, float> Thresholds = new()
     {
         { HungerThreshold.Overfed, 200.0f },
@@ -66,8 +61,7 @@ public sealed partial class HungerComponent : Component
     /// <summary>
     /// A dictionary relating hunger thresholds to corresponding alerts.
     /// </summary>
-    [DataField("hungerThresholdAlerts")]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Dictionary<HungerThreshold, ProtoId<AlertPrototype>> HungerThresholdAlerts = new()
     {
         { HungerThreshold.Peckish, "Peckish" },
@@ -81,8 +75,7 @@ public sealed partial class HungerComponent : Component
     /// <summary>
     /// A dictionary relating HungerThreshold to how much they modify <see cref="BaseDecayRate"/>.
     /// </summary>
-    [DataField("hungerThresholdDecayModifiers", customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>))]
-    [AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>)), AutoNetworkedField]
     public Dictionary<HungerThreshold, float> HungerThresholdDecayModifiers = new()
     {
         { HungerThreshold.Overfed, 1.2f },
@@ -95,20 +88,19 @@ public sealed partial class HungerComponent : Component
     /// <summary>
     /// The amount of slowdown applied when an entity is starving
     /// </summary>
-    [DataField("starvingSlowdownModifier"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float StarvingSlowdownModifier = 0.75f;
 
     /// <summary>
     /// Damage dealt when your current threshold is at HungerThreshold.Dead
     /// </summary>
-    [DataField("starvationDamage")]
+    [DataField]
     public DamageSpecifier? StarvationDamage;
 
     /// <summary>
     /// The time when the hunger will update next.
     /// </summary>
-    [DataField("nextUpdateTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan NextUpdateTime;

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 namespace Content.Shared.Nutrition.Components;
 
 [RegisterComponent, NetworkedComponent, Access(typeof(HungerSystem))]
-[AutoGenerateComponentState, AutoGenerateComponentPause]
+[AutoGenerateComponentState(true, fieldDeltas: true), AutoGenerateComponentPause]
 public sealed partial class HungerComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -112,7 +112,7 @@ public sealed class HungerSystem : EntitySystem
             component.Thresholds[HungerThreshold.Dead],
             component.Thresholds[HungerThreshold.Overfed]);
         UpdateCurrentThreshold(uid, component);
-        Dirty(uid, component);
+        DirtyField(uid, component, nameof(HungerComponent.CurrentHunger));
     }
 
     private void UpdateCurrentThreshold(EntityUid uid, HungerComponent? component = null)
@@ -125,7 +125,7 @@ public sealed class HungerSystem : EntitySystem
             return;
         component.CurrentThreshold = calculatedHungerThreshold;
         DoHungerThresholdEffects(uid, component);
-        Dirty(uid, component);
+        DirtyField(uid, component, nameof(HungerComponent.CurrentThreshold));
     }
 
     private void DoHungerThresholdEffects(EntityUid uid, HungerComponent? component = null, bool force = false)

--- a/Content.Shared/Projectiles/ActiveEmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ActiveEmbeddableProjectileComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Projectiles;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ActiveEmbeddableProjectileComponent : Component;


### PR DESCRIPTION
# Description

These are all essentially just random systems that scaled directly with player count (or were on my list of the top 50 anyways). So just a couple systems that had very inefficient enumerators being swapped out with significantly more efficient ones, plus a few swaps from O(n) to O(m) m << n. A big one was DrainSystem, which was querrying all possible entities, rather than doing so from the "set of all static objects", which is significantly smaller. Puddles are always static objects, so it doesn't make sense to have the drains check for anything other than static. 

We can also use DirtyField to save on performance costs of Dirty(uid, component) in cases where the Dirty is only networking a single component field. 

# Changelog

no CL this isn't player facing.
