### PR TITLE
Borg Emag Panel Tweak

### DIFF
--- a/Content.Shared/Silicons/Laws/Components/EmagSiliconLawComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/EmagSiliconLawComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class EmagSiliconLawComponent : Component
     /// Does the panel need to be open to EMAG this law provider.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool RequireOpenPanel = true;
+    public bool RequireOpenPanel;
 
     /// <summary>
     /// How long the borg is stunned when it's emagged. Setting to 0 will disable it.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description



Small tweak to make it possible to emag the panel of a borg open and thus emag their laws. This makes it more viable to emag borgs as I hardly seen anyone attempt to subvert borgs in a fair while ever since you couldn't emag the panel open. Give the silicon players a chance to be evil too...
<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/e318b353-8ab0-4fa0-aea3-8f26130193f0




</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Borgs can be now be emagged without the panel being opened.
