### PR TITLE
Softer Traits Anticheat

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Server.Administration.Logs;
 using Content.Server.Administration.Systems;
 using Content.Server.Chat.Managers;
 using Content.Shared.GameTicking;
@@ -7,7 +6,6 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Customization.Systems;
-using Content.Shared.Database;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
@@ -20,6 +18,8 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
 using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 
 namespace Content.Server.Traits;
 
@@ -31,11 +31,11 @@ public sealed class TraitSystem : EntitySystem
     [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
     [Dependency] private readonly IConfigurationManager _configuration = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
-    [Dependency] private readonly IAdminLogManager _adminLog = default!;
     [Dependency] private readonly AdminSystem _adminSystem = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogManager = default!;
 
     public override void Initialize()
     {
@@ -81,7 +81,7 @@ public sealed class TraitSystem : EntitySystem
         }
 
         sortedTraits.Sort();
-
+        var traitsToAdd = new List<TraitPrototype>();
         foreach (var traitPrototype in sortedTraits)
         {
             if (!_characterRequirements.CheckRequirementsValid(
@@ -95,12 +95,31 @@ public sealed class TraitSystem : EntitySystem
             // To check for cheaters. :FaridaBirb.png:
             pointsTotal += traitPrototype.Points;
             --traitSelections;
-
-            AddTrait(uid, traitPrototype);
+            traitsToAdd.Add(traitPrototype);
         }
 
-        if (punishCheater && (pointsTotal < 0 || traitSelections < 0))
-            PunishCheater(uid);
+        if (pointsTotal < 0 || traitSelections < 0)
+        {
+            _adminLogManager.Add(LogType.AdminMessage, LogImpact.Extreme, $"{ToPrettyString(uid):player} attempted to spawn with illegal trait selection total {profile.TraitPreferences.Count}, and {pointsTotal} net trait points");
+            if (punishCheater)
+                PunishCheater(uid);
+
+            if (_playerManager.TryGetSessionByEntity(uid, out var targetPlayer))
+            {
+                var feedbackMessage = "You have attempted to spawn with an illegal trait list. None of your traits will be applied. If you think this is in error, please return to the lobby and correct your trait selections.";
+                _chatManager.ChatMessageToOne(
+                    ChatChannel.Emotes,
+                    feedbackMessage,
+                    feedbackMessage,
+                    EntityUid.Invalid,
+                    false,
+                    targetPlayer.Channel);
+            }
+            return;
+        }
+
+        foreach (var trait in traitsToAdd)
+            AddTrait(uid, trait);
     }
 
     /// <summary>
@@ -119,9 +138,6 @@ public sealed class TraitSystem : EntitySystem
     /// </summary>
     private void PunishCheater(EntityUid uid)
     {
-        _adminLog.Add(LogType.AdminMessage, LogImpact.High,
-            $"{ToPrettyString(uid):entity} attempted to spawn with an invalid trait list. This might be a mistake, or they might be cheating");
-
         if (!_configuration.GetCVar(CCVars.TraitsPunishCheaters)
             || !_playerManager.TryGetSessionByEntity(uid, out var targetPlayer))
             return;


### PR DESCRIPTION
# Description

This PR introduces a new "Soft" Anti-Cheat that will outright prevent invalid trait selections from being applied to a character, while also informing admins directly of the potential cheater. 

# Changelog

:cl:
- add: Attempting to spawn in with an invalid trait list will now simply prevent you from spawning with any traits at all. It will also inform any admins who may be online of the attempt. 