### PR TITLE
Equipment Tweaks

### DIFF
--- a/Resources/Locale/en-US/extenddescriptions/items/weapons/civiliandisabler.ftl
+++ b/Resources/Locale/en-US/extenddescriptions/items/weapons/civiliandisabler.ftl
@@ -1,1 +1,1 @@
-civiliandisabler-extenddescription-security = This weapon is legal to own and carry without a license on NanoTrasen stations, but may be considered as an accessory equivalent to a weapon if used in a crime.
+civiliandisabler-extenddescription-security = This weapon is legal to own and carry without a license for command members on NanoTrasen stations, but may be considered as an accessory equivalent to a weapon if used in a crime.

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -90,7 +90,6 @@
       - id: ClothingUniformJumpsuitSecFormal # DeltaV - emergency parade time, Central's coming to visit
         prob: 0.25
       - id: ClothingBeltSecurityFilled
-      - id: ClothingBeltCorporateJudo # Goobstation - Martial Arts
       - id: Flash
         prob: 0.5
       - id: ClothingEyesGlassesSunglasses

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -27,6 +27,7 @@
     ClothingOuterArmorDuraVest: 2
     ClothingHeadHelmetBasic: 2
     BreachingCharge: 8
+    ClothingBeltCorporateJudo: 2
   # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 12

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/commandUncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/commandUncategorized.yml
@@ -26,9 +26,7 @@
     - type: loadout
       id: LoadoutCommandTelescopicBaton
     - type: loadout
-      id: LoadoutCommandDisabler
-    - type: loadout
-      id: LoadoutCommandStunBaton
+      id: LoadoutCommandCivilianDisabler
     - type: loadout
       id: LoadoutCommandFlash
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -383,7 +383,6 @@
     - SyringeBluespace
   #  - WeaponForceGun
     - WeaponLaserSvalinn
-    - WeaponCivilianDisabler
     - WeaponProtoKineticAccelerator
   #  - WeaponTetherGun
   #  - WeaponGrapplingGun
@@ -460,6 +459,7 @@
     - WeaponLaserCannon
     - WeaponLaserCarbine
     - WeaponXrayCannon
+    - WeaponCivilianDisabler
     - WeaponEnergyGun       # DeltaV - Energy Gun
     - WeaponEnergyGunMini   # DeltaV - Miniature Energy Gun
     - WeaponEnergyGunPistol # DeltaV - PDW-9 Energy Pistol
@@ -1101,6 +1101,7 @@
       - WeaponEnergyGun
       - WeaponEnergyGunMini
       - WeaponEnergyGunPistol
+      - WeaponCivilianDisabler
       - WeaponGunLaserCarbineAutomatic
       - CartridgeSpecialIncendiary
       - CartridgeSpecialUranium

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -697,19 +697,6 @@
 
 #Misc Items
 - type: loadout
-  id: LoadoutCivilianDisabler
-  category: Items
-  cost: 5
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-      - Prisoner
-  items:
-  - WeaponCivilianDisabler
-
-- type: loadout
   id: LoadoutItemFlash
   category: Items
   cost: 1

--- a/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
@@ -22,7 +22,7 @@
   - TelescopicBaton
 
 - type: loadout
-  id: LoadoutCommandDisabler
+  id: LoadoutCommandCivilianDisabler
   category: JobsCommandAUncategorized
   cost: 2
   exclusive: true
@@ -33,21 +33,7 @@
       departments:
       - Command
   items:
-  - WeaponDisabler
-
-- type: loadout
-  id: LoadoutCommandStunBaton
-  category: JobsCommandAUncategorized
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCommandSelfDefense
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Command
-  items:
-  - Stunbaton
+  - WeaponCivilianDisabler
 
 - type: loadout
   id: LoadoutCommandFlash


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

It removes civilian disablers from everybody's loadouts, instead of giving them commands to combat valid hunting and unfun antag gameplay. It also reduces the number of judo belts sec gets, removing them from sec lockers and putting two in the sec tech instead.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/5e43dc7a-aeb0-4956-a98a-595ac531624a)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Civillian disablers are now a command loadout item, and shouldn't be used by random people.
- tweak: Judo belts don't spawn in sec lockers anymore, now the sec vend starts with two in its stock.
