### PR TITLE
Flammable Performance Improvements

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -295,10 +295,11 @@ namespace Content.Server.Atmos.EntitySystems
 
         public void Extinguish(EntityUid uid, FlammableComponent? flammable = null)
         {
-            if (!Resolve(uid, ref flammable))
+            if (!Resolve(uid, ref flammable) || !flammable.CanExtinguish)
                 return;
 
-            if (!flammable.OnFire || !flammable.CanExtinguish)
+            RemCompDeferred<OnFireComponent>(uid);
+            if (!flammable.OnFire)
                 return;
 
             _adminLogger.Add(LogType.Flammable, $"{ToPrettyString(uid):entity} stopped being on fire damage");
@@ -317,6 +318,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!Resolve(uid, ref flammable, false)) // Lavaland Change: SHUT THE FUCK UP FLAMMABLE
                 return;
 
+            EnsureComp<OnFireComponent>(uid);
             if (flammable.AlwaysCombustible)
             {
                 flammable.FireStacks = Math.Max(flammable.FirestacksOnIgnite, flammable.FireStacks);
@@ -410,9 +412,15 @@ namespace Content.Server.Atmos.EntitySystems
             _timer -= UpdateTime;
 
             // TODO: This needs cleanup to take off the crust from TemperatureComponent and shit.
-            var query = EntityQueryEnumerator<FlammableComponent, TransformComponent>();
-            while (query.MoveNext(out var uid, out var flammable, out _))
+            var query = EntityQueryEnumerator<OnFireComponent>();
+            while (query.MoveNext(out var uid, out _))
             {
+                if (!TryComp(uid, out FlammableComponent? flammable))
+                {
+                    RemCompDeferred<OnFireComponent>(uid);
+                    continue;
+                }
+
                 // Slowly dry ourselves off if wet.
                 if (flammable.FireStacks < 0)
                 {
@@ -423,6 +431,7 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     _alertsSystem.ClearAlert(uid, flammable.FireAlert);
                     RaiseLocalEvent(uid, new MoodRemoveEffectEvent("OnFire"));
+                    RemCompDeferred<OnFireComponent>(uid);
                     continue;
                 }
 

--- a/Content.Shared/Atmos/Components/OnFireComponent.cs
+++ b/Content.Shared/Atmos/Components/OnFireComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Atmos.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class OnFireComponent : Component { }


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/8d33ca00-9ad7-4c51-8cbd-5ea09a3067a8)

I'm yeeting the server costs for the flammable system. This system will no longer querry every entity that might be on fire to check if they're on fire, and is instead querrying only entities that have a new OnFireComponent, which is used to tell them that they're on fire. 99% cost reductions are fun.

I have verified in testing that this works. 

# Changelog

:cl:
- fix: Dramatically improved performance of the flammable system.
