### PR TITLE
Cyberiad 3.0: High Sec Rework

### DIFF
--- a/Resources/Prototypes/Maps/cyberiad.yml
+++ b/Resources/Prototypes/Maps/cyberiad.yml
@@ -9,7 +9,10 @@
       stationProto: StandardNanotrasenStationCargoOnly
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'NSS Cyberiad {1}'
+          mapNameTemplate: 'NSS{0} Cyberiad Station {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
         - type: StationJobs
@@ -19,31 +22,29 @@
             NanotrasenRepresentative: [ 1, 1 ]
             BlueshieldOfficer: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
             Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
+            Botanist: [ 2, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            AtmosphericTechnician: [ 2, 3 ]
+            StationEngineer: [ 3, 5 ]
+            TechnicalAssistant: [ 2, 4 ]
             SeniorEngineer: [ 1, 1 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
+            MedicalDoctor: [ 2, 4 ]
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 2, 4 ]
             Psychologist: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
+            Scientist: [ 3, 5 ]
+            Chaplain: [ 1, 1 ]
+            Librarian: [ 1, 1 ]
             Roboticist: [ 1, 2 ]
             ResearchAssistant: [ 4, 4 ]
             ForensicMantis: [ 1, 1 ]
@@ -51,17 +52,16 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
+            SecurityOfficer: [ 3, 5 ]
             Brigmedic: [ 1, 1 ]
             Prisoner: [ 1, 3 ]
-            PrisonGuard: [ 1, 2 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             SeniorOfficer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
+            SalvageSpecialist: [ 2, 3 ]
             CargoTechnician: [ 3, 5 ]
             MailCarrier: [ 1, 2 ]
             #civilian
@@ -73,5 +73,3 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
-            MedicalBorg: [ 2, 2 ]
-


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Third part of the rework of the Box map, now focused on Sec, the department was completely reworked, along with some fixes in med, eng, epis and service.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Cyberiad-0](https://github.com/user-attachments/assets/39ec3454-e656-4527-8948-56e1850d0d41)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Emilly
- tweak: Cyberiad Sec has been completely reworked! Enjoy its new layout
- remove: Magistrate, Admin assistant, prison guard and medical borgs removed.
- add: Old XenoBio room added to the epistemics
- fix: Cyberiad name fixed
