### PR TITLE
More Drain System Perf Tweaks

### DIFF
--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -23,9 +23,6 @@ public sealed partial class DrainComponent : Component
     [ViewVariables]
     public Entity<SolutionComponent>? Solution = null;
 
-    [DataField("accumulator")]
-    public float Accumulator = 0f;
-
     /// <summary>
     /// Does this drain automatically absorb surrouding puddles? Or is it a drain designed to empty
     /// solutions in it manually?
@@ -53,13 +50,6 @@ public sealed partial class DrainComponent : Component
     /// </summary>
     [DataField("range"), ViewVariables(VVAccess.ReadWrite)]
     public float Range = 2f;
-
-    /// <summary>
-    /// How often in seconds the drain checks for puddles around it.
-    /// If the EntityQuery seems a bit unperformant this can be increased.
-    /// </summary>
-    [DataField("drainFrequency")]
-    public float DrainFrequency = 1f;
 
     /// <summary>
     /// How much time it takes to unclog it with a plunger


### PR DESCRIPTION
# Description

Actually the bulk of this system's cost was in having these expensive entity querries running on every frame, so instead of interrupting the drain logic on a per drain basis, we interrupt the entire system of querries itself globally, and cut off the main expense of the system at its root source.

# Changelog

:cl:
- tweak: Made some significant performance improvements to Drains. 
