### PR TITLE
Fix the Color of Xelthia Blood as Rendered when Damaged

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/xelthia.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/xelthia.yml
@@ -1,5 +1,5 @@
 - type: entity
   save: false
-  name: Urist McXelthia
+  name: Urist McTentacles
   parent: BaseMobXelthia
   id: MobXelthia

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/xelthia.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/xelthia.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: BaseMobSpeciesOrganic
   id: BaseMobXelthia
-  name: Urist McXelthia
+  name: Urist McTentacles
   abstract: true
   components:
   - type: Hunger
@@ -62,6 +62,11 @@
         Blunt: 0.14 #per second, scales with pressure and other constants.
   - type: Bloodstream
     bloodReagent: AcidBlood
+  - type: DamageVisuals
+    damageOverlayGroups:
+      Brute:
+        sprite: Mobs/Effects/brute_damage.rsi
+        color: "#00FF69"
 #  - type: Hands # This doesnt seem to work. I can't tell why. Is this implemented here and i'm doing this wrong, or is it just on goob? Fix later.
 #    handDisplacement:
 #      sprite: _EE/Mobs/Species/Xelthia/displacement.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

It was rendering as red. Added a thing to make it render as green.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/555b92b2-5a10-4a11-b625-c672697f8aea)

</p>
</details>
