### PR TITLE
Medical Biofab Additions 

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Parts/generic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/generic.yml
@@ -70,6 +70,18 @@
   name: bio-synthetic right foot
   description: This right foot can be transplanted into any living organism and it will adapt to its recipient.
 
+- type: entity
+  parent: HeadHuman
+  id: BioSynthHead
+  name: bio-synthetic head
+  description: This head can be transplanted into any living organism and it will adapt to its recipient.
+
+- type: entity
+  parent: TorsoHuman
+  id: BioSynthTorso
+  name: bio-synthetic torso
+  description: This torso can be transplanted into any living organism and it will adapt to its recipient.
+
 # JOKE ITEMS
 
 - type: entity

--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/lathe.yml
@@ -40,7 +40,14 @@
     - SynthRightArm
     - SynthLeftHand
     - SynthRightHand
+    - SynthHead
+    - SynthTorso
   - type: EmagLatheRecipes
     emagStaticRecipes:
     - PizzaLeftArm
     - PizzaRightArm
+    - SpaceLungsAnimal
+    - SpaceHeartAnimal
+    - SpaceLungsDragon
+    - SpaceEyesLaser
+    - SpaceHeartCobra

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/rehydrateable.yml
@@ -96,3 +96,52 @@
   completetime: 30
   materials:
     Biomass: 5
+
+- type: latheRecipe
+  id: SynthHead
+  result: BioSynthHead
+  completetime: 60
+  materials:
+    Biomass: 30
+
+- type: latheRecipe
+  id: SynthTorso
+  result: BioSynthTorso
+  completetime: 120
+  materials:
+    Biomass: 60
+
+- type: latheRecipe
+  id: SpaceLungsAnimal
+  result: OrganSpaceAnimalLungs
+  completetime: 60
+  materials:
+    Biomass: 20
+
+- type: latheRecipe
+  id: SpaceHeartAnimal
+  result: OrganSpaceAnimalHeart
+  completetime: 60
+  materials:
+    Biomass: 20
+
+- type: latheRecipe
+  id: SpaceLungsDragon
+  result: OrganDragonLungs
+  completetime: 60
+  materials:
+    Biomass: 20
+
+- type: latheRecipe
+  id: SpaceEyesLaser
+  result: OrganLaserEyes
+  completetime: 60
+  materials:
+    Biomass: 20
+
+- type: latheRecipe
+  id: SpaceHeartCobra
+  result: OrganCobraHeart
+  completetime: 60
+  materials:
+    Biomass: 20


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR adds the bio-synthetic torso, head to the normal medical biofabricator recipes (they cost more and take more time to print out) and the space animal lungs, heart, dragon lungs, laser eyes and cobra gland to the emagged medical biofabricator recipes. The emagged recipes all cost and take double the amount of time to print compared to normal organs. The torso takes 60 biomass and takes 4 times as much time to print (due to the fact it's loaded with 5 organs in it, so that's 10 for the torso and 50 for organs) and the head takes 30 biomass and double the time to print (it has 2 organs inside of it, 10 + 20)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![recipes including emagged ones showcased](https://github.com/user-attachments/assets/36c43cc0-f1aa-4221-a9aa-905d45bf456e)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added a printable torso and head to the medical biofabricator, as well as some space organs for when it is emagged.