### PR TITLE
Plasmemes can now wear full modsuits.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
@@ -125,4 +125,11 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 2
+  - type: Tag
+    tags:
+    - PlasmamanSafe
+    - Envirohelm
+  - type: IgniteFromGasImmunity
+    parts:
+    - Head
 


### PR DESCRIPTION
Yay

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Plasmamen no longer burn when they have a modsuit helmet on.

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Literally what it says on the title.

What this PR changes is it adds a type in the YML of the modsuit helmet, that disallows the plasmamen from burning when they equip a helmet piece.

There is a module to fix this issue with plasmamen in 13, so once said modules are implemented we could just add that and revert this.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/c3ae0701-c0a8-4dd1-b069-a4ba2e13adab)

Plasmamen with normal modsuit, no longer burns.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Plasmamen can now wear Modsuit helmets.

