### PR TITLE
Free Cosmetic Loadouts

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/headGroup.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/headGroup.yml
@@ -109,3 +109,19 @@
       id: ClothingHeadHatTCFLBeretSentinel
     - type: loadout
       id: ClothingHeadHatTCFLSoftCap
+    - type: loadout
+      id: ClothingHeadHatSANArmyCap
+    - type: loadout
+      id: ClothingHeadHatSANArmyField
+    - type: loadout
+      id: ClothingHeadHatSANArmyFieldGrey
+    - type: loadout
+      id: ClothingHeadHatSANArmyGarrison
+    - type: loadout
+      id: ClothingHeadHatSANMarineUtility
+    - type: loadout
+      id: ClothingHeadHatSANMarineUtilityGrey
+    - type: loadout
+      id: ClothingHeadHatSANNavyCap
+    - type: loadout
+      id: ClothingHeadHatSANWheelCap

--- a/Resources/Prototypes/CharacterItemGroups/Generic/itemGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/itemGroups.yml
@@ -389,3 +389,17 @@
       id: ClothingUniformTCFLSentinel
     - type: loadout
       id: ClothingUniformTCFLVolunteer
+    - type: loadout
+      id: ClothingUniformJumpsuitSolArmyService
+    - type: loadout
+      id: ClothingUniformJumpsuitSolFatigueGreen
+    - type: loadout
+      id: ClothingUniformJumpsuitSolFatigueGrey
+    - type: loadout
+      id: ClothingUniformJumpsuitSolFatigueTan
+    - type: loadout
+      id: ClothingUniformJumpsuitSolNavyCoveralls
+    - type: loadout
+      id: ClothingUniformJumpsuitSolNavySailor
+    - type: loadout
+      id: ClothingUniformJumpsuitSolServiceWhite

--- a/Resources/Prototypes/Loadouts/Generic/belt.yml
+++ b/Resources/Prototypes/Loadouts/Generic/belt.yml
@@ -56,7 +56,7 @@
 - type: loadout
   id: LoadoutItemWaistbag
   category: Belt
-  cost: 2
+  cost: 0
   items:
     - ClothingBeltStorageWaistbag
   requirements:
@@ -70,7 +70,7 @@
 - type: loadout
   id: LoadoutBeltWaistbagColor
   category: Belt
-  cost: 2
+  cost: 0
   customColorTint: true
   items:
     - ClothingBeltStorageWaistbagColor

--- a/Resources/Prototypes/Loadouts/Generic/eyes.yml
+++ b/Resources/Prototypes/Loadouts/Generic/eyes.yml
@@ -47,7 +47,7 @@
 - type: loadout
   id: LoadoutEyesGlassesJamjar
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -59,7 +59,7 @@
 - type: loadout
   id: LoadoutEyesGlasses3D
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingEyesGlasses3D
@@ -82,7 +82,7 @@
 - type: loadout
   id: LoadoutEyesGlassesMonocle
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -106,7 +106,7 @@
 - type: loadout
   id: LoadoutEyesGlassesJensen
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingEyesGlassesJensen
@@ -138,7 +138,7 @@
 - type: loadout
   id: LoadoutItemCheapSunglasses
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingEyesGlassesCheapSunglasses
@@ -149,7 +149,7 @@
 - type: loadout
   id: LoadoutEyesGlassesCheapSunglassesAviator
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -161,7 +161,7 @@
 - type: loadout
   id: LoadoutEyesGlassesCheapSunglassesBig
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingEyesGlassesCheapSunglassesBig
@@ -172,7 +172,7 @@
 - type: loadout
   id: LoadoutEyesGlassesCheapSunglassesVisor
   category: Eyes
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingEyesGlassesCheapSunglassesVisor

--- a/Resources/Prototypes/Loadouts/Generic/hands.yml
+++ b/Resources/Prototypes/Loadouts/Generic/hands.yml
@@ -44,7 +44,7 @@
 - type: loadout
   id: LoadoutHandsGlovesPowerglove
   category: Hands
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:

--- a/Resources/Prototypes/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/Loadouts/Generic/head.yml
@@ -2,7 +2,7 @@
 - type: loadout
   id: LoadoutHeadBeaverHat
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatBeaverHat
@@ -17,7 +17,7 @@
 - type: loadout
   id: LoadoutHeadTophat
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatTophat
@@ -28,7 +28,7 @@
 - type: loadout
   id: LoadoutHeadFedoraWhite
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -40,7 +40,7 @@
 - type: loadout
   id: LoadoutHeadFlatBlack
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatFlatBlack
@@ -51,7 +51,7 @@
 - type: loadout
   id: LoadoutHeadFlatBrown
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatFlatBrown
@@ -66,7 +66,7 @@
 - type: loadout
   id: LoadoutHeadHatCowboyWhite
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -78,7 +78,7 @@
 - type: loadout
   id: LoadoutHeadHatCowboyBountyHunter
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -104,7 +104,7 @@
 - type: loadout
   id: LoadoutHeadBellhop
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatBellhop
@@ -210,7 +210,7 @@
 - type: loadout
   id: LoadoutHeadFishCap
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadFishCap
@@ -225,7 +225,7 @@
 - type: loadout
   id: LoadoutHeadRastaHat
   category: Head
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadRastaHat
@@ -240,7 +240,7 @@
 - type: loadout
   id: LoadoutHeadFez
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatFez
@@ -251,7 +251,7 @@
 - type: loadout
   id: LoadoutHeadBowlerHat
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatBowlerHat
@@ -263,7 +263,7 @@
 - type: loadout
   id: LoadoutHeadGreyFlatcap
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatGreyFlatcap
@@ -274,7 +274,7 @@
 - type: loadout
   id: LoadoutHeadBrownFlatcap
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingHeadHatBrownFlatcap
@@ -290,7 +290,7 @@
 - type: loadout
   id: LoadoutHeadBeretWhite
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -302,7 +302,7 @@
 - type: loadout
   id: LoadoutHeadBeretArtist
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -314,7 +314,7 @@
 - type: loadout
   id: LoadoutHeadBeretPeaked
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -327,7 +327,7 @@
 - type: loadout
   id: LoadoutHeadBeanie
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -339,7 +339,7 @@
 - type: loadout
   id: LoadoutHeadBeanieWinter
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -351,7 +351,7 @@
 - type: loadout
   id: LoadoutHeadBeanieSubmariner
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -363,7 +363,7 @@
 - type: loadout
   id: LoadoutHeadBeanieTight
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -375,7 +375,7 @@
 - type: loadout
   id: LoadoutHeadSlouch
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -387,7 +387,7 @@
 - type: loadout
   id: LoadoutHeadSunVisor
   category: Head
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -677,6 +677,151 @@
     - !type:CharacterNationalityRequirement
       nationalities:
         - Bieselite
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+# Solarian headwear
+- type: loadout
+  id: ClothingHeadHatSANArmyCap
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANArmyCap
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANArmyField
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANArmyField
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANArmyFieldGrey
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANArmyFieldGrey
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANArmyGarrison
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANArmyGarrison
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANMarineUtility
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANMarineUtility
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANMarineUtilityGrey
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANMarineUtilityGrey
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANNavyCap
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANNavyCap
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingHeadHatSANWheelCap
+  category: Head
+  cost: 0
+  canBeHeirloom: true
+  guideEntry: SANInfo
+  items:
+    - ClothingHeadHatSANWheelCap
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHead
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
     - !type:CharacterLifepathRequirement
       lifepaths:
         - WarVet

--- a/Resources/Prototypes/Loadouts/Generic/head.yml
+++ b/Resources/Prototypes/Loadouts/Generic/head.yml
@@ -578,6 +578,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCAFBeretDress
@@ -596,6 +597,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCAFBeretField
@@ -614,6 +616,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCFLBeretDress
@@ -632,6 +635,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCFLBeretField
@@ -650,6 +654,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCFLBeretSentinel
@@ -668,6 +673,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: TCFLInfo
   items:
     - ClothingHeadHatTCFLSoftCap
@@ -687,6 +693,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANArmyCap
@@ -705,6 +712,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANArmyField
@@ -723,6 +731,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANArmyFieldGrey
@@ -741,6 +750,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANArmyGarrison
@@ -759,6 +769,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANMarineUtility
@@ -777,6 +788,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANMarineUtilityGrey
@@ -795,6 +807,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANNavyCap
@@ -813,6 +826,7 @@
   category: Head
   cost: 0
   canBeHeirloom: true
+  exclusive: true
   guideEntry: SANInfo
   items:
     - ClothingHeadHatSANWheelCap

--- a/Resources/Prototypes/Loadouts/Generic/mask.yml
+++ b/Resources/Prototypes/Loadouts/Generic/mask.yml
@@ -13,7 +13,7 @@
 - type: loadout
   id: LoadoutMaskMuzzle
   category: Mask
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingMaskMuzzle
@@ -62,7 +62,7 @@
 - type: loadout
   id: LoadoutMaskNeckGaiterWhite
   category: Mask
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:

--- a/Resources/Prototypes/Loadouts/Generic/neck.yml
+++ b/Resources/Prototypes/Loadouts/Generic/neck.yml
@@ -1,7 +1,7 @@
 - type: loadout
   id: LoadoutNeckHeadphones
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingNeckHeadphones
@@ -12,7 +12,7 @@
 - type: loadout
   id: LoadoutNeckBellCollar
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingNeckBellCollar
@@ -455,7 +455,7 @@
 - type: loadout
   id: LoadoutNeckBedsheetCosmos
   category: Neck
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -474,7 +474,7 @@
 - type: loadout
   id: LoadoutNeckBedsheetRainbow
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - BedsheetRainbow
@@ -492,7 +492,7 @@
 - type: loadout
   id: LoadoutNeckBedsheetWhite
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -511,7 +511,7 @@
 - type: loadout
   id: LoadoutNeckBedsheetNT
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - BedsheetNT
@@ -582,7 +582,7 @@
 - type: loadout
   id: LoadoutNeckNecklaceGold
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -594,7 +594,7 @@
 - type: loadout
   id: LoadoutNeckNecklaceSilver
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -606,7 +606,7 @@
 - type: loadout
   id: LoadoutNeckNecklaceChainGold
   category: Neck
-  cost: 3
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -618,7 +618,7 @@
 - type: loadout
   id: LoadoutNeckNecklaceChainSilver
   category: Neck
-  cost: 3
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -630,7 +630,7 @@
 - type: loadout
   id: LoadoutNeckNecklacePendantGold
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -642,7 +642,7 @@
 - type: loadout
   id: LoadoutNeckNecklacePendantGoldLarge
   category: Neck
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -654,7 +654,7 @@
 - type: loadout
   id: LoadoutNeckNecklacePendantSilver
   category: Neck
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -666,7 +666,7 @@
 - type: loadout
   id: LoadoutNeckNecklacePendantSilverLarge
   category: Neck
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:

--- a/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
+++ b/Resources/Prototypes/Loadouts/Generic/outerClothing.yml
@@ -1,7 +1,7 @@
 - type: loadout
   id: LoadoutOuterCoatBomberjacket
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatBomber
@@ -33,7 +33,7 @@
 - type: loadout
   id: LoadoutOuterCoatWinterCoat
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterWinterCoat
@@ -44,7 +44,7 @@
 - type: loadout
   id: LoadoutOuterCoatHyenhSweater
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatHyenhSweater
@@ -55,7 +55,7 @@
 - type: loadout
   id: LoadoutOuterWinterCoatLong
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterWinterCoatLong
@@ -66,7 +66,7 @@
 - type: loadout
   id: LoadoutOuterWinterCoatPlaid
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterWinterCoatPlaid
   requirements:
@@ -76,7 +76,7 @@
 - type: loadout
   id: LoadoutOuterVestValet
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterVestValet
   requirements:
@@ -86,7 +86,7 @@
 - type: loadout
   id: LoadoutOuterVest
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterVest
   requirements:
@@ -97,7 +97,7 @@
 - type: loadout
   id: LoadoutOuterCoatLettermanBlue
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatLettermanBlue
   requirements:
@@ -107,7 +107,7 @@
 - type: loadout
   id: LoadoutOuterCoatLettermanRed
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatLettermanRed
   requirements:
@@ -118,7 +118,7 @@
 - type: loadout
   id: LoadoutOuterCoatMNKWhiteHoodie
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatMNKWhiteHoodie
@@ -129,7 +129,7 @@
 - type: loadout
   id: LoadoutOuterCoatMNKBlackTopCoat
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatMNKBlackTopCoat
   requirements:
@@ -139,7 +139,7 @@
 - type: loadout
   id: LoadoutOuterCoatMNKBlackJacket
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatMNKBlackJacket
   requirements:
@@ -304,7 +304,7 @@
 - type: loadout
   id: LoadoutOuterIdrisIncorporatedWindbreaker
   category: Outer
-  cost: 3
+  cost: 0
   guideEntry: IdrisIncorporated
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -318,7 +318,7 @@
 - type: loadout
   id: LoadoutOuterDenimJacket
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterDenimJacket
   requirements:
@@ -329,7 +329,7 @@
 - type: loadout
   id: LoadoutOuterFlannelRed
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterFlannelRed
   requirements:
@@ -339,7 +339,7 @@
 - type: loadout
   id: LoadoutOuterFlannelGreen
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterFlannelGreen
   requirements:
@@ -349,7 +349,7 @@
 - type: loadout
   id: LoadoutOuterFlannelBlue
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterFlannelBlue
   requirements:
@@ -359,7 +359,7 @@
 - type: loadout
   id: LoadoutOuterCoatTrench
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatTrench
   requirements:
@@ -369,7 +369,7 @@
 - type: loadout
   id: LoadoutOuterCoatJensen
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatJensen
   requirements:
@@ -379,7 +379,7 @@
 - type: loadout
   id: LoadoutOuterCoatGentle
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatGentle
   requirements:
@@ -389,7 +389,7 @@
 - type: loadout
   id: LoadoutOuterCoatInspector
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatInspector
   requirements:
@@ -399,7 +399,7 @@
 - type: loadout
   id: LoadoutOuterCoatOvercoat
   category: Outer
-  cost: 2
+  cost: 0
   items:
     - ClothingOuterCoatOvercoat
   requirements:
@@ -592,7 +592,7 @@
 - type: loadout
   id: LoadoutOuterTailcoat
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterTailcoat
@@ -603,7 +603,7 @@
 - type: loadout
   id: LoadoutOuterCoatVictorian
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatVictorian
   requirements:
@@ -613,7 +613,7 @@
 - type: loadout
   id: LoadoutOuterCoatVictorianRed
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterCoatVictorianRed
   requirements:
@@ -722,7 +722,7 @@
 - type: loadout
   id: LoadoutOuterBlazerBasic
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterBlazer
@@ -733,7 +733,7 @@
 - type: loadout
   id: LoadoutOuterBlazerBasicOpened
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterBlazerOpened
@@ -744,7 +744,7 @@
 - type: loadout
   id: LoadoutOuterBlazerLong
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterBlazerLong
@@ -755,7 +755,7 @@
 - type: loadout
   id: LoadoutOuterBlazerLongOpened
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterBlazerLongOpened
@@ -799,7 +799,7 @@
 - type: loadout
   id: LoadoutOuterBlazerPosh
   category: Outer
-  cost: 1
+  cost: 0
   items:
     - ClothingOuterBlazerPosh
   requirements:
@@ -809,7 +809,7 @@
 - type: loadout
   id: LoadoutOuterCoatPeacoat
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatPeacoat
@@ -820,7 +820,7 @@
 - type: loadout
   id: LoadoutOuterCoatPeacoatOpened
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatPeacoatOpened
@@ -831,7 +831,7 @@
 - type: loadout
   id: LoadoutOuterCoatAsymmetric
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatAsymmetric
@@ -842,7 +842,7 @@
 - type: loadout
   id: LoadoutOuterCoatAsymmetricOpened
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterCoatAsymmetricOpened
@@ -875,7 +875,7 @@
 - type: loadout
   id: LoadoutOuterVestColorable
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterVestColorable
@@ -886,7 +886,7 @@
 - type: loadout
   id: LoadoutOuterVestThick
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterVestThick
@@ -897,7 +897,7 @@
 - type: loadout
   id: ClothingOuterSuitWitchRobes
   category: Outer
-  cost: 1
+  cost: 0
   customColorTint: true
   items:
     - ClothingOuterSuitWitchRobes
@@ -908,7 +908,7 @@
 - type: loadout
   id: ClothingOuterCoatExpensive
   category: Outer
-  cost: 3
+  cost: 0
   items:
     - ClothingOuterCoatExpensive
   requirements:

--- a/Resources/Prototypes/Loadouts/Generic/satchels.yml
+++ b/Resources/Prototypes/Loadouts/Generic/satchels.yml
@@ -13,7 +13,7 @@
 - type: loadout
   id: LoadoutItemBackpackSatchelLeather
   category: Backpacks
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingBackpackSatchelLeather

--- a/Resources/Prototypes/Loadouts/Generic/shoes.yml
+++ b/Resources/Prototypes/Loadouts/Generic/shoes.yml
@@ -25,7 +25,7 @@
 - type: loadout
   id: LoadoutShoesTourist
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -48,7 +48,7 @@
 - type: loadout
   id: LoadoutShoesBootsWorkColor
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -60,7 +60,7 @@
 - type: loadout
   id: LoadoutShoesBootsJackFake
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -71,7 +71,7 @@
 - type: loadout
   id: LoadoutShoesBootsJackColor
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -83,7 +83,7 @@
 - type: loadout
   id: LoadoutShoesBootsLaceup
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -105,7 +105,7 @@
 - type: loadout
   id: LoadoutShoesBootsCowboyWhite
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -118,7 +118,7 @@
 - type: loadout
   id: LoadoutShoesBootsCowboyFancy
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -131,7 +131,7 @@
 - type: loadout
   id: LoadoutShoesBootsFishing
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -142,7 +142,7 @@
 - type: loadout
   id: LoadoutShoesBootsAnkle
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -154,7 +154,7 @@
 - type: loadout
   id: LoadoutShoesBootsFull
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -166,7 +166,7 @@
 - type: loadout
   id: LoadoutShoesBootsMud
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -178,7 +178,7 @@
 - type: loadout
   id: LoadoutShoesBootsMudThigh
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -190,7 +190,7 @@
 - type: loadout
   id: LoadoutShoesBootsThigh
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   requirements:
@@ -204,7 +204,7 @@
 - type: loadout
   id: LoadoutShoesSlippersDuck
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -242,7 +242,7 @@
 - type: loadout
   id: LoadoutShoesHighheelBoots
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   requirements:
@@ -258,7 +258,7 @@
 - type: loadout
   id: LoadoutShoesUnderSocksCoder
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -269,7 +269,7 @@
 - type: loadout
   id: LoadoutShoesUnderSocksBee
   category: Shoes
-  cost: 1
+  cost: 0
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/Loadouts/Generic/uniform.yml
+++ b/Resources/Prototypes/Loadouts/Generic/uniform.yml
@@ -1,7 +1,7 @@
 - type: loadout
   id: LoadoutUniformAncientJumpsuit
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -61,7 +61,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannel
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannel
@@ -296,7 +296,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiBlack
@@ -312,7 +312,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiBlue
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiBlue
@@ -328,7 +328,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiRed
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiRed
@@ -343,7 +343,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitHawaiYellow
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitHawaiYellow
@@ -360,7 +360,7 @@
 - type: loadout
   id: LoadoutUniformDressRed
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformDressRed
@@ -405,7 +405,7 @@
 - type: loadout
   id: LoadoutUniformGeisha
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformGeisha
@@ -420,7 +420,7 @@
 - type: loadout
   id: LoadoutUniformCostumeArcDress
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingCostumeArcDress
@@ -436,7 +436,7 @@
 - type: loadout
   id: LoadoutUniformCostumeMioSkirt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingCostumeMioSkirt
@@ -452,7 +452,7 @@
 - type: loadout
   id: LoadoutUniformCostumeNaota
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingCostumeNaota
@@ -468,7 +468,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitLoungewear
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitLoungewear
@@ -519,7 +519,7 @@
 - type: loadout
   id: LoadoutUniformKendoHakama
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -535,7 +535,7 @@
 - type: loadout
   id: LoadoutUniformMartialGi
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -555,7 +555,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitKimono
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -573,7 +573,7 @@
 - type: loadout
   id: LoadoutClothingKimonoBlue
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -590,7 +590,7 @@
 - type: loadout
   id: LoadoutClothingKimonoPink
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -607,7 +607,7 @@
 - type: loadout
   id: LoadoutClothingKimonoPurple
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -624,7 +624,7 @@
 - type: loadout
   id: LoadoutClothingKimonoSky
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -641,7 +641,7 @@
 - type: loadout
   id: LoadoutClothingKimonoGreen
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -659,7 +659,7 @@
 - type: loadout
   id: LoadoutUniformSchoolGakuranBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -676,7 +676,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlBlack
@@ -691,7 +691,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlBlue
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlBlue
@@ -707,7 +707,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlCyan
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlCyan
@@ -723,7 +723,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlGreen
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlGreen
@@ -739,7 +739,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlOrange
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlOrange
@@ -755,7 +755,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlPink
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlPink
@@ -771,7 +771,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlPurple
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlPurple
@@ -787,7 +787,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlRed
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlRed
@@ -802,7 +802,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlDusk
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlDusk
@@ -818,7 +818,7 @@
 - type: loadout
   id: LoadoutUniformSchoolgirlBlazerTan
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - UniformSchoolgirlBlazerTan
@@ -835,7 +835,7 @@
 - type: loadout
   id: LoadoutClothingMNKOfficeSkirt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -851,7 +851,7 @@
 - type: loadout
   id: LoadoutClothingMNKUnderGarment
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -867,7 +867,7 @@
 - type: loadout
   id: LoadoutClothingMNKGymBra
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -883,7 +883,7 @@
 - type: loadout
   id: LoadoutClothingMNKDressBlack
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformMNKDressBlack
@@ -898,7 +898,7 @@
 - type: loadout
   id: LoadoutClothingMNKBlackOveralls
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformMNKBlackOveralls
@@ -913,7 +913,7 @@
 - type: loadout
   id: LoadoutClothingMNKBlackShoulder
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformMNKBlackShoulder
@@ -928,7 +928,7 @@
 - type: loadout
   id: LoadoutClothingMNKTracksuitBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformMNKTracksuitBlack
@@ -944,7 +944,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -960,7 +960,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBlackAlt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBlackAlt
@@ -975,7 +975,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBlackMob
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBlackMob
@@ -990,7 +990,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrown
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBrown
@@ -1006,7 +1006,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrownAlt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBrownAlt
@@ -1021,7 +1021,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitBrownMob
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBrownMob
@@ -1036,7 +1036,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhite
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1053,7 +1053,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhiteAlt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1069,7 +1069,7 @@
 - type: loadout
   id: LoadoutClothingJumpsuitSuitWhiteMob
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1086,7 +1086,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressAsymmetric
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1102,7 +1102,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressEvening
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1118,7 +1118,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressMidi
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1134,7 +1134,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressOpenShoulder
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1150,7 +1150,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressTea
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1166,7 +1166,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressSleeveless
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1182,7 +1182,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressLongSleeve
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1198,7 +1198,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressBlackAndGold
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1214,7 +1214,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressBlackTango
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressBlackTango
@@ -1229,7 +1229,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressBlackTangoAlt
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressBlackTangoAlt
@@ -1244,7 +1244,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtSuitBlueBlazer
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtSuitBlueBlazer
@@ -1260,7 +1260,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressBlueSundress
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressBlueSundress
@@ -1276,7 +1276,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressCheongsamBlue
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1293,7 +1293,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressCheongsamGreen
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1310,7 +1310,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressCheongsamPurple
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1327,7 +1327,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressCheongsamRed
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1343,7 +1343,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressCheongsamWhite
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -1361,7 +1361,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressClub
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -1394,7 +1394,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressFlamenco
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1410,7 +1410,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressFire
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressFire
@@ -1426,7 +1426,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressOrange
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressOrange
@@ -1442,7 +1442,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressYellow
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressYellow
@@ -1474,7 +1474,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressFluffy
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1490,7 +1490,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressFormalRed
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressFormalRed
@@ -1505,7 +1505,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressGothic
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressGothic
@@ -1520,7 +1520,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtKimonoColor
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   canBeHeirloom: true
@@ -1537,7 +1537,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressLacyGown
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1553,7 +1553,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressLong
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1569,7 +1569,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressLongFlared
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1585,7 +1585,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtQipao
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1601,7 +1601,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtQipaoSlim
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1617,7 +1617,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressRedSwept
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressRedSwept
@@ -1632,7 +1632,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtPencilSkirtGymBra
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1648,7 +1648,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressPuffy
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1664,7 +1664,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtSailor
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtSailor
@@ -1679,7 +1679,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressSariGreen
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressSariGreen
@@ -1695,7 +1695,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressSariRed
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressSariRed
@@ -1726,7 +1726,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressSpider
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -1742,7 +1742,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressStriped
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressStriped
@@ -1790,7 +1790,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressVictorianBlack
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressVictorianBlack
@@ -1805,7 +1805,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressVictorianRed
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressVictorianRed
@@ -1820,7 +1820,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtWaitress
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtWaitress
@@ -1836,7 +1836,7 @@
 - type: loadout
   id: LoadoutUniformJumpskirtDressYellowSwoop
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtDressYellowSwoop
@@ -1852,7 +1852,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitAmish
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -1868,7 +1868,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitAristocratic
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitAristocratic
@@ -1883,7 +1883,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitAristocraticTuxedo
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitAristocraticTuxedo
@@ -1914,7 +1914,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitBarber
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitBarber
@@ -1929,7 +1929,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitBlueBlazer
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitBlueBlazer
@@ -1962,7 +1962,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitRegal
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitRegal
@@ -1977,7 +1977,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitRegalTuxedo
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitRegalTuxedo
@@ -1992,7 +1992,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitRippedPunk
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   canBeHeirloom: true
   items:
@@ -2008,7 +2008,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSailor
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -2024,7 +2024,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitStriped
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitStriped
@@ -2055,7 +2055,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitTurtleneckGrey
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -2071,7 +2071,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitVictorianRedBlack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitVictorianRedBlack
@@ -2086,7 +2086,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitVictorianRedVest
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitVictorianRedVest
@@ -2101,7 +2101,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitVictorianVest
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitVictorianVest
@@ -2116,7 +2116,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitWaiter
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitWaiter
@@ -2132,7 +2132,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitYogaGymBra
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   customColorTint: true
   items:
@@ -2148,7 +2148,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitBlackTurtleneck
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitBlackTurtleneck
@@ -2163,7 +2163,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitBlackTurtleneckFlipped
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitBlackTurtleneckFlipped
@@ -2179,7 +2179,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitSuitRolledSleeves
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitSuitRolledSleeves
@@ -2194,7 +2194,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitBartenderGrey
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitBartenderGrey
@@ -2209,7 +2209,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitCheckered
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitCheckered
@@ -2224,7 +2224,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannelOveralls
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannelOveralls
@@ -2239,7 +2239,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitCowboyBrown
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitCowboyBrown
@@ -2254,7 +2254,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitCowboyGrey
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitCowboyGrey
@@ -2269,7 +2269,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitCamouflageShirt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitCamouflageShirt
@@ -2284,7 +2284,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitOliveSweater
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitOliveSweater
@@ -2300,7 +2300,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitDesertUniform
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitDesertUniform
@@ -2315,7 +2315,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitLumberjack
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitLumberjack
@@ -2346,7 +2346,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitGreyShirt
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitGreyShirt
@@ -2362,7 +2362,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannelJeans
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannelJeans
@@ -2377,7 +2377,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannelBlackJeans
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannelBlackJeans
@@ -2392,7 +2392,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannelKhakis
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannelKhakis
@@ -2407,7 +2407,7 @@
 - type: loadout
   id: LoadoutUniformJumpsuitFlannelBlackKhakis
   category: Uniform
-  cost: 1
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitFlannelBlackKhakis
@@ -2422,7 +2422,7 @@
 - type: loadout
   id: ClothingUniformJumpsuitTacticool
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpsuitTacticool
@@ -2437,7 +2437,7 @@
 - type: loadout
   id: ClothingUniformJumpskirtTacticool
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtTacticool
@@ -2452,7 +2452,7 @@
 - type: loadout
   id: ClothingUniformJumpskirtTacticalMaid
   category: Uniform
-  cost: 2
+  cost: 0
   exclusive: true
   items:
     - ClothingUniformJumpskirtTacticalMaid
@@ -2556,6 +2556,140 @@
     - !type:CharacterNationalityRequirement
       nationalities:
         - Bieselite
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+# Solarian Aliance Uniforms
+- type: loadout
+  id: ClothingUniformJumpsuitSolArmyService
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolArmyService
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolFatigueGreen
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolFatigueGreen
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolFatigueGrey
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolFatigueGrey
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolFatigueTan
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolFatigueTan
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolNavyCoveralls
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolNavyCoveralls
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolNavySailor
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolNavySailor
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
+    - !type:CharacterLifepathRequirement
+      lifepaths:
+        - WarVet
+
+- type: loadout
+  id: ClothingUniformJumpsuitSolServiceWhite
+  category: Uniform
+  cost: 0
+  canBeHeirloom: true
+  exclusive: true
+  guideEntry: SANInfo
+  items:
+    - ClothingUniformJumpsuitSolServiceWhite
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutUniformsCivilian
+    - !type:CharacterNationalityRequirement
+      nationalities:
+        - Solarian
     - !type:CharacterLifepathRequirement
       lifepaths:
         - WarVet


### PR DESCRIPTION
# Description

This PR addresses a common complaint about our loadouts by making all generic non-job cosmetic clothing items covered by ItemGroups completely free. You can only take one of them anyway.

Also by popular request, I'm adding several of the enlisted-men uniforms from the Solarian assets to loadouts, with a Solarian+WarVeteran combination required to take them. None of the officers or admiralty, these are purely cosmetic.

# TODO

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/c030b383-0a0f-4944-9ad9-eca0dd5eeeef)

![image](https://github.com/user-attachments/assets/eac43054-870b-4193-8ba1-4511468e06dc)

![image](https://github.com/user-attachments/assets/539a00c9-6187-426d-a81c-c4da644a2a7d)

All the cosmetics are free
![image](https://github.com/user-attachments/assets/1a07d0b2-2c30-47c4-ac77-6c1f07ebbab6)

</p>
</details>

# Changelog

:cl:
- add: Added Solarian army/navy outfits to loadouts for characters with Solarian+WarVeteran.
- tweak: All cosmetic loadout items are now free.
