### PR TITLE
Fix Action Bar

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -453,8 +453,11 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         foreach (var page in _pages)
             for (var i = 0; i < page.Size; i++)
+            {
                 if (page[i] == actionId)
                     page[i] = null;
+                    (_container.GetChild(i) as ActionButton)?.ClearData();
+            }
     }
 
     private void OnActionsUpdated()

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -452,12 +452,16 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             StopTargeting();
 
         foreach (var page in _pages)
+        {
             for (var i = 0; i < page.Size; i++)
             {
                 if (page[i] == actionId)
+                {
                     page[i] = null;
                     (_container.GetChild(i) as ActionButton)?.ClearData();
+                }
             }
+        }
     }
 
     private void OnActionsUpdated()


### PR DESCRIPTION
# Description

This pr fixes the issue where, when picking up an item with an action, the item's action would become duplicated or flicker briefly on the action bar.

---

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/4ef3e05c-8614-44ee-a75f-e34cec6431e1

</p>
</details>

---

# Changelog

:cl: 
- fix: Now the action bar doesn’t turn into a party when it picks up an item with an action.