### PR TITLE
Chef and Bartender Employment Fixes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -11,6 +11,7 @@
       employers:
       - IdrisIncorporated
       - NanoTrasen
+      - OrionExpress
   startingGear: BartenderGear
   icon: "JobIconBartender"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -10,6 +10,8 @@
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen
+      - OrionExpress
+      - IdrisIncorporated
   startingGear: ChefGear
   icon: "JobIconChef"
   supervisors: job-supervisors-hop


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Chef and Bartender have clothing that is specified for Orion Express and Idris, however, they don't have those companies as potential employers. This PR fixes that.

No media since it's purely just like three lines of added text

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Bartenders and Chefs can now be employed by Orion Express and Idris Incorporated
