### PR TITLE
Nerf TCAF Heavy Armor

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/outerwear.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/outerwear.yml
@@ -31,10 +31,10 @@
     - type: Armor
       modifiers:
         coefficients:
-          Blunt: 0.35
-          Slash: 0.35
-          Piercing: 0.35
-          Heat: 0.35
+          Blunt: 0.5
+          Slash: 0.5
+          Piercing: 0.5
+          Heat: 0.5
           Caustic: 0.5
     - type: ExplosionResistance
       damageCoefficient: 0.35


### PR DESCRIPTION
# Description

This was supposed to be equivalent to heavy security vests, and essentially be a reskin of the heavy armor. I guess I never pushed the nerf somehow.

# Changelog

:cl:
- tweak: Nerfed the TCAF Heavy Armor to be equivalent to Heavy Security Armor.
