### PR TITLE
Marking Shaders

### DIFF
--- a/Content.Client/Body/Systems/BodySystem.cs
+++ b/Content.Client/Body/Systems/BodySystem.cs
@@ -47,6 +47,10 @@ public sealed class BodySystem : SharedBodySystem
                 sprite.LayerSetColor(layerId, colors[j]);
             else
                 sprite.LayerSetColor(layerId, Color.White);
+
+            var shaders = markingPrototype.Shaders;
+            if (shaders is not null && shaders.ContainsKey(rsi.RsiState))
+                sprite.LayerSetShader(layerId, shaders[rsi.RsiState]);
         }
     }
 

--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -288,9 +288,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         SpriteComponent sprite)
     {
         if (!sprite.LayerMapTryGet(markingPrototype.BodyPart, out int targetLayer))
-        {
             return;
-        }
 
         visible &= !IsHidden(humanoid, markingPrototype.BodyPart);
         visible &= humanoid.BaseLayers.TryGetValue(markingPrototype.BodyPart, out var setting)
@@ -301,9 +299,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             var markingSprite = markingPrototype.Sprites[j];
 
             if (markingSprite is not SpriteSpecifier.Rsi rsi)
-            {
                 continue;
-            }
 
             var layerId = $"{markingPrototype.ID}-{rsi.RsiState}";
 
@@ -317,21 +313,19 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             sprite.LayerSetVisible(layerId, visible);
 
             if (!visible || setting == null) // this is kinda implied
-            {
                 continue;
-            }
 
             // Okay so if the marking prototype is modified but we load old marking data this may no longer be valid
             // and we need to check the index is correct.
             // So if that happens just default to white?
             if (colors != null && j < colors.Count)
-            {
                 sprite.LayerSetColor(layerId, colors[j]);
-            }
             else
-            {
                 sprite.LayerSetColor(layerId, Color.White);
-            }
+
+            var shaders = markingPrototype.Shaders;
+            if (shaders is not null && shaders.ContainsKey(rsi.RsiState))
+                sprite.LayerSetShader(layerId, shaders[rsi.RsiState]);
         }
     }
 

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -39,6 +39,9 @@ namespace Content.Shared.Humanoid.Markings
         public MarkingColors Coloring { get; private set; } = new();
 
         [DataField]
+        public Dictionary<string, string>? Shaders { get; private set; }
+
+        [DataField]
         public string PreviewDirection { get; private set; } = "South";
 
         [DataField("sprites", required: true)]

--- a/Resources/Locale/en-US/markings/face.ftl
+++ b/Resources/Locale/en-US/markings/face.ftl
@@ -93,3 +93,9 @@ marking-FaceNeckWideThick-neck_thick_m = Neck Cover (Wide Thick)
 
 marking-IronJaw = Iron Jaw
 marking-IronJaw-iron_jaw = Iron Jaw
+
+marking-EmissiveEyeRight-tattoo_eye_r = Right Cybernetic Eye (Emissive)
+marking-EmissiveEyeRight = Right Cybernetic Eye (Emissive)
+
+marking-EmissiveEyeLeft-tattoo_eye_l = Left Cybernetic Eye (Emissive)
+marking-EmissiveEyeLeft = Left Cybernetic Eye (Emissive)

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/harpy.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/harpy.yml
@@ -376,12 +376,13 @@
   bodyPart: RArm
   markingCategory: RightArm
   speciesRestriction: [Harpy]
+  shaders:
+    bionic_wings_tone_2: unshaded
   sprites:
     - sprite: Mobs/Customization/Harpy/harpy_wings.rsi
       state: bionic_wings_tone_1
     - sprite: Mobs/Customization/Harpy/harpy_wings.rsi
       state: bionic_wings_tone_2
-      shader: unshaded
 
 - type: marking
   id: HarpyChestDefault

--- a/Resources/Prototypes/Entities/Mobs/Customization/cyberlimbs/eyes.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/cyberlimbs/eyes.yml
@@ -1,0 +1,31 @@
+- type: marking
+  id: EmissiveEyeRight
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy, Lamia, Plasmaman, Tajaran]
+  shaders:
+    tattoo_eye_r: unshaded
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_r
+
+- type: marking
+  id: EmissiveEyeLeft
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy, Lamia, Plasmama, Tajaran]
+  shaders:
+    tattoo_eye_l: unshaded
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true
+  sprites:
+  - sprite: Mobs/Customization/tattoos.rsi
+    state: tattoo_eye_l

--- a/Resources/Prototypes/Entities/Mobs/Customization/screens.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/screens.yml
@@ -1,11 +1,10 @@
-## CANT SET THESE SCREENS TO "shader: unshaded"
-## RobustToolbox/Robust.Shared/Utility/SpriteSpecifier.cs
-
 - type: marking
   speciesRestriction: [ IPC ]
   id: ScreenStatic
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_static: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_static
@@ -16,6 +15,8 @@
   id: ScreenBlue
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_blue: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_blue
@@ -26,6 +27,8 @@
   id: ScreenBreakout
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_breakout: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_breakout
@@ -36,6 +39,8 @@
   id: ScreenEight
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_eight: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_eight
@@ -46,6 +51,8 @@
   id: ScreenGoggles
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_goggles: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_goggles
@@ -56,6 +63,8 @@
   id: ScreenExclaim
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_exclaim: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_exclaim
@@ -66,6 +75,8 @@
   id: ScreenHeart
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_heart: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_heart
@@ -76,6 +87,8 @@
   id: ScreenMonoeye
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_monoeye: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_monoeye
@@ -86,6 +99,8 @@
   id: ScreenNature
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_nature: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_nature
@@ -96,6 +111,8 @@
   id: ScreenOrange
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_orange: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_orange
@@ -106,6 +123,8 @@
   id: ScreenPink
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_pink: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_pink
@@ -116,6 +135,8 @@
   id: ScreenQuestion
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_question: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_question
@@ -126,6 +147,8 @@
   id: ScreenShower
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_shower: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_shower
@@ -136,6 +159,8 @@
   id: ScreenYellow
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_yellow: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_yellow
@@ -146,6 +171,8 @@
   id: ScreenScroll
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_scroll: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_scroll
@@ -156,6 +183,8 @@
   id: ScreenConsole
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_console: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_console
@@ -166,6 +195,8 @@
   id: ScreenRgb
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_rgb: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_rgb
@@ -176,6 +207,8 @@
   id: ScreenGlider
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_glider: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_glider
@@ -186,6 +219,8 @@
   id: ScreenRainbowhoriz
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_rainbowhoriz: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_rainbowhoriz
@@ -196,6 +231,8 @@
   id: ScreenBsod
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_bsod: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_bsod
@@ -206,6 +243,8 @@
   id: ScreenRedtext
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_redtext: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_redtext
@@ -216,6 +255,8 @@
   id: ScreenSinewave
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_sinewave: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_sinewave
@@ -226,6 +267,8 @@
   id: ScreenSquarewave
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_squarewave: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_squarewave
@@ -236,6 +279,8 @@
   id: ScreenEcgwave
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_ecgwave: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_ecgwave
@@ -246,6 +291,8 @@
   id: ScreenEyes
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_eyes: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_eyes
@@ -256,6 +303,8 @@
   id: ScreenEyestall
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_eyestall: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_eyestall
@@ -266,6 +315,8 @@
   id: ScreenEyesangry
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_eyesangry: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_eyesangry
@@ -276,6 +327,8 @@
   id: ScreenLoading
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_loading: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_loading
@@ -286,6 +339,8 @@
   id: ScreenWindowsxp
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_windowsxp: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_windowsxp
@@ -296,6 +351,8 @@
   id: ScreenTetris
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_tetris: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_tetris
@@ -306,6 +363,8 @@
   id: ScreenTv
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_tv: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_tv
@@ -316,6 +375,8 @@
   id: ScreenTextdrop
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_textdrop: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_textdrop
@@ -326,6 +387,8 @@
   id: ScreenStars
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_stars: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_stars
@@ -336,6 +399,8 @@
   id: ScreenRainbowdiag
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_rainbowdiag: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_rainbowdiag
@@ -346,6 +411,8 @@
   id: ScreenBlank
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_blank: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_blank
@@ -356,6 +423,8 @@
   id: ScreenSmile
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_smile: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_smile
@@ -365,6 +434,8 @@
   id: ScreenFrown
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_frown: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_frown
@@ -375,6 +446,8 @@
   id: ScreenRing
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_ring: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_ring
@@ -385,6 +458,8 @@
   id: ScreenL
   bodyPart: Face
   markingCategory: Face
+  shaders:
+    ipc_screen_l: unshaded
   sprites:
     - sprite: Mobs/Customization/ipc_screens.rsi
       state: ipc_screen_l

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -43,6 +43,9 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
+    Head:
+      points: 2
+      required: false
     Hair:
       points: 1
       required: false


### PR DESCRIPTION
# Description

This PR adds shader support to markings, which can define specific layers that have a shader, and which shader is desired. I wanted to have glowing eyes like my character in Aurora does, but was frustrated that I couldn't. So here's that tiny feature now.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/f8241813-3f3d-4c5a-84f1-3ea8e291e258)

</p>
</details>

# Changelog

:cl:
- add: Markings can now use shaders. Including things like glowing light effects. You can now also have glowing cybernetic eyes. IPC head screens now glow. 