### PR TITLE
Holopad System Performance Tweaks

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -470,22 +470,21 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
         _updateTimer += frameTime;
 
-        if (_updateTimer >= UpdateTime)
+        if (_updateTimer < UpdateTime)
+            return;
+
+        _updateTimer = 0f;
+
+        var query = AllEntityQuery<HolopadComponent, TelephoneComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var holopad, out var telephone, out var xform))
         {
-            _updateTimer -= UpdateTime;
+            UpdateUIState((uid, holopad), telephone);
 
-            var query = AllEntityQuery<HolopadComponent, TelephoneComponent, TransformComponent>();
-            while (query.MoveNext(out var uid, out var holopad, out var telephone, out var xform))
-            {
-                UpdateUIState((uid, holopad), telephone);
+            if (holopad.User == null || !HasComp<IgnoreUIRangeComponent>(holopad.User)
+                || _xformSystem.InRange((holopad.User.Value, Transform(holopad.User.Value)), (uid, xform), telephone.ListeningRange))
+                continue;
 
-                if (holopad.User != null &&
-                    !HasComp<IgnoreUIRangeComponent>(holopad.User) &&
-                    !_xformSystem.InRange((holopad.User.Value, Transform(holopad.User.Value)), (uid, xform), telephone.ListeningRange))
-                {
-                    UnlinkHolopadFromUser((uid, holopad), holopad.User.Value);
-                }
-            }
+            UnlinkHolopadFromUser((uid, holopad), holopad.User.Value);
         }
 
         _recentlyUpdatedHolograms.Clear();

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -480,11 +480,12 @@ public sealed class HolopadSystem : SharedHolopadSystem
         {
             UpdateUIState((uid, holopad), telephone);
 
-            if (holopad.User == null || !HasComp<IgnoreUIRangeComponent>(holopad.User)
-                || _xformSystem.InRange((holopad.User.Value, Transform(holopad.User.Value)), (uid, xform), telephone.ListeningRange))
-                continue;
-
-            UnlinkHolopadFromUser((uid, holopad), holopad.User.Value);
+            if (holopad.User != null &&
+                !HasComp<IgnoreUIRangeComponent>(holopad.User) &&
+                !_xformSystem.InRange((holopad.User.Value, Transform(holopad.User.Value)), (uid, xform), telephone.ListeningRange))
+            {
+                UnlinkHolopadFromUser((uid, holopad), holopad.User.Value);
+            }
         }
 
         _recentlyUpdatedHolograms.Clear();


### PR DESCRIPTION
# Description

Holopad System had a vestigial set of logic for preventing it from running an expensive AABB check on every frame. I say vestigial because it was actually nonfunctional, and would run on every frame after a single second had passed since roundstart. This PR fixes the logic so that it correctly only checks once per second. Ideally I'd revisit this later and make it only run on ActiveHolopads in the first place, but this was simple enough of a fix.

# Changelog

:cl:
- fix: Made some performance improvements to the Holopad system.