### PR TITLE
Pretty Big Atmos Fixes PR

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -281,6 +281,14 @@ namespace Content.Server.Atmos.EntitySystems
             return true;
         }
 
+        public GasCompareResult CompareExchange(TileAtmosphere sample, TileAtmosphere otherSample)
+        {
+            if (sample.AirArchived == null || otherSample.AirArchived == null)
+                return GasCompareResult.NoExchange;
+
+            return CompareExchange(sample.AirArchived, otherSample.AirArchived);
+        }
+
         /// <summary>
         ///     Compares two gas mixtures to see if they are within acceptable ranges for group processing to be enabled.
         /// </summary>
@@ -288,12 +296,12 @@ namespace Content.Server.Atmos.EntitySystems
         {
             var moles = 0f;
 
-            for(var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
             {
                 var gasMoles = sample.Moles[i];
                 var delta = MathF.Abs(gasMoles - otherSample.Moles[i]);
                 if (delta > Atmospherics.MinimumMolesDeltaToMove && (delta > gasMoles * Atmospherics.MinimumAirRatioToMove))
-                    return (GasCompareResult)i; // We can move gases!
+                    return (GasCompareResult) i; // We can move gases!
                 moles += gasMoles;
             }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -268,7 +268,7 @@ public sealed partial class AtmosphereSystem
     {
         DebugTools.AssertNotNull(tile.Air);
         DebugTools.Assert(tile.Air?.Immutable == false );
-        Array.Clear(tile.MolesArchived);
+        tile.AirArchived = null;
         tile.ArchivedCycle = 0;
 
         var count = 0;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -55,10 +55,10 @@ public sealed partial class AtmosphereSystem
         // No atmos yeets, return early.
         if (!SpaceWind
             || !gridAtmosphere.Comp.SpaceWindSimulation // Is the grid marked as exempt from space wind?
-            || tile.Air is null || tile.Space // No Air Checks. Pressure differentials can't exist in a hard vacuum.
-            || tile.Air.Pressure <= atmosComp.PressureCutoff // Below 5kpa(can't throw a base item)
-            || oneAtmos - atmosComp.PressureCutoff <= tile.Air.Pressure
-            && tile.Air.Pressure <= oneAtmos + atmosComp.PressureCutoff // Check within 5kpa of default pressure.
+            || tile.AirArchived is null || tile.Space // No Air Checks. Pressure differentials can't exist in a hard vacuum.
+            || tile.AirArchived.Pressure <= atmosComp.PressureCutoff // Below 5kpa(can't throw a base item)
+            || oneAtmos - atmosComp.PressureCutoff <= tile.AirArchived.Pressure
+            && tile.AirArchived.Pressure <= oneAtmos + atmosComp.PressureCutoff // Check within 5kpa of default pressure.
             || !TryComp(gridAtmosphere.Owner, out MapGridComponent? mapGrid)
             || !_mapSystem.TryGetTileRef(gridAtmosphere.Owner, mapGrid, tile.GridIndices, out var tileRef))
             return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -114,15 +114,15 @@ public sealed partial class AtmosphereSystem
             // Ideally containers would have their own EntityQuery internally or something given recursively it may need to slam GetComp<T> anyway.
             // Also, don't care about static bodies (but also due to collisionwakestate can't query dynamic directly atm).
             if (!bodies.TryGetComponent(entity, out var body)
-                || !pressureQuery.TryGetComponent(entity, out var pressure)
-                || !pressure.Enabled
+                || !pressureQuery.TryGetComponent(entity, out var pressureComp)
+                || !pressureComp.Enabled
                 || _containers.IsEntityInContainer(entity, metas.GetComponent(entity))
-                || pressure.LastHighPressureMovementAirCycle >= gridAtmosphere.Comp.UpdateCounter)
+                || pressureComp.LastHighPressureMovementAirCycle >= gridAtmosphere.Comp.UpdateCounter)
                 continue;
 
             // tl;dr YEET
             ExperiencePressureDifference(
-                (entity, pressure),
+                (entity, pressureComp),
                 gridAtmosphere.Comp.UpdateCounter,
                 pressureVector,
                 pVecLength,

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -54,11 +54,15 @@ public sealed partial class AtmosphereSystem
 
         // No atmos yeets, return early.
         if (!SpaceWind
-            || !gridAtmosphere.Comp.SpaceWindSimulation // Is the grid marked as exempt from space wind?
-            || tile.AirArchived is null || tile.Space // No Air Checks. Pressure differentials can't exist in a hard vacuum.
-            || tile.AirArchived.Pressure <= atmosComp.PressureCutoff // Below 5kpa(can't throw a base item)
-            || oneAtmos - atmosComp.PressureCutoff <= tile.AirArchived.Pressure
-            && tile.AirArchived.Pressure <= oneAtmos + atmosComp.PressureCutoff // Check within 5kpa of default pressure.
+            || !gridAtmosphere.Comp.SpaceWindSimulation // Is the grid marked as exempt from space wind?)
+            || tile.Space) // No Air Checks. Pressure differentials can't exist in a hard vacuum.
+            return;
+
+        var pressure = tile.AirArchived?.Pressure;
+        if (pressure is null
+            || pressure <= atmosComp.PressureCutoff // Below 5kpa(can't throw a base item)
+            || oneAtmos - atmosComp.PressureCutoff <= pressure
+            && pressure <= oneAtmos + atmosComp.PressureCutoff // Check within 5kpa of default pressure.
             || !TryComp(gridAtmosphere.Owner, out MapGridComponent? mapGrid)
             || !_mapSystem.TryGetTileRef(gridAtmosphere.Owner, mapGrid, tile.GridIndices, out var tileRef))
             return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Atmos.EntitySystems
                     }
 
                     shouldShareAir = true;
-                } else if (CompareExchange(tile.Air, enemyTile.Air) != GasCompareResult.NoExchange)
+                } else if (CompareExchange(tile, enemyTile) != GasCompareResult.NoExchange)
                 {
                     AddActiveTile(gridAtmosphere, enemyTile);
                     if (ExcitedGroups)
@@ -108,9 +108,7 @@ namespace Content.Server.Atmos.EntitySystems
         private void Archive(TileAtmosphere tile, int fireCount)
         {
             if (tile.Air != null)
-                tile.Air.Moles.AsSpan().CopyTo(tile.MolesArchived.AsSpan());
-
-            tile.TemperatureArchived = tile.Temperature;
+                tile.AirArchived = new GasMixture(tile.Air);
             tile.ArchivedCycle = fireCount;
         }
 
@@ -175,10 +173,10 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float GetHeatCapacityArchived(TileAtmosphere tile)
         {
-            if (tile.Air == null)
+            if (tile.AirArchived == null)
                 return tile.HeatCapacity;
 
-            return GetHeatCapacityCalculation(tile.MolesArchived!, tile.Space);
+            return GetHeatCapacity(tile.AirArchived);
         }
 
         /// <summary>
@@ -186,10 +184,10 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float Share(TileAtmosphere tileReceiver, TileAtmosphere tileSharer, int atmosAdjacentTurfs)
         {
-            if (tileReceiver.Air is not {} receiver || tileSharer.Air is not {} sharer)
+            if (tileReceiver.Air is not {} receiver || tileSharer.Air is not {} sharer ||  tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
                 return 0f;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - tileSharer.TemperatureArchived;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - tileSharer.AirArchived.Temperature;
             var absTemperatureDelta = Math.Abs(temperatureDelta);
             var oldHeatCapacity = 0f;
             var oldSharerHeatCapacity = 0f;
@@ -240,12 +238,12 @@ namespace Content.Server.Atmos.EntitySystems
                 // Transfer of thermal energy (via changed heat capacity) between self and sharer.
                 if (!receiver.Immutable && newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    receiver.Temperature = ((oldHeatCapacity * receiver.Temperature) - (heatCapacityToSharer * tileReceiver.TemperatureArchived) + (heatCapacitySharerToThis * tileSharer.TemperatureArchived)) / newHeatCapacity;
+                    receiver.Temperature = ((oldHeatCapacity * receiver.Temperature) - (heatCapacityToSharer * tileReceiver.AirArchived.Temperature) + (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature)) / newHeatCapacity;
                 }
 
                 if (!sharer.Immutable && newSharerHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    sharer.Temperature = ((oldSharerHeatCapacity * sharer.Temperature) - (heatCapacitySharerToThis * tileSharer.TemperatureArchived) + (heatCapacityToSharer * tileReceiver.TemperatureArchived)) / newSharerHeatCapacity;
+                    sharer.Temperature = ((oldSharerHeatCapacity * sharer.Temperature) - (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature) + (heatCapacityToSharer * tileReceiver.AirArchived.Temperature)) / newSharerHeatCapacity;
                 }
 
                 // Thermal energy of the system (self and sharer) is unchanged.
@@ -264,7 +262,7 @@ namespace Content.Server.Atmos.EntitySystems
             var moles = receiver.TotalMoles;
             var theirMoles = sharer.TotalMoles;
 
-            return (tileReceiver.TemperatureArchived * (moles + movedMoles)) - (tileSharer.TemperatureArchived * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
+            return (tileReceiver.AirArchived.Temperature * (moles + movedMoles)) - (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
         }
 
         /// <summary>
@@ -272,10 +270,11 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float TemperatureShare(TileAtmosphere tileReceiver, TileAtmosphere tileSharer, float conductionCoefficient)
         {
-            if (tileReceiver.Air is not { } receiver || tileSharer.Air is not { } sharer)
+            if (tileReceiver.Air is not { } receiver || tileSharer.Air is not { } sharer ||
+                tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
                 return 0f;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - tileSharer.TemperatureArchived;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - tileSharer.AirArchived.Temperature;
             if (MathF.Abs(temperatureDelta) > Atmospherics.MinimumTemperatureDeltaToConsider)
             {
                 var heatCapacity = GetHeatCapacityArchived(tileReceiver);
@@ -301,10 +300,10 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float TemperatureShare(TileAtmosphere tileReceiver, float conductionCoefficient, float sharerTemperature, float sharerHeatCapacity)
         {
-            if (tileReceiver.Air is not {} receiver)
+            if (tileReceiver.Air is not {} receiver || tileReceiver.AirArchived == null)
                 return 0;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - sharerTemperature;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - sharerTemperature;
             if (MathF.Abs(temperatureDelta) > Atmospherics.MinimumTemperatureDeltaToConsider)
             {
                 var heatCapacity = GetHeatCapacityArchived(tileReceiver);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.MAS.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.MAS.cs
@@ -35,7 +35,7 @@ public sealed partial class AtmosphereSystem
         if (!HasComp<MapGridComponent>(tile.GridIndex))
             return new Vector2(0, 0);
 
-        var centerPressure = tile.Air?.Pressure ?? 0f;
+        var centerPressure = tile.AirArchived?.Pressure ?? 0f;
         var pressureVector = new Vector2(0, 0);
         foreach (var (x, y, dir) in MASSearchPattern)
         {
@@ -64,18 +64,18 @@ public sealed partial class AtmosphereSystem
             // opposite direction.
             if (tileAtmosphere.AirtightData.BlockedDirections is AtmosDirection.All
                 || tileAtmosphere.AirtightData.BlockedDirections.HasFlag(dir)
-                || tileAtmosphere.Air is null)
+                || tileAtmosphere.AirArchived is null)
             {
                 pressureVector -= offsetVector * centerPressure;
                 continue;
             }
 
             // Center tile now transfers its pressure across the target.
-            var pressureDiff = centerPressure - tileAtmosphere.Air.Pressure;
+            var pressureDiff = centerPressure - tileAtmosphere.AirArchived.Pressure;
             pressureVector += offsetVector * pressureDiff;
 
             // And finally, the pressure in the target tile is resisting the original target pressure.
-            pressureVector -= offsetVector * tileAtmosphere.Air.Pressure;
+            pressureVector -= offsetVector * tileAtmosphere.AirArchived.Pressure;
         }
         // from TCJ: By this point in the equation, all possible conditions are now checked, and for any airtight vessel with a standard atmosphere, the final output will be <0, 0>.
         // Should any holes exist in the ship, the air will now flow at an exponential rate towards it, while deflecting around walls.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.MAS.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.MAS.cs
@@ -39,15 +39,26 @@ public sealed partial class AtmosphereSystem
         var pressureVector = new Vector2(0, 0);
         foreach (var (x, y, dir) in MASSearchPattern)
         {
+            // Create a new "Integer Vector2" using the search pattern, which will first be used to search the matrix of air tiles via its index.
+            // It'll be normalized immediately after that check is performed.
             var offsetVector = new Vector2(x, y);
+
             // If the tile checked doesn't exist, or has no air, or it's space,
             // then there's nothing to "push back" against our center tile's air.
             if (!gridAtmos.Tiles.TryGetValue(tile.GridIndices + (x, y), out var tileAtmosphere)
                 || tileAtmosphere.Space)
             {
+                // Since vectors with values of <+-1, +-1> actually have a length of Sqrt(2) instead of 1, we need to normalize them.
+                // We'll normalize all of them uniformly, even the ones that already have a length of 1, because we can't guarantee
+                // that our search pattern will always have normalized vectors.
+                // It's roughly the same computation time both ways since these are all integers. Thank you identity property shenanigans.
+                offsetVector.Normalize();
+
                 pressureVector += offsetVector * centerPressure;
                 continue;
             }
+            // See above, both sides of the condition have to have the Normalize.
+            offsetVector.Normalize();
 
             // If the tile checked is blocking airflow from this direction, the center tile's air "Bounces" off it and into the
             // opposite direction.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -358,7 +358,7 @@ namespace Content.Server.Atmos.EntitySystems
                         continue;
 
                     DebugTools.Assert(otherTile2.AdjacentBits.IsFlagSet(direction.GetOpposite()));
-                    if (otherTile2.Air != null && CompareExchange(otherTile2.Air, tile.Air) == GasCompareResult.NoExchange)
+                    if (otherTile2.Air != null && CompareExchange(otherTile2, tile) == GasCompareResult.NoExchange)
                         continue;
 
                     AddActiveTile(gridAtmosphere, otherTile2);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -233,7 +233,7 @@ namespace Content.Server.Atmos.EntitySystems
             tile.MapAtmosphere = false;
             atmos.MapTiles.Remove(tile);
             tile.Air = null;
-            Array.Clear(tile.MolesArchived);
+            tile.AirArchived = null;
             tile.ArchivedCycle = 0;
             tile.LastShare = 0f;
             tile.Space = false;
@@ -263,7 +263,7 @@ namespace Content.Server.Atmos.EntitySystems
                     return;
 
                 tile.Air = null;
-                Array.Clear(tile.MolesArchived);
+                tile.AirArchived = null;
                 tile.ArchivedCycle = 0;
                 tile.LastShare = 0f;
                 tile.Hotspot = new Hotspot();
@@ -659,16 +659,6 @@ namespace Content.Server.Atmos.EntitySystems
                         }
 
                         atmosphere.ProcessingPaused = false;
-                        atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
-                        continue;
-                    case AtmosphereProcessingState.HighPressureDelta:
-                        if (!ProcessHighPressureDelta((ent, ent)))
-                        {
-                            atmosphere.ProcessingPaused = true;
-                            return;
-                        }
-
-                        atmosphere.ProcessingPaused = false;
                         atmosphere.State = AtmosphereProcessingState.Hotspots;
                         continue;
                     case AtmosphereProcessingState.Hotspots:
@@ -684,10 +674,20 @@ namespace Content.Server.Atmos.EntitySystems
                         //       Therefore, a change to this CVar might only be applied after that step is over.
                         atmosphere.State = Superconduction
                             ? AtmosphereProcessingState.Superconductivity
-                            : AtmosphereProcessingState.PipeNet;
+                            : AtmosphereProcessingState.HighPressureDelta;
                         continue;
                     case AtmosphereProcessingState.Superconductivity:
                         if (!ProcessSuperconductivity(atmosphere))
+                        {
+                            atmosphere.ProcessingPaused = true;
+                            return;
+                        }
+
+                        atmosphere.ProcessingPaused = false;
+                        atmosphere.State = AtmosphereProcessingState.HighPressureDelta;
+                        continue;
+                    case AtmosphereProcessingState.HighPressureDelta:
+                        if (!ProcessHighPressureDelta((ent, ent)))
                         {
                             atmosphere.ProcessingPaused = true;
                             return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
@@ -131,7 +131,11 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void TemperatureShareMutualSolid(TileAtmosphere tile, TileAtmosphere other, float conductionCoefficient)
         {
-            var deltaTemperature = (tile.TemperatureArchived - other.TemperatureArchived);
+            if (tile.AirArchived == null || other.AirArchived == null)
+                return;
+
+            var deltaTemperature = (tile.AirArchived.Temperature - other.AirArchived.Temperature);
+
             if (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider
                 && tile.HeatCapacity != 0f && other.HeatCapacity != 0f)
             {
@@ -145,11 +149,14 @@ namespace Content.Server.Atmos.EntitySystems
 
         public void RadiateToSpace(TileAtmosphere tile)
         {
+            if (tile.AirArchived == null)
+                return;
+
             // Considering 0ºC as the break even point for radiation in and out.
             if (tile.Temperature > Atmospherics.T0C)
             {
                 // Hardcoded space temperature.
-                var deltaTemperature = (tile.TemperatureArchived - Atmospherics.TCMB);
+                var deltaTemperature = (tile.AirArchived.Temperature - Atmospherics.TCMB);
                 if ((tile.HeatCapacity > 0) && (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider))
                 {
                     var heat = tile.ThermalConductivity * deltaTemperature * (tile.HeatCapacity *

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -81,11 +81,11 @@ public sealed class TileAtmosphere : IGasMixtureHolder
     [Access(typeof(AtmosphereSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
     public GasMixture? Air { get; set; }
 
+    [ViewVariables]
+    public GasMixture? AirArchived { get; set; }
+
     [DataField("lastShare")]
     public float LastShare;
-
-    [ViewVariables]
-    public readonly float[] MolesArchived = new float[Atmospherics.AdjustedNumberOfGases];
 
     GasMixture IGasMixtureHolder.Air
     {
@@ -127,6 +127,7 @@ public sealed class TileAtmosphere : IGasMixtureHolder
         GridIndex = gridIndex;
         GridIndices = gridIndices;
         Air = mixture;
+        AirArchived = Air?.Clone();
         Space = space;
 
         if(immutable)
@@ -143,6 +144,6 @@ public sealed class TileAtmosphere : IGasMixtureHolder
         NoGridTile = other.NoGridTile;
         MapAtmosphere = other.MapAtmosphere;
         Air = other.Air?.Clone();
-        Array.Copy(other.MolesArchived, MolesArchived, MolesArchived.Length);
+        AirArchived = Air?.Clone();
     }
 }

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -160,8 +160,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     {
         if (!(args.Target is { }) || _standing.IsDown(args.Target)
             || !TryComp(uid, out ProjectileComponent? projectile)
-            || !TryEmbed(uid, args.Target, args.Shooter, component)
-            || projectile.Weapon is null)
+            || projectile.Weapon is null
+            || !TryEmbed(uid, args.Target, args.Shooter, component))
             return;
 
         // Raise a specific event for projectiles.

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -160,7 +160,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     {
         if (!(args.Target is { }) || _standing.IsDown(args.Target)
             || !TryComp(uid, out ProjectileComponent? projectile)
-            || !TryEmbed(uid, args.Target, args.Shooter, component))
+            || !TryEmbed(uid, args.Target, args.Shooter, component)
+            || projectile.Weapon is null)
             return;
 
         // Raise a specific event for projectiles.


### PR DESCRIPTION
# Description

This PR ports some fixes to the order of operations for air pressure processing, which will help fix issues with temperature not correctly diffusing, as well as errors in the order of operations processing that made it so that Space Wind was receiving wildly incorrect pressure values. 

Additionally, this fixes a math error that made it so that the diagonal airflows were contributing 41% more to airflows, making diagonal motion unusually harsh. There's still two more bugs I need to fix though. 
