### PR TITLE
Weapon Range Fixes

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeArcOverlay.cs
+++ b/Content.Client/Weapons/Melee/MeleeArcOverlay.cs
@@ -1,11 +1,9 @@
 using System.Numerics;
 using Content.Shared.CombatMode;
-using Content.Shared.Weapons.Melee;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
-using Robust.Shared.Map;
 
 namespace Content.Client.Weapons.Melee;
 

--- a/Content.Client/Weapons/Melee/MeleeArcOverlay.cs
+++ b/Content.Client/Weapons/Melee/MeleeArcOverlay.cs
@@ -64,7 +64,7 @@ public sealed class MeleeArcOverlay : Overlay
         if (diff.Equals(Vector2.Zero))
             return;
 
-        diff = diff.Normalized() * Math.Min(weapon.Range, diff.Length());
+        diff = diff.Normalized() * Math.Min(weapon.Range * weapon.HeavyRangeModifier, diff.Length());
         args.WorldHandle.DrawLine(playerPos.Position, playerPos.Position + diff, Color.Aqua);
 
         if (weapon.Angle.Theta == 0)

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -149,7 +149,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             var attackerPos = TransformSystem.GetMapCoordinates(entity);
 
             if (mousePos.MapId != attackerPos.MapId ||
-                (attackerPos.Position - mousePos.Position).Length() > weapon.Range)
+                (attackerPos.Position - mousePos.Position).Length() > weapon.Range * weapon.LightRangeModifier)
             {
                 if (weapon.HeavyOnLightMiss)
                     ClientHeavyAttack(entity, coordinates, weaponUid, weapon);

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -75,10 +75,10 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var altDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.UseSecondary) == BoundKeyState.Down;
 
         // Disregard inputs to the shoot binding
-        if (TryComp<GunComponent>(weaponUid, out var gun) &&
-            // Except if can't shoot due to being unwielded
-            (!HasComp<GunRequiresWieldComponent>(weaponUid) ||
-            (TryComp<WieldableComponent>(weaponUid, out var wieldable) && wieldable.Wielded)))
+        if (TryComp<GunComponent>(weaponUid, out var gun)
+            && (!HasComp<GunRequiresWieldComponent>(weaponUid)
+            || TryComp<WieldableComponent>(weaponUid, out var wieldable)
+            && wieldable.Wielded))
         {
             if (gun.UseKey)
                 useDown = false;
@@ -86,38 +86,16 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
                 altDown = false;
         }
 
-        if (weapon.AutoAttack || !useDown && !altDown)
-        {
-            if (weapon.Attacking)
-            {
-                RaisePredictiveEvent(new StopAttackEvent(GetNetEntity(weaponUid)));
-            }
-        }
+        if ((weapon.AutoAttack || !useDown && !altDown) && weapon.Attacking)
+            RaisePredictiveEvent(new StopAttackEvent(GetNetEntity(weaponUid)));
 
-        if (weapon.Attacking || weapon.NextAttack > Timing.CurTime || (!useDown && !altDown))
-        {
+        if (weapon.Attacking || weapon.NextAttack > Timing.CurTime || !useDown && !altDown)
             return;
-        }
 
         // TODO using targeted actions while combat mode is enabled should NOT trigger attacks.
 
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition);
-
-        if (mousePos.MapId == MapId.Nullspace)
-        {
-            return;
-        }
-
-        EntityCoordinates coordinates;
-
-        if (MapManager.TryFindGridAt(mousePos, out var gridUid, out _))
-        {
-            coordinates = EntityCoordinates.FromMap(gridUid, mousePos, TransformSystem, EntityManager);
-        }
-        else
-        {
-            coordinates = EntityCoordinates.FromMap(MapManager.GetMapEntityId(mousePos.MapId), mousePos, TransformSystem, EntityManager);
-        }
+        var coordinates = TransformSystem.ToCoordinates(mousePos);
 
         // Heavy attack.
         if (!weapon.DisableHeavy &&
@@ -159,9 +137,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             EntityUid? target = null;
 
             if (_stateManager.CurrentState is GameplayStateBase screen)
-            {
                 target = screen.GetClickedEntity(mousePos);
-            }
 
             // Don't light-attack if interaction will be handling this instead
             if (Interaction.CombatModeCanHandInteract(entity, target))
@@ -186,22 +162,15 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range);
     }
 
-    protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
-    {
-        // Server never sends the event to us for predictiveeevent.
+    protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform) =>
         _color.RaiseEffect(Color.Red, targets, Filter.Local());
-    }
 
     protected override bool DoDisarm(EntityUid user, DisarmAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
     {
-        if (!base.DoDisarm(user, ev, meleeUid, component, session))
+        if (!base.DoDisarm(user, ev, meleeUid, component, session)
+            || !TryComp<CombatModeComponent>(user, out var combatMode)
+            || combatMode.CanDisarm != true)
             return false;
-
-        if (!TryComp<CombatModeComponent>(user, out var combatMode) ||
-            combatMode.CanDisarm != true)
-        {
-            return false;
-        }
 
         var target = GetEntity(ev.Target);
 
@@ -228,14 +197,11 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     private void ClientHeavyAttack(EntityUid user, EntityCoordinates coordinates, EntityUid meleeUid, MeleeWeaponComponent component)
     {
         // Only run on first prediction to avoid the potential raycast entities changing.
-        if (!_xformQuery.TryGetComponent(user, out var userXform) ||
-            !Timing.IsFirstTimePredicted)
-        {
+        if (!_xformQuery.TryGetComponent(user, out var userXform)
+            || !Timing.IsFirstTimePredicted)
             return;
-        }
 
-        var targetMap = coordinates.ToMap(EntityManager, TransformSystem);
-
+        var targetMap = TransformSystem.ToMapCoordinates(coordinates);
         if (targetMap.MapId != userXform.MapID)
             return;
 
@@ -255,7 +221,9 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var entWeapon = GetEntity(ev.Weapon);
 
         // Entity might not have been sent by PVS.
-        if (Exists(ent) && Exists(entWeapon))
-            DoLunge(ent, entWeapon, ev.Angle, ev.LocalPos, ev.Animation);
+        if (!Exists(ent) || Exists(entWeapon))
+            return;
+
+        DoLunge(ent, entWeapon, ev.Angle, ev.LocalPos, ev.Animation);
     }
 }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Client.Gameplay;
-using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -98,7 +98,7 @@ public sealed partial class NPCCombatSystem
         // TODO: When I get parallel operators move this as NPC combat shouldn't be handling this.
         _steering.Register(uid, new EntityCoordinates(component.Target, Vector2.Zero), steering);
 
-        if (distance > weapon.Range)
+        if (distance > weapon.Range * weapon.LightRangeModifier)
         {
             component.Status = CombatStatus.TargetOutOfRange;
             return;

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -11,7 +11,6 @@ namespace Content.Server.NPC.Systems;
 
 public sealed partial class NPCCombatSystem
 {
-    [Dependency] private readonly IRobustRandom _rng = default!;
     private const float TargetMeleeLostRange = 14f;
 
     private void InitializeMelee()
@@ -129,6 +128,6 @@ public sealed partial class NPCCombatSystem
         }
 
         if (Comp<HTNComponent>(uid).Blackboard.TryGetValue<float>("AttackDelayDeviation", out var dev, EntityManager))
-            weapon.NextAttack += TimeSpan.FromSeconds(_rng.NextFloat(-dev, dev));
+            weapon.NextAttack += TimeSpan.FromSeconds(_random.NextFloat(-dev, dev));
     }
 }

--- a/Content.Server/NPC/Systems/NPCJukeSystem.cs
+++ b/Content.Server/NPC/Systems/NPCJukeSystem.cs
@@ -1,15 +1,10 @@
 using System.Numerics;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Events;
-using Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat;
 using Content.Server.Weapons.Melee;
-using Content.Shared.Coordinates.Helpers;
 using Content.Shared.NPC;
-using Content.Shared.Weapons.Melee;
-using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 

--- a/Content.Server/NPC/Systems/NPCJukeSystem.cs
+++ b/Content.Server/NPC/Systems/NPCJukeSystem.cs
@@ -171,7 +171,7 @@ public sealed class NPCJukeSystem : EntitySystem
                     return;
 
                 // TODO: Probably add in our bounds and target bounds for ideal distance.
-                var idealDistance = weapon.Range * 4f;
+                var idealDistance = weapon.Range * weapon.LightRangeModifier * 4f;
                 var obstacleDistance = obstacleDirection.Length();
 
                 if (obstacleDistance > idealDistance || obstacleDistance == 0f)

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -123,7 +123,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
                 return false;
         }
 
-        if (!InRange(user, target, component.Range, session))
+        if (!InRange(user, target, component.Range * component.DisarmRangeModifier, session))
         {
             return false;
         }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -13,7 +13,6 @@ using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Popups;
 using Content.Shared.Speech.Components;
 using Content.Shared.StatusEffect;
 using Content.Shared.Weapons.Melee;
@@ -60,20 +59,20 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (!component.DisableClick)
             _damageExamine.AddDamageExamine(args.Message, damageSpec, Loc.GetString("damage-melee"));
 
-        if (!component.DisableHeavy)
-        {
-            if (damageSpec * component.HeavyDamageBaseModifier != damageSpec)
-                _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
+        if (component.DisableHeavy)
+            return;
 
-            if (component.HeavyStaminaCost != 0)
-            {
-                var staminaCostMarkup = FormattedMessage.FromMarkupOrThrow(
-                    Loc.GetString("damage-stamina-cost",
-                    ("type", Loc.GetString("damage-melee-heavy")), ("cost", Math.Round(component.HeavyStaminaCost, 2).ToString("0.##"))));
-                args.Message.PushNewline();
-                args.Message.AddMessage(staminaCostMarkup);
-            }
-        }
+        if (damageSpec * component.HeavyDamageBaseModifier != damageSpec)
+            _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
+
+        if (component.HeavyStaminaCost == 0)
+            return;
+
+        var staminaCostMarkup = FormattedMessage.FromMarkupOrThrow(
+            Loc.GetString("damage-stamina-cost",
+            ("type", Loc.GetString("damage-melee-heavy")), ("cost", Math.Round(component.HeavyStaminaCost, 2).ToString("0.##"))));
+        args.Message.PushNewline();
+        args.Message.AddMessage(staminaCostMarkup);
     }
 
     protected override bool ArcRaySuccessful(EntityUid targetUid, Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId,
@@ -101,50 +100,27 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     protected override bool DoDisarm(EntityUid user, DisarmAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
     {
-        if (!base.DoDisarm(user, ev, meleeUid, component, session))
+        if (!base.DoDisarm(user, ev, meleeUid, component, session)
+            || !TryComp<CombatModeComponent>(user, out var combatMode)
+            || combatMode.CanDisarm != true)
             return false;
-
-        if (!TryComp<CombatModeComponent>(user, out var combatMode) ||
-            combatMode.CanDisarm != true)
-        {
-            return false;
-        }
 
         var target = GetEntity(ev.Target!.Value);
 
-        if (_mobState.IsIncapacitated(target))
-        {
+        if (_mobState.IsIncapacitated(target)
+            || !TryComp<HandsComponent>(target, out var targetHandsComponent)
+            && (!TryComp<StatusEffectsComponent>(target, out var status) || !status.AllowedEffects.Contains("KnockedDown"))
+            || !InRange(user, target, component.Range * component.DisarmRangeModifier, session))
             return false;
-        }
 
-        if (!TryComp<HandsComponent>(target, out var targetHandsComponent))
-        {
-            if (!TryComp<StatusEffectsComponent>(target, out var status) || !status.AllowedEffects.Contains("KnockedDown"))
-                return false;
-        }
-
-        if (!InRange(user, target, component.Range * component.DisarmRangeModifier, session))
-        {
-            return false;
-        }
-
-        EntityUid? inTargetHand = null;
-
-        if (targetHandsComponent?.ActiveHand is { IsEmpty: false })
-        {
-            inTargetHand = targetHandsComponent.ActiveHand.HeldEntity!.Value;
-        }
+        EntityUid? inTargetHand = targetHandsComponent?.ActiveHand is { IsEmpty: false }
+            ? targetHandsComponent.ActiveHand.HeldEntity!.Value
+            : null;
 
         Interaction.DoContactInteraction(user, target);
 
         var attemptEvent = new DisarmAttemptEvent(target, user, inTargetHand);
-
-        if (inTargetHand != null)
-        {
-            RaiseLocalEvent(inTargetHand.Value, attemptEvent);
-        }
-
-        RaiseLocalEvent(target, attemptEvent);
+        RaiseLocalEvent(inTargetHand != null ? inTargetHand.Value : target, attemptEvent);
 
         if (attemptEvent.Cancelled)
             return false;
@@ -194,20 +170,15 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         EntityCoordinates targetCoordinates;
         Angle targetLocalAngle;
 
-        if (session is { } pSession)
-        {
-            (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
-            return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range);
-        }
+        if (session is not { } pSession)
+            return Interaction.InRangeUnobstructed(user, target, range);
 
-        return Interaction.InRangeUnobstructed(user, target, range);
+        (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
+        return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range);
     }
 
-    protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
-    {
-        var filter = Filter.Pvs(targetXform.Coordinates, entityMan: EntityManager).RemoveWhereAttachedEntity(o => o == user);
-        _color.RaiseEffect(Color.Red, targets, filter);
-    }
+    protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform) =>
+        _color.RaiseEffect(Color.Red, targets, Filter.Pvs(targetXform.Coordinates, entityMan: EntityManager).RemoveWhereAttachedEntity(o => o == user));
 
     private float CalculateDisarmChance(EntityUid disarmer, EntityUid disarmed, EntityUid? inTargetHand, CombatModeComponent disarmerComp)
     {
@@ -220,9 +191,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var chance = disarmerComp.BaseDisarmFailChance;
 
         if (inTargetHand != null && TryComp<DisarmMalusComponent>(inTargetHand, out var malus))
-        {
             chance += malus.Malus;
-        }
 
         return Math.Clamp(chance
                         * _contests.MassContest(disarmer, disarmed, false, 0.5f)
@@ -231,34 +200,20 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
                         0f, 1f);
     }
 
-    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
-    {
-        Filter filter;
-
-        if (predicted)
-        {
-            filter = Filter.PvsExcept(user, entityManager: EntityManager);
-        }
-        else
-        {
-            filter = Filter.Pvs(user, entityManager: EntityManager);
-        }
-
-        RaiseNetworkEvent(new MeleeLungeEvent(GetNetEntity(user), GetNetEntity(weapon), angle, localPos, animation), filter);
-    }
+    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true) =>
+        RaiseNetworkEvent(new MeleeLungeEvent(
+            GetNetEntity(user),
+            GetNetEntity(weapon),
+            angle,
+            localPos,
+            animation),
+            predicted ? Filter.PvsExcept(user, entityManager: EntityManager) : Filter.Pvs(user, entityManager: EntityManager));
 
     private void OnSpeechHit(EntityUid owner, MeleeSpeechComponent comp, MeleeHitEvent args)
     {
-        if (!args.IsHit ||
-        !args.HitEntities.Any())
-        {
+        if (!args.IsHit || !args.HitEntities.Any() || comp.Battlecry is null)
             return;
-        }
 
-        if (comp.Battlecry != null)//If the battlecry is set to empty, doesn't speak
-        {
-            _chat.TrySendInGameICMessage(args.User, comp.Battlecry, InGameICChatType.Speak, true, true, checkRadioPrefix: false);  //Speech that isn't sent to chat or adminlogs
-        }
-
+        _chat.TrySendInGameICMessage(args.User, comp.Battlecry, InGameICChatType.Speak, true, true, checkRadioPrefix: false);  //Speech that isn't sent to chat or adminlogs
     }
 }

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -133,6 +133,18 @@ public sealed partial class MeleeWeaponComponent : Component
     public float Range = 1.5f;
 
     /// <summary>
+    ///     Bonus range for disarm attacks, not currently used for melee weapons, and is instead only on innate melee.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DisarmRangeModifier = 1f;
+
+    /// <summary>
+    ///     Bonus attack range for light (direct click) attacks.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float LightRangeModifier = 1f;
+
+    /// <summary>
     ///     Attack range for heavy swings
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -21,9 +21,6 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
-using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -36,21 +33,21 @@ namespace Content.Shared.Weapons.Melee;
 
 public abstract class SharedMeleeWeaponSystem : EntitySystem
 {
-    [Dependency] protected readonly ISharedAdminLogManager   AdminLogger     = default!;
-    [Dependency] protected readonly ActionBlockerSystem      Blocker         = default!;
-    [Dependency] protected readonly SharedCombatModeSystem   CombatMode      = default!;
-    [Dependency] protected readonly DamageableSystem         Damageable      = default!;
-    [Dependency] protected readonly SharedInteractionSystem  Interaction     = default!;
-    [Dependency] protected readonly IMapManager              MapManager      = default!;
-    [Dependency] protected readonly SharedPopupSystem        PopupSystem     = default!;
-    [Dependency] protected readonly IGameTiming              Timing          = default!;
-    [Dependency] protected readonly SharedTransformSystem    TransformSystem = default!;
-    [Dependency] private   readonly InventorySystem         _inventory       = default!;
-    [Dependency] private   readonly MeleeSoundSystem        _meleeSound      = default!;
-    [Dependency] private   readonly SharedPhysicsSystem     _physics         = default!;
-    [Dependency] private   readonly IPrototypeManager       _protoManager    = default!;
-    [Dependency] private   readonly StaminaSystem           _stamina         = default!;
-    [Dependency] private   readonly ContestsSystem          _contests        = default!;
+    [Dependency] protected readonly ISharedAdminLogManager AdminLogger = default!;
+    [Dependency] protected readonly ActionBlockerSystem Blocker = default!;
+    [Dependency] protected readonly SharedCombatModeSystem CombatMode = default!;
+    [Dependency] protected readonly DamageableSystem Damageable = default!;
+    [Dependency] protected readonly SharedInteractionSystem Interaction = default!;
+    [Dependency] protected readonly IMapManager MapManager = default!;
+    [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
+    [Dependency] protected readonly IGameTiming Timing = default!;
+    [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly MeleeSoundSystem _meleeSound = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly StaminaSystem _stamina = default!;
+    [Dependency] private readonly ContestsSystem _contests = default!;
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -71,8 +68,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeAllEvent<StopAttackEvent>(OnStopAttack);
 
 #if DEBUG
-        SubscribeLocalEvent<MeleeWeaponComponent,
-                            MapInitEvent>                   (OnMapInit);
+        SubscribeLocalEvent<MeleeWeaponComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnMapInit(EntityUid uid, MeleeWeaponComponent component, MapInitEvent args)
@@ -85,13 +81,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     private void OnMeleeSelected(EntityUid uid, MeleeWeaponComponent component, HandSelectedEvent args)
     {
         var attackRate = GetAttackRate(uid, args.User, component);
-        if (attackRate.Equals(0f))
-            return;
-
-        if (!component.ResetOnHandSelected)
-            return;
-
-        if (Paused(uid))
+        if (attackRate.Equals(0f) || !component.ResetOnHandSelected || Paused(uid))
             return;
 
         // If someone swaps to this weapon then reset its cd.
@@ -129,16 +119,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     {
         var user = args.SenderSession.AttachedEntity;
 
-        if (user == null)
-            return;
-
-        if (!TryGetWeapon(user.Value, out var weaponUid, out var weapon) ||
-            weaponUid != GetEntity(msg.Weapon))
-        {
-            return;
-        }
-
-        if (!weapon.Attacking)
+        if (user == null
+            || !TryGetWeapon(user.Value, out var weaponUid, out var weapon)
+            || weaponUid != GetEntity(msg.Weapon)
+            || !weapon.Attacking)
             return;
 
         weapon.Attacking = false;
@@ -147,40 +131,32 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     private void OnLightAttack(LightAttackEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not {} user)
+        if (args.SenderSession.AttachedEntity is not { } user
+            || !TryGetWeapon(user, out var weaponUid, out var weapon)
+            || weaponUid != GetEntity(msg.Weapon))
             return;
-
-        if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
-            weaponUid != GetEntity(msg.Weapon))
-        {
-            return;
-        }
 
         AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
     }
 
     private void OnHeavyAttack(HeavyAttackEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not {} user)
+        if (args.SenderSession.AttachedEntity is not { } user
+            || !TryGetWeapon(user, out var weaponUid, out var weapon)
+            || weaponUid != GetEntity(msg.Weapon)
+            || !weapon.CanWideSwing)
             return;
-
-        if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
-            weaponUid != GetEntity(msg.Weapon) ||
-            !weapon.CanWideSwing) // Goobstation Change
-        {
-            return;
-        }
 
         AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
     }
 
     private void OnDisarmAttack(DisarmAttackEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not {} user)
+        if (args.SenderSession.AttachedEntity is not { } user
+            || !TryGetWeapon(user, out var weaponUid, out var weapon))
             return;
 
-        if (TryGetWeapon(user, out var weaponUid, out var weapon))
-            AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
+        AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
     }
 
     /// <summary>
@@ -236,7 +212,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     public bool TryGetWeapon(EntityUid entity, out EntityUid weaponUid, [NotNullWhen(true)] out MeleeWeaponComponent? melee)
     {
         weaponUid = default;
-        melee = null;
 
         var ev = new GetMeleeWeaponEvent();
         RaiseLocalEvent(entity, ev);
@@ -287,10 +262,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return false;
     }
 
-    public void AttemptLightAttackMiss(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityCoordinates coordinates)
-    {
+    public void AttemptLightAttackMiss(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityCoordinates coordinates) =>
         AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(null, GetNetEntity(weaponUid), GetNetCoordinates(coordinates)), null);
-    }
 
     public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)
     {
@@ -787,11 +760,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     {
         var target = GetEntity(ev.Target);
 
-        if (Deleted(target) ||
-            user == target || !CanDoLightAttack(user, target, component, out var targetXform, session))
-        {
+        if (Deleted(target) || user == target || !CanDoLightAttack(user, target, component, out var _, session))
             return false;
-        }
 
         var comboEv = new ComboAttackPerformedEvent(user, target.Value, meleeUid, ComboAttackType.Disarm);
         RaiseLocalEvent(user, comboEv);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -371,30 +371,34 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         for (var i = 0; i < swings; i++)
         {
             string animation;
+            var animationRange = weapon.Range;
 
             switch (attack)
             {
                 case LightAttackEvent light:
                     DoLightAttack(user, light, weaponUid, weapon, session);
                     animation = weapon.Animation;
+                    animationRange *= weapon.LightRangeModifier;
                     break;
                 case DisarmAttackEvent disarm:
                     if (!DoDisarm(user, disarm, weaponUid, weapon, session))
                         return false;
 
                     animation = weapon.Animation;
+                    animationRange *= weapon.DisarmRangeModifier;
                     break;
                 case HeavyAttackEvent heavy:
                     if (!DoHeavyAttack(user, heavy, weaponUid, weapon, session))
                         return false;
 
                     animation = weapon.WideAnimation;
+                    animationRange *= weapon.HeavyRangeModifier;
                     break;
                 default:
                     throw new NotImplementedException();
             }
 
-            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range * weapon.HeavyRangeModifier, animation);
+            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), animationRange, animation);
         }
 
         var attackEv = new MeleeAttackEvent(weaponUid);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -479,11 +479,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         RaiseLocalEvent(target.Value, attackedEvent);
 
         var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
-        var damageResult = Damageable.TryChangeDamage(target, modifiedDamage, origin:user, ignoreResistances: resistanceBypass, partMultiplier: component.ClickPartDamageMultiplier);
+        var damageResult = Damageable.TryChangeDamage(target, modifiedDamage, origin: user, ignoreResistances: resistanceBypass, partMultiplier: component.ClickPartDamageMultiplier);
         var comboEv = new ComboAttackPerformedEvent(user, target.Value, meleeUid, ComboAttackType.Harm);
         RaiseLocalEvent(user, comboEv);
 
-        if (damageResult is {Empty: false})
+        if (damageResult is { Empty: false })
         {
             // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
             if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -421,7 +421,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                     throw new NotImplementedException();
             }
 
-            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range, animation);
+            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range * weapon.HeavyRangeModifier, animation);
         }
 
         var attackEv = new MeleeAttackEvent(weaponUid);
@@ -440,7 +440,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             HasComp<DamageableComponent>(target) &&
             TryComp<TransformComponent>(target, out targetXform) &&
             // Not in LOS.
-            InRange(user, target.Value, component.Range, session);
+            InRange(user, target.Value, component.Range * component.LightRangeModifier, session);
     }
 
     protected virtual void DoLightAttack(EntityUid user, LightAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
@@ -563,7 +563,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var userPos = TransformSystem.GetWorldPosition(userXform);
         var direction = targetMap.Position - userPos;
-        var distance = Math.Min(component.Range, direction.Length());
+        var distance = Math.Min(component.Range * component.HeavyRangeModifier, direction.Length());
 
         var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
         var entities = GetEntityList(ev.Entities);

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -58,7 +58,7 @@
     damage:
       types:
         Blunt: 7.5
-    heavyRangeModifier: 1.5
+    heavyRangeModifier: 1.2
     heavyStaminaCost: 5
     maxTargets: 1
     angle: 25

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -87,7 +87,7 @@
       types:
         Slash: 7
     heavyRateModifier: 2
-    heavyRangeModifier: 1.85
+    heavyRangeModifier: 1.35
     heavyDamageBaseModifier: 2
     heavyStaminaCost: 2.5
     maxTargets: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -14,7 +14,7 @@
         Blunt: 2
     bluntStaminaDamageFactor: 3
     heavyRateModifier: 2.5
-    heavyRangeModifier: 2
+    heavyRangeModifier: 1.3
     heavyDamageBaseModifier: 1.25
     heavyStaminaCost: 5
     maxTargets: 7
@@ -72,7 +72,7 @@
           Blunt: 2
       bluntStaminaDamageFactor: 3
       heavyRateModifier: 2.5
-      heavyRangeModifier: 2
+      heavyRangeModifier: 1.3
       heavyDamageBaseModifier: 1.25
       heavyStaminaCost: 5
       maxTargets: 7

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -67,7 +67,7 @@
       types:
         Piercing: 8
     heavyRateModifier: 1.5
-    heavyRangeModifier: 2
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.5
     heavyStaminaCost: 2.5
     maxTargets: 1
@@ -123,7 +123,7 @@
       types:
         Slash: 7.5
     heavyRateModifier: 1.25
-    heavyRangeModifier: 2
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.25
     heavyStaminaCost: 2.5
     maxTargets: 1
@@ -432,7 +432,7 @@
         Blunt: 4.5
         Slash: 5.5
     heavyRateModifier: 2
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 10
     maxTargets: 8
@@ -479,7 +479,7 @@
         Blunt: 4.5
         Slash: 7.5
     heavyRateModifier: 2
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 10
     maxTargets: 8

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -126,7 +126,7 @@
         Blunt: 8
     bluntStaminaDamageFactor: 2.5
     heavyRateModifier: 2
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.25
     maxTargets: 1
     angle: 20

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -27,7 +27,7 @@
       types:
         Blunt: 9
     bluntStaminaDamageFactor: 2.0
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.5
     heavyRateModifier: 2
     heavyStaminaCost: 2.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -43,7 +43,7 @@
         Piercing: 7
         Slash: 1
     heavyRateModifier: 1.3
-    heavyRangeModifier: 1.25
+    heavyRangeModifier: 1.35
     heavyDamageBaseModifier: 1.0
     heavyStaminaCost: 2.5
     maxTargets: 3
@@ -239,7 +239,7 @@
         Piercing: 10
         Slash: 2
     heavyRateModifier: 1.3
-    heavyRangeModifier: 1.25
+    heavyRangeModifier: 1.35
     heavyDamageBaseModifier: 1.0
     heavyStaminaCost: 2.5
     maxTargets: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -39,7 +39,7 @@
     clickPartDamageMultiplier: 3
     heavyPartDamageMultiplier: 2.5
     heavyRateModifier: 1.25
-    heavyRangeModifier: 1.8
+    lightRangeModifier: 1.25
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 2.5
     maxTargets: 7
@@ -87,7 +87,7 @@
       types:
         Slash: 12
     heavyRateModifier: 4
-    heavyRangeModifier: 2.75 #Superior Japanese folded steel
+    lightRangeModifier: 1.25
     heavyDamageBaseModifier: 2
     heavyStaminaCost: 10
     maxTargets: 1
@@ -193,7 +193,7 @@
         Blunt: 1
     bluntStaminaDamageFactor: 25.0
     heavyRateModifier: 4
-    heavyRangeModifier: 1.85
+    heavyRangeModifier: 1.3
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 10
     maxTargets: 10
@@ -232,7 +232,7 @@
       types:
         Slash: 12
     heavyRateModifier: 1.25
-    heavyRangeModifier: 1.75
+    lightRangeModifier: 1.25
     heavyDamageBaseModifier: 1.2
     heavyStaminaCost: 2.5
     maxTargets: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/white_cane.yml
@@ -19,7 +19,7 @@
         Blunt: 4
     bluntStaminaDamageFactor: 4
     heavyRateModifier: 2
-    heavyRangeModifier: 1.75
+    lightRangeModifier: 1.3
     heavyDamageBaseModifier: 1.2
     heavyStaminaCost: 0
     maxTargets: 1

--- a/Resources/Prototypes/_EE/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/_EE/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -18,7 +18,7 @@
       types:
         Piercing: 8
     heavyRateModifier: 1.25
-    heavyRangeModifier: 1.5
+    heavyRangeModifier: 1.15
     heavyDamageBaseModifier: 1.25
     maxTargets: 1
     angle: 20

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
@@ -16,7 +16,7 @@
         Structural: 20
     clickPartDamageMultiplier: 3
     heavyPartDamageMultiplier: 2.5
-    heavyRangeModifier: 2.75
+    lightRangeModifier: 1.2
     heavyRateModifier: 2.5
     heavyDamageBaseModifier: 1.2
     maxTargets: 1

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_hammer.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_hammer.yml
@@ -16,7 +16,7 @@
         Blunt: 20
         Structural: 50
     heavyStaminaCost: 10
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyRateModifier: 2.5
     heavyDamageBaseModifier: 1.5
     maxTargets: 12

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -16,7 +16,7 @@
       types:
         Slash: 10
     heavyRateModifier: 2
-    heavyRangeModifier: 1.75
+    heavyRangeModifier: 1.2
     heavyDamageBaseModifier: 1.5
     maxTargets: 1
     angle: 10


### PR DESCRIPTION
# Description

My previous code for melee weapon range modifiers was missing, this PR restores and adds actual functionality for weapon range modifiers in all instances of weapon range, as well as adds specific range modifiers for light attack and disarm attack.

# Changelog

:cl:
- fix: Fixed melee weapons "Bonus range for heavy attacks" not functioning correctly. 
- add: Added support for melee weapons having bonus range on disarms or light attacks.
