### PR TITLE
ScribeSystem

### DIFF
--- a/Content.Server/_EE/Scribe/ScribeComponent.cs
+++ b/Content.Server/_EE/Scribe/ScribeComponent.cs
@@ -1,0 +1,40 @@
+namespace Content.Server._EE.Scribe;
+
+[RegisterComponent]
+public sealed partial class ScribeBookComponent : Component
+{
+    /// <summary>
+    ///     The key to find the Webhook data by.
+    ///     See the formatting of the <see cref="Content.Shared.CCVar.CCVars.DiscordScribeWebhooks">DiscordScribeWebhooks</see> cvar for more information.
+    /// </summary>
+    [DataField]
+    public string WebhookKey = "";
+
+    /// <summary>
+    ///     The fluent format to be used in the Webhook's username.
+    ///     Null for default name.
+    /// </summary>
+    [DataField]
+    public string? NameFormat = null;
+
+    /// <summary>
+    ///     The fluent format to be used in the Webhook's content.
+    ///     Null for no formatting.
+    /// </summary>
+    [DataField]
+    public string? ContentFormat = null;
+
+    /// <summary>
+    ///     The footer to be provided. Can be a fluent format string but can also be raw.
+    ///     Null for no footer.
+    /// </summary>
+    [DataField]
+    public string? Footer = null;
+
+    /// <summary>
+    ///     The colour to be used with the Webhook, in decimal.
+    ///     See <see href="https://birdie0.github.io/discord-webhooks-guide/structure/embed/color.html">this guide</see> for more info.
+    /// </summary>
+    [DataField]
+    public int Color = 0;
+}

--- a/Content.Server/_EE/Scribe/ScribeSystem.cs
+++ b/Content.Server/_EE/Scribe/ScribeSystem.cs
@@ -1,0 +1,112 @@
+using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Paper;
+using Content.Server.Discord;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._EE.Scribe;
+
+public sealed partial class ScribeSystem : EntitySystem
+{
+    [Dependency] private readonly DiscordWebhook _discord = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    private Dictionary<string, WebhookIdentifier> _webHooks = new ();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_config, CCVars.DiscordScribeWebhooks, cvar => _webHooks = ParseCVarTable(cvar), true);
+
+        SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
+    }
+
+    private void OnRoundEnded(RoundEndedEvent ev)
+    {
+        // Collect all the scribebooks into groups based on the Webhook they target.
+        foreach (var result in EntityQuery<ScribeBookComponent, PaperComponent>().GroupBy(q => q.Item1.WebhookKey))
+        {
+            if (!_webHooks.TryGetValue(result.Key, out var identifier))
+                continue;
+
+            // Collect them into messages.
+            var embeds = new List<WebhookEmbed>();
+
+            foreach (var (scribeComp, paperComp) in result)
+            {
+                var embed = new WebhookEmbed();
+
+                if (scribeComp.NameFormat is { } nameLoc)
+                    embed.Title = Loc.GetString(nameLoc, ("name", "Urist McHands")); //TODO: Need to work out how to hold on to people's names.
+
+                embed.Description = scribeComp.ContentFormat is { } contentLoc
+                    ? Loc.GetString(contentLoc, ("content", paperComp.Content))
+                    : paperComp.Content;
+
+                if (scribeComp.Footer is { } footer)
+                {
+                    embed.Footer = new ()
+                    {
+                        Text = Loc.GetString(footer, ("round-id", ev.RoundId)),
+                    };
+                }
+
+                embed.Color = scribeComp.Color;
+
+                embeds.Add(embed);
+            }
+
+            _discord.CreateMessage(identifier, new () { Embeds = embeds, });
+        }
+    }
+
+    private Dictionary<string, WebhookIdentifier> ParseCVarTable(string src)
+    {
+        var dict = new Dictionary<string, WebhookIdentifier>();
+        foreach (var line in src.Split('\n'))
+        {
+            // Expected format is:
+            //
+            // <key>: <id>/<token>
+            // <key>: <id>/<token>
+            // <key>: <id>/<token>
+
+            // Maps as CCVars when? ;~;
+
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            if (Split(src, ':') is not { } keyValue)
+                continue;
+
+            if (Split(keyValue.Item2, '/') is not { } idToken)
+                continue;
+
+            dict.Add(keyValue.Item1.Trim(), new (idToken.Item1.Trim(), idToken.Item2.Trim()));
+
+            // Helper function to split the lines.
+            (string, string)? Split(string input, char c)
+            {
+                var parts = input.Split(c, 2);
+                if (parts.Length != 2)
+                {
+                    Log.Warning($"Webhook table line missing key: {line}");
+                    return null;
+                }
+
+                var (part1, part2) = (parts[0], parts[1]);
+                if (string.IsNullOrWhiteSpace(part1) || string.IsNullOrWhiteSpace(part2))
+                {
+                    Log.Warning($"Webhook table line malformed: {line}");
+                    return null;
+                }
+
+                return (part1, part2);
+            }
+        }
+
+        return dict;
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -69,4 +69,22 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> DiscordAuthApiKey =
         CVarDef.Create("discord.auth_api_key", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    /// <summary>
+    ///     Table of the Discord webhook URL IDs/tokens which will relay all scribe messages.
+    /// </summary>
+    /// <remarks>
+    ///     Expected to be formatted as one <c>&lt;key&gt;: &lt;id&gt;/&lt;token&gt;</c> per line,
+    ///     where the <c>key</c> is the same as a key in the <c>ScribeComponent</c>'s <c>WebhookKey</c> field and
+    ///     the <c>id</c> and <c>token</c> are the same as they appear in a Webhook URL.
+    ///     For example
+    ///     <code>
+    ///         scribe_webhooks: """
+    ///             first_scribe_key: 0000000000000000000/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ///             second_scribe_key: 1111111111112222222/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccc
+    ///         """
+    ///     </code>
+    /// </remarks>
+    public static readonly CVarDef<string> DiscordScribeWebhooks =
+        CVarDef.Create("discord.scribe_webhooks", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
 }

--- a/Resources/Locale/en-US/_EE/scribe.ftl
+++ b/Resources/Locale/en-US/_EE/scribe.ftl
@@ -1,0 +1,3 @@
+scribe-name-format = Scribe {$name}
+scribe-content-format = {$content}
+scribe-footer-format = Nanotrasen shift #{$round-id}

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -54,7 +54,7 @@
     outerClothing: ClothingOuterCoatRnd
     id: LibrarianPDA
     ears: ClothingHeadsetScience
-    pocket1: BookPsionicsGuidebook
+    pocket1: PaperScribeBook
     pocket2: HandLabeler
   innerClothingSkirt: ClothingUniformJumpskirtLibrarian
   satchel: ClothingBackpackSatchelLibrarianFilled

--- a/Resources/Prototypes/_EE/Entities/Objects/Misc/scribe.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Misc/scribe.yml
@@ -1,0 +1,31 @@
+- type: entity
+  name: scribe
+  parent: Paper
+  id: PaperScribeBook
+  description: "A page of the captain's journal. In luxurious lavender."
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    layers:
+    - state: paper
+      color: "#e6e6fa"
+    - state: paper_words
+      map: ["enum.PaperVisualLayers.Writing"]
+      color: "#e6e6fa"
+      visible: false
+    - state: paper_stamp-generic
+      map: ["enum.PaperVisualLayers.Stamp"]
+      visible: false
+  - type: PaperLabelType
+    paperType: CaptainsPaper
+  - type: PaperVisuals
+    headerImagePath: "/Textures/Interface/Paper/paper_heading_captains_thoughts.svg.96dpi.png"
+    backgroundImagePath: "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png"
+    backgroundModulate: "#e6e6fa"
+    backgroundPatchMargin: 16.0, 16.0, 16.0, 16.0
+    contentMargin: 32.0, 16.0, 32.0, 0.0
+  - type: ScribeBook
+    webhookKey: librarian
+    nameFormat: scribe-name-format
+    contentFormat: scribe-content-format
+    footer: scribe-footer-format


### PR DESCRIPTION
# Description
Implements the 'Scribe' functionality as per ODJ's request. 
Allows reporting text recorded in specific paper-like Entities to a Discord relay with specific formatting so Cataloguers can have their records made permanent for all to read.

Draft state currently, discussion needed about how to implement some features and aesthetics needed to be dealt with.
Will leave more details about what is/needs to be done, super tired right now.

# TODO

- [ ] Make todo list

---

<!--
<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---
-->

# Changelog

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
