### PR TITLE
Add more tools for the Aghost

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -246,6 +246,12 @@
   components:
   - type: StorageFill
     contents:
+    - id: WelderExperimental
+    - id: PowerDrill
+    - id: Multitool
     - id: GasAnalyzer
-    - id: trayScanner
+    - id: AccessConfigurator
+    - id: GeigerCounter
+    - id: JawsOfLife
+    - id: HandheldHealthAnalyzer
   - type: Unremoveable


### PR DESCRIPTION

# Description

Howdy y'all, I'm adding tools to the Aghost Bag. Here's a list:

 **WelderExperimental**
 **PowerDri**ll
 **Multitool**
 **AccessConfigurator**
 **GeigerCounter**
 **JawsOfLife**
 **HandheldHealthAnalyzer**

I know you can spawn them, but I prefer to have them ready.
<details><summary><h1>Media</h1></summary>
<p>

![Screenshot 2025-06-22 053832](https://github.com/user-attachments/assets/e1635846-f63c-4c93-a1c2-139150898d83)

</p>
</details>

# Changelog


:cl: Mike32oz
- tweak: Aghost Inventory bag 

