### PR TITLE
Support Generating In Specific Chunks

### DIFF
--- a/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
@@ -28,21 +28,45 @@ public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
     /// <summary>
     ///     The valid ranges of noise values under which this biome can be picked.
     /// </summary>
-    [DataField("noiseRanges", required: true)]
+    [DataField(required: true)]
     public Dictionary<string, List<Vector2>> NoiseRanges = default!;
 
     /// <summary>
     ///     Higher priority biomes get picked before lower priority ones.
     /// </summary>
-    [DataField("priority", required: true)]
+    [DataField(required: true)]
     public int Priority { get; private set; }
 
     /// <summary>
     ///     The components that get added to the target map.
     /// </summary>
-    [DataField("chunkComponents")]
+    [DataField]
     [AlwaysPushInheritance]
     public ComponentRegistry ChunkComponents { get; } = new();
+
+    /// <summary>
+    ///     Minimum X coordinate value to spawn this biome.
+    /// </summary>
+    [DataField]
+    public int? MinX;
+
+    /// <summary>
+    ///     Minimum Y coordinate value to spawn this biome.
+    /// </summary>
+    [DataField]
+    public int? MinY;
+
+    /// <summary>
+    ///     Maximum X coordinate value to spawn this biome.
+    /// </summary>
+    [DataField]
+    public int? MaxX;
+
+    /// <summary>
+    ///     Maximum Y coordinate value to spawn this biome.
+    /// </summary>
+    [DataField]
+    public int? MaxY;
 
     //TODO: Get someone to make this a method on componentregistry that does it Correctly.
     /// <summary>
@@ -54,7 +78,6 @@ public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
         foreach (var data in ChunkComponents.Values)
         {
             var comp = (Component) serialization.CreateCopy(data.Component, notNullableOverride: true);
-            comp.Owner = target; // look im sorry ok this .owner has to live until engine api exists
             entityManager.AddComponent(target, comp);
         }
     }

--- a/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
+++ b/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
@@ -38,17 +38,12 @@ public sealed class BiomeSelectionSystem : BaseWorldSystem
         Log.Error($"Biome selection ran out of biomes to select? See biomes list: {component.Biomes}");
     }
 
-    private void OnBiomeSelectionStartup(EntityUid uid, BiomeSelectionComponent component, ComponentStartup args)
-    {
-        // surely this can't be THAAAAAAAAAAAAAAAT bad right????
-        var sorted = component.Biomes
+    private void OnBiomeSelectionStartup(EntityUid uid, BiomeSelectionComponent component, ComponentStartup args) =>
+        component.Biomes = component.Biomes
             .Select(x => (Id: x, _proto.Index<BiomePrototype>(x).Priority))
             .OrderByDescending(x => x.Priority)
             .Select(x => x.Id)
             .ToList();
-
-        component.Biomes = sorted; // my hopes and dreams rely on this being pre-sorted by priority.
-    }
 
     private bool CheckBiomeValidity(EntityUid chunk, BiomePrototype biome, Vector2i coords) =>
         (biome.MinX is null || biome.MaxX is null || biome.MinY is null || biome.MaxY is null)

--- a/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
+++ b/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
@@ -71,6 +71,6 @@ public sealed class BiomeSelectionSystem : BaseWorldSystem
     }
 
     private bool CheckSpecificChunkRange(BiomePrototype biome, Vector2i coords) =>
-        coords.X > biome.MinX || coords.X < biome.MaxX || coords.Y > biome.MinY || coords.Y < biome.MaxY;
+        coords.X >= biome.MinX && coords.X <= biome.MaxX && coords.Y >= biome.MinY && coords.Y <= biome.MaxY;
 }
 

--- a/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
+++ b/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
@@ -52,22 +52,29 @@ public sealed class BiomeSelectionSystem : BaseWorldSystem
 
     private bool CheckBiomeValidity(EntityUid chunk, BiomePrototype biome, Vector2i coords)
     {
-        foreach (var (noise, ranges) in biome.NoiseRanges)
-        {
-            var value = _noiseIdx.Evaluate(chunk, noise, coords);
-            var anyValid = false;
-            foreach (var range in ranges)
+        if (biome.MinX is null || biome.MaxX is null || biome.MinY is null || biome.MaxY is null)
+            foreach (var (noise, ranges) in biome.NoiseRanges)
             {
-                if (range.X < value && value < range.Y)
+                var value = _noiseIdx.Evaluate(chunk, noise, coords);
+                var anyValid = false;
+                foreach (var range in ranges)
                 {
-                    anyValid = true;
-                    break;
+                    if (range.X < value && value < range.Y)
+                    {
+                        anyValid = true;
+                        break;
+                    }
                 }
-            }
 
-            if (!anyValid)
-                return false;
-        }
+                if (!anyValid)
+                    return false;
+            }
+        else
+        if (coords.X < biome.MinX
+            || coords.X > biome.MaxX
+            || coords.Y < biome.MinY
+            || coords.Y > biome.MaxY)
+            return false;
 
         return true;
     }

--- a/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
@@ -213,7 +213,7 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
         }
 
         if (failures > 0)
-            _sawmill.Error($"Failed to place {failures} debris at chunk {args.Chunk}");
+            _sawmill.Error($"Failed to place {failures} debris at chunk {args.Chunk} at coords {args.Coords}");
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

Done by request from Aisha at Hullrot, this PR adds support for defining specific world chunks that will always generate a specific biome prototype. I've slightly adapted the old hullrot code to support the prototypes, while also making sure that it's an optional functionality. Simply don't define the specific locations if you want a prototype to potentially generate anywhere.

# Changelog

No CL this isn't player facing.
