### PR TITLE
Cyberware Code Support

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -129,6 +129,23 @@ public sealed partial class TraitAddActions : TraitFunction
     }
 }
 
+[UsedImplicitly]
+public sealed partial class TraitRemoveActions : TraitFunction
+{
+    [DataField, AlwaysPushInheritance]
+    public List<EntProtoId> Actions { get; private set; } = new();
+
+    public override void OnPlayerSpawn(EntityUid uid,
+        IComponentFactory factory,
+        IEntityManager entityManager,
+        ISerializationManager serializationManager)
+    {
+        var actionSystem = entityManager.System<SharedActionsSystem>();
+        foreach (var proto in Actions)
+            actionSystem.RemoveAction(uid, proto);
+    }
+}
+
 /// Used for traits that add an Implant upon spawning in.
 [UsedImplicitly]
 public sealed partial class TraitAddImplant : TraitFunction

--- a/Content.Shared/Body/Organ/OrganComponent.cs
+++ b/Content.Shared/Body/Organ/OrganComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Body.Systems;
+using Content.Shared.Traits;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes; // Shitmed Change
 using Content.Shared._Shitmed.Medical.Surgery; // Shitmed Change
@@ -69,4 +70,16 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
     [DataField]
     public bool CanEnable = true;
     // Shitmed Change End
+
+    /// <summary>
+    ///     These functions are called when this organ is added/implanted to an entity.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public TraitFunction[] OnImplantFunctions { get; private set; } = Array.Empty<TraitFunction>();
+
+    /// <summary>
+    ///     These functions are called when this organ is removed from an entity.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public TraitFunction[] OnRemoveFunctions { get; private set; } = Array.Empty<TraitFunction>();
 }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -10,12 +10,17 @@ using Robust.Shared.Containers;
 using Content.Shared.Damage;
 using Content.Shared._Shitmed.BodyEffects;
 using Content.Shared._Shitmed.Body.Organ;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Network;
 
 namespace Content.Shared.Body.Systems;
 
 public partial class SharedBodySystem
 {
     // Shitmed Change Start
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly INetManager _netManager = default!;
 
     private void InitializeOrgans()
     {
@@ -42,15 +47,26 @@ public partial class SharedBodySystem
 
         if (organEnt.Comp.Body is not null)
         {
-        // Shitmed Change Start
+            // Shitmed Change Start
             var addedInBodyEv = new OrganAddedToBodyEvent(bodyUid, parentPartUid);
             RaiseLocalEvent(organEnt, ref addedInBodyEv);
             var organEnabledEv = new OrganEnableChangedEvent(true);
             RaiseLocalEvent(organEnt, ref organEnabledEv);
+            AddFunctions(bodyUid, organEnt.Comp);
         }
         // Shitmed Change End
 
         Dirty(organEnt, organEnt.Comp);
+    }
+
+    private void AddFunctions(EntityUid body, OrganComponent organ)
+    {
+        // TraitFunctions don't currently exist on the client.
+        if (!_netManager.IsServer)
+            return;
+
+        foreach (var function in organ.OnImplantFunctions)
+            function.OnPlayerSpawn(body, _componentFactory, EntityManager, _serializationManager);
     }
 
     private void RemoveOrgan(Entity<OrganComponent> organEnt, EntityUid parentPartUid)
@@ -67,6 +83,7 @@ public partial class SharedBodySystem
             // Shitmed Change End
             var removedInBodyEv = new OrganRemovedFromBodyEvent(bodyUid, parentPartUid);
             RaiseLocalEvent(organEnt, ref removedInBodyEv);
+            RemoveFunctions(parentPartUid, organEnt.Comp);
         }
 
         if (parentPartUid is { Valid: true }
@@ -76,6 +93,16 @@ public partial class SharedBodySystem
 
         organEnt.Comp.Body = null;
         Dirty(organEnt, organEnt.Comp);
+    }
+
+    private void RemoveFunctions(EntityUid body, OrganComponent organ)
+    {
+        // TraitFunctions don't currently exist on the client.
+        if (!_netManager.IsServer)
+            return;
+
+        foreach (var function in organ.OnRemoveFunctions)
+            function.OnPlayerSpawn(body, _componentFactory, EntityManager, _serializationManager);
     }
 
     /// <summary>

--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -83,7 +83,7 @@ public partial class SharedBodySystem
             // Shitmed Change End
             var removedInBodyEv = new OrganRemovedFromBodyEvent(bodyUid, parentPartUid);
             RaiseLocalEvent(organEnt, ref removedInBodyEv);
-            RemoveFunctions(parentPartUid, organEnt.Comp);
+            RemoveFunctions(bodyUid, organEnt.Comp);
         }
 
         if (parentPartUid is { Valid: true }


### PR DESCRIPTION
# Description

Another request by Aisha for Hullrot. This adds the necessary code for supporting completely yml serialized cybernetics, via use of the all powerful TraitFunctions library. A new TraitFunction exists for removing actions from an entity, and in order to make it less terrible to use, I added a new public function to the SharedActionsSystem to allow removing an Action from an entity via Action Prototype rather than EntityUid. 

# Changelog

:cl:
- add: Added support for Organs(such as Cybernetics) to utilize the same massive library of functions used by Traits.