### PR TITLE
Turrets Shoot Laying Down People

### DIFF
--- a/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
+++ b/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
@@ -61,4 +61,16 @@ public sealed partial class NPCRangedCombatComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier? SoundTargetInLOS;
+
+    /// <summary>
+    ///     Whether or not the NPC will always attempt to shoot targets that are laying down.
+    /// </summary>
+    [DataField]
+    public bool AlwaysDirectTargets;
+
+    /// <summary>
+    ///     The chance that an NPC will aim to hit targets that are laying down.
+    /// </summary>
+    [DataField]
+    public float DirectTargetChance = 0.5f;
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Ranged/GunOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Ranged/GunOperator.cs
@@ -39,6 +39,18 @@ public sealed partial class GunOperator : HTNOperator, IHtnConditionalShutdown
     [DataField("opaqueKey")]
     public bool UseOpaqueForLOSChecks = false;
 
+    /// <summary>
+    ///     Whether or not the NPC will always attempt to shoot targets that are laying down.
+    /// </summary>
+    [DataField]
+    public bool AlwaysDirectTargets;
+
+    /// <summary>
+    ///     The chance that an NPC will aim to hit targets that are laying down.
+    /// </summary>
+    [DataField]
+    public float DirectTargetChance = 0.5f;
+
     // Like movement we add a component and pass it off to the dedicated system.
 
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
@@ -66,6 +78,8 @@ public sealed partial class GunOperator : HTNOperator, IHtnConditionalShutdown
         var ranged = _entManager.EnsureComponent<NPCRangedCombatComponent>(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
         ranged.Target = blackboard.GetValue<EntityUid>(TargetKey);
         ranged.UseOpaqueForLOSChecks = UseOpaqueForLOSChecks;
+        ranged.AlwaysDirectTargets = AlwaysDirectTargets;
+        ranged.DirectTargetChance = DirectTargetChance;
 
         if (blackboard.TryGetValue<float>(NPCBlackboard.RotateSpeed, out var rotSpeed, _entManager))
         {

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -7,6 +7,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.NPC.Systems;
 
@@ -202,6 +203,8 @@ public sealed partial class NPCCombatSystem
             {
                 return;
             }
+
+            gun.Target = comp.AlwaysDirectTargets || _random.Prob(comp.DirectTargetChance) ? comp.Target : null;
 
             _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
         }

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -1,17 +1,13 @@
 using System.Numerics;
-using Content.Shared.Nyanotrasen.Abilities.Oni;
 using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Content.Shared._Goobstation.Weapons.Multishot;
 
 namespace Content.Shared.Weapons.Ranged.Components;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access(typeof(SharedGunSystem), typeof(SharedMultishotSystem), typeof(SharedOniSystem))] // DeltaV - I didn't feel like rewriting big chunks of code
 public sealed partial class GunComponent : Component
 {
     #region Sound


### PR DESCRIPTION
# Description

This fixes an issue whereby turrets were not capable of hitting players who lay down on the floor. Now turrets have a 50% chance to hit them anways, meaning that laying down offers some, but not perfect protection from turrets.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/599583be-d298-452c-8b1b-f32d8d545131

</p>
</details>

# Changelog

:cl:
- fix: Turrets and NPCs can now hit players who are laying down on the floor. They (by default) have a 50% chance to miss players who are laying down, meaning it still offers some protection, but not perfect protection from turrets. 