### PR TITLE
Gas Tile Overlay Performance Tweaks

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         ///     Overlay update interval, in seconds.
         /// </summary>
-        private float _updateInterval;
+        private float _updateInterval = 1f;
 
         private int _thresholds;
         private EntityQuery<GasTileOverlayComponent> _query;
@@ -293,18 +293,18 @@ namespace Content.Server.Atmos.EntitySystems
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
+
+            // Prevent this system from running the expensive checks on every frame.
             AccumulatedFrameTime += frameTime;
+            if (AccumulatedFrameTime < _updateInterval)
+                return;
+            AccumulatedFrameTime = 0f;
 
             if (_doSessionUpdate)
             {
                 UpdateSessions();
                 return;
             }
-
-            if (AccumulatedFrameTime < _updateInterval)
-                return;
-
-            AccumulatedFrameTime -= _updateInterval;
 
             // First, update per-chunk visual data for any invalidated tiles.
             UpdateOverlayData();


### PR DESCRIPTION
# Description

Gas Tile Overlay had a non-functional check for preventing it from running on every frame. This PR fixes the frametime stopper, such that it actually prevents the system from constantly running at all times.

# Changelog

:cl:
- tweak: Made some performance improvements to the Gas Tile Overlay.
