### PR TITLE
Supermatter Tweaks

### DIFF
--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -2,7 +2,6 @@ using Content.Shared._EE.Supermatter.Monitor;
 using Content.Shared.Atmos;
 using Content.Shared.DoAfter;
 using Content.Shared.Radio;
-using Content.Shared.Speech;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -19,7 +18,7 @@ public sealed partial class SupermatterComponent : Component
     ///     The SM will only cycle if activated.
     /// </summary>
     [DataField]
-    public bool Activated = false;
+    public bool Activated;
 
     /// <summary>
     ///     The current status of the singularity, used for alert sounds and the monitoring console
@@ -453,7 +452,4 @@ public sealed partial class GasFact
 }
 
 [Serializable, NetSerializable]
-public sealed partial class SupermatterDoAfterEvent : SimpleDoAfterEvent
-{
-
-}
+public sealed partial class SupermatterDoAfterEvent : SimpleDoAfterEvent { }

--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -128,5 +128,5 @@
         volume: 2500
         moles:
           - 0 # oxygen
-          - 18710.71051 # nitrogen
+          - 9350.0 # nitrogen
         temperature: 72


### PR DESCRIPTION
# Description

_config.GetCVar() is generally to be deprecated and replaced with the significantly better performant Subs.CVar(), since it doesn't need to fetch the CVar each time its used and instead keeps it cached. This is particularly important for systems that operate on every frame. Technically Supermatter wasn't on my list of systems to optimize, but it's a good look since it's a system we're uniquely responsible for.

No actual functionality for the Supermatter has been changed, this is just a code cleanup and performance pass.

# Changelog

No CL since this isn't player facing.