### PR TITLE
Fix the Deathsquad Ghostrole

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -1,4 +1,4 @@
-## Random humanoids
+# Random humanoids
 
 - type: randomHumanoidSettings
   id: EventHumanoid

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -65,8 +65,7 @@
       rules: ghost-role-information-Death-Squad-rules
       raffle:
         settings: short
-      mindRoles:
-      - MindRoleGhostRoleFamiliar
+    - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ DeathSquadGear ]
     - type: RandomMetadata

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -73,7 +73,6 @@
         - NamesFirstMilitaryLeader
         - NamesLastMilitary
 
-
 ## ERT Leader
 
 - type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes an issue where the deathsquad ghostrole was missing 'GhostTakeoverAvailable', and removes the familiar mindrole from it.
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix deathsquad ghostrole

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/6d28edbf-2442-4687-81e0-ba7f5b475eb6)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed deathsquad ghostrole
