### PR TITLE
Machine Languages

### DIFF
--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Replays;
 using System.Linq;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Silicons.Borgs.Components;
+using Content.Server.Language;
 
 namespace Content.Server.Telephone;
 
@@ -36,6 +37,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IReplayRecordingManager _replay = default!;
+    [Dependency] private readonly LanguageSystem _language = default!;
 
     // Has set used to prevent telephone feedback loops
     private HashSet<(EntityUid, string, Entity<TelephoneComponent>)> _recentChatMessages = new();
@@ -114,7 +116,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
         var range = args.TelephoneSource.Comp.LinkedTelephones.Count > 1 ? ChatTransmitRange.HideChat : ChatTransmitRange.GhostRangeLimit;
         var volume = entity.Comp.SpeakerVolume == TelephoneVolume.Speak ? InGameICChatType.Speak : InGameICChatType.Whisper;
 
-        _chat.TrySendInGameICMessage(speaker, args.Message, volume, range, nameOverride: name, checkRadioPrefix: false);
+        _chat.TrySendInGameICMessage(speaker, args.Message, volume, range, nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language);
     }
 
     #endregion
@@ -363,7 +365,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
         RaiseLocalEvent(source, ref evSentMessage);
         source.Comp.StateStartTime = _timing.CurTime;
 
-        var evReceivedMessage = new TelephoneMessageReceivedEvent(message, chatMsg, messageSource, source);
+        var evReceivedMessage = new TelephoneMessageReceivedEvent(message, chatMsg, messageSource, source, _language.GetLanguage(messageSource));
 
         foreach (var receiver in source.Comp.LinkedTelephones)
         {

--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chat;
+using Content.Shared.Language;
 using Content.Shared.Speech;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -179,7 +180,7 @@ public readonly record struct TelephoneMessageSentEvent(string Message, MsgChatM
 /// Raised when a chat message is received by a telephone from another
 /// </summary>
 [ByRefEvent]
-public readonly record struct TelephoneMessageReceivedEvent(string Message, MsgChatMessage ChatMsg, EntityUid MessageSource, Entity<TelephoneComponent> TelephoneSource);
+public readonly record struct TelephoneMessageReceivedEvent(string Message, MsgChatMessage ChatMsg, EntityUid MessageSource, Entity<TelephoneComponent> TelephoneSource, LanguagePrototype? Language = null);
 
 #endregion
 

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/aac_tablet.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/aac_tablet.yml
@@ -42,3 +42,9 @@
     speechSounds: Alto
   - type: AACTablet
   - type: VoiceMask
+  - type: LanguageSpeaker
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    understands:
+    - TauCetiBasic

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -55,6 +55,12 @@
       soundHit:
         path: /Audio/Weapons/smash.ogg
     - type: ToggleCellDraw
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+      - TauCetiBasic
+      understands:
+      - TauCetiBasic
 
 - type: entity
   id: Defibrillator

--- a/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
@@ -55,6 +55,12 @@
   - type: ExtensionCableReceiver
   - type: LightningTarget
     priority: 1
+  - type: LanguageSpeaker # Yes, on BASE MACHINE. This is all I need to make sure that in 99% of cases, machines use the language system.
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    understands:
+    - TauCetiBasic
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -106,13 +106,6 @@
     price: 100
   - type: Appearance
   - type: WiresVisuals
-  - type: LanguageKnowledge
-    speaks:
-    - TauCetiBasic
-    - RobotTalk
-    understands:
-    - TauCetiBasic
-    - RobotTalk
 
 - type: entity
   parent: VendingMachine
@@ -2447,6 +2440,11 @@
     color: "#9dc5c9"
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
+  - type: LanguageKnowledge
+    speaks:
+    - SolCommon
+    understands:
+    - SolCommon
 
 - type: entity
   id: VendingMachineSolsnack
@@ -2487,6 +2485,11 @@
     color: "#9dc5c9"
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
+  - type: LanguageKnowledge
+    speaks:
+    - SolCommon
+    understands:
+    - SolCommon
 
 - type: entity
   id: VendingMachineWeeb
@@ -2528,3 +2531,8 @@
     color: "#9dc5c9"
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
+  - type: LanguageKnowledge
+    speaks:
+    - SolCommon
+    understands:
+    - SolCommon

--- a/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -77,7 +77,7 @@
     location: supermatter
   - type: SinguloFood
     energy: 10000
-  - type: LanguageSpeaker # If you're an engineer with the foreigner trait, SUFFER.
+  - type: LanguageSpeaker
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic

--- a/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_EE/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -77,3 +77,9 @@
     location: supermatter
   - type: SinguloFood
     energy: 10000
+  - type: LanguageSpeaker # If you're an engineer with the foreigner trait, SUFFER.
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    understands:
+    - TauCetiBasic


### PR DESCRIPTION
# Description

This PR fixes a bug whereby the Holopads weren't respecting languages, and actually basically every machine in the entire game wasn't. There's an in-general broader issue that I would reaaaaaally like if UI elements in general could be differentiated by language, but that's a lot harder to do than this fix. This was shockingly easy to fix actually.

# Changelog

:cl:
- fix: Holopads now correctly respect the speaker's language, and transmit said language to the receiver. They are no longer Universal translators. Have fun yelling at people over the holopad in whatever obscure language your character knows.
- fix: Nearly every machine that can speak, now correctly respects that languages exist. For example, mice can now no longer understand what vending machines are saying. 
