### PR TITLE
Fix Psi Power Rolling Messages

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
@@ -257,7 +257,7 @@ public sealed partial class PsionicFeedbackSelfChat : PsionicPowerFunction
         PsionicPowerPrototype proto)
     {
         var chatManager = IoCManager.Resolve<IChatManager>();
-        if (playerManager.TryGetSessionByEntity(uid, out var session)
+        if (!playerManager.TryGetSessionByEntity(uid, out var session)
             || session is null
             || !loc.TryGetString(FeedbackMessage, out var feedback))
             return;


### PR DESCRIPTION
# Description

A single missing exclamation mark was breaking this.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/d66d3507-4e53-4f00-84ae-068c8efddf16)

</p>
</details>

# Changelog

:cl:
- fix: Fixed rolling psionic powers not generating their unique messages in chat.
