### PR TITLE
Profile Loading Extensions

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -120,7 +120,11 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
     ///     This should not be used if the entity is owned by the server. The server will otherwise
     ///     override this with the appearance data it sends over.
     /// </remarks>
-    public override void LoadProfile(EntityUid uid, HumanoidCharacterProfile? profile, HumanoidAppearanceComponent? humanoid = null)
+    public override void LoadProfile(EntityUid uid,
+        HumanoidCharacterProfile? profile,
+        HumanoidAppearanceComponent? humanoid = null,
+        bool loadExtensions = true,
+        bool generateLoadouts = true)
     {
         if (profile == null)
             return;

--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -316,7 +316,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
                 _prototypeManager.Index<SpeciesPrototype>(DefaultSpecies).DollPrototype,
                 MapCoordinates.Nullspace);
 
-        _humanoid.LoadProfile(dummyEnt, humanoid);
+        _humanoid.LoadProfile(dummyEnt, humanoid, loadExtensions: false, generateLoadouts: false);
 
         if (humanoid != null)
         {

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -921,7 +921,7 @@ namespace Content.Client.Lobby.UI
             {
                 var hiddenLayers = humanoid.HiddenLayers;
                 var appearanceSystem = _entManager.System<HumanoidAppearanceSystem>();
-                appearanceSystem.LoadProfile(PreviewDummy, Profile, humanoid);
+                appearanceSystem.LoadProfile(PreviewDummy, Profile, humanoid, false, false);
                 // Reapply the hidden layers set from clothing
                 appearanceSystem.SetLayersVisibility(PreviewDummy, hiddenLayers, false, humanoid: humanoid);
             }

--- a/Content.Server/Cloning/CloningSystem.Utility.cs
+++ b/Content.Server/Cloning/CloningSystem.Utility.cs
@@ -326,10 +326,10 @@ public sealed partial class CloningSystem
             if (_config.GetCVar(CCVars.CloningPreserveFlavorText))
                 pref = pref.WithFlavorText(flavorText);
 
-            _humanoidSystem.LoadProfile(mob, pref);
+            _humanoidSystem.LoadProfile(mob, pref, loadExtensions: true, generateLoadouts: false);
             return;
         }
-        _humanoidSystem.LoadProfile(mob, pref);
+        _humanoidSystem.LoadProfile(mob, pref, loadExtensions: true, generateLoadouts: false);
     }
 
     /// <summary>

--- a/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -133,7 +133,11 @@ public sealed class ParadoxAnomalySystem : EntitySystem
         //////////////////////////
 
         // Copy the details.
-        _humanoid.LoadProfile(spawned, profile);
+        _humanoid.LoadProfile(
+            spawned,
+            profile,
+            loadExtensions: true, //Yes it's absolutely intended that they should straight up be EXACTLY the same character
+            generateLoadouts: true); //That means loadouts too. Have fun with there potentially being a 2nd HoS Gun for traitors to want to steal.
         _metaData.SetEntityName(spawned, Name(uid));
 
         if (TryComp<DetailExaminableComponent>(uid, out var detail))

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -47,6 +47,9 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
             species = _proto.Index(ent.Comp.SpeciesHardOverride.Value); // Shitmed - Starlight Abductors
 
         args.Entity = Spawn(species.Prototype);
-        _humanoid.LoadProfile(args.Entity.Value, profile?.WithSpecies(species.ID));
+        _humanoid.LoadProfile(args.Entity.Value,
+            profile?.WithSpecies(species.ID),
+            loadExtensions: ent.Comp.AllowProfileExtensions,
+            generateLoadouts: ent.Comp.AllowAntagLoadouts);
     }
 }

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -33,4 +33,16 @@ public sealed partial class AntagLoadProfileRuleComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<SpeciesPrototype>? SpeciesHardOverride;
+
+    /// <summary>
+    ///     Whether this antag will also attempt to generate Traits, Nationality, Employer, and Lifepath. Basically all the "Traits"
+    /// </summary>
+    [DataField]
+    public bool AllowProfileExtensions = true;
+
+    /// <summary>
+    ///     Whether this antag will also generate Loadouts. Fun fact: Look up CharacterAntagonistRequirement
+    /// </summary>
+    [DataField]
+    public bool AllowAntagLoadouts = true;
 }

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -207,7 +207,7 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
         if (TryComp<HumanoidAppearanceComponent>(ent, out var humanoid))
         {
             var newProfile = HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species);
-            _humanoidAppearance.LoadProfile(ent, newProfile, humanoid);
+            _humanoidAppearance.LoadProfile(ent, newProfile, humanoid, false, false);
             _metaData.SetEntityName(ent, newProfile.Name);
             if (TryComp<DnaComponent>(ent, out var dna))
             {

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -154,7 +154,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
         if (profile != null)
         {
-            _humanoidSystem.LoadProfile(entity.Value, profile);
+            _humanoidSystem.LoadProfile(entity.Value, profile, loadExtensions: false, generateLoadouts: false);
             _metaSystem.SetEntityName(entity.Value, profile.Name);
             if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
                 EnsureComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -20,6 +20,7 @@ using Timer = Robust.Shared.Timing.Timer;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.Humanoid;
 
 namespace Content.Server.Traits;
 
@@ -42,10 +43,15 @@ public sealed class TraitSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<LoadProfileExtensionsEvent>(OnProfileLoad);
     }
 
     // When the player is spawned in, add all trait components selected during character creation
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args) =>
+        ApplyTraits(args.Mob, args.JobId, args.Profile,
+            _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
+
+    private void OnProfileLoad(LoadProfileExtensionsEvent args) =>
         ApplyTraits(args.Mob, args.JobId, args.Profile,
             _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
 

--- a/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/LifepathSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.CCVar;
@@ -8,7 +7,6 @@ using Content.Shared.Humanoid;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
-using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -30,10 +28,15 @@ public sealed class LifepathSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<LoadProfileExtensionsEvent>(OnProfileLoad);
     }
 
     // When the player is spawned in, add the Lifepath components selected during character creation
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args) =>
+        ApplyLifepath(args.Mob, args.JobId, args.Profile,
+            _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
+
+    private void OnProfileLoad(LoadProfileExtensionsEvent args) =>
         ApplyLifepath(args.Mob, args.JobId, args.Profile,
             _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
 
@@ -48,9 +51,9 @@ public sealed class LifepathSystem : EntitySystem
 
         var jobPrototypeToUse = _prototype.Index(jobId.Value);
 
-        ProtoId<LifepathPrototype> lifepath = profile.Lifepath != string.Empty? profile.Lifepath : SharedHumanoidAppearanceSystem.DefaultLifepath;
+        ProtoId<LifepathPrototype> lifepath = profile.Lifepath != string.Empty ? profile.Lifepath : SharedHumanoidAppearanceSystem.DefaultLifepath;
 
-        if(!_prototype.TryIndex<LifepathPrototype>(lifepath, out var lifepathPrototype))
+        if (!_prototype.TryIndex(lifepath, out var lifepathPrototype))
         {
             DebugTools.Assert($"Lifepath '{lifepath}' not found!");
             return;

--- a/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
+++ b/Content.Server/_EE/Contractors/Systems/NationalitySystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.CCVar;
@@ -8,7 +7,6 @@ using Content.Shared.Humanoid;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
-using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
@@ -30,10 +28,15 @@ public sealed class NationalitySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<LoadProfileExtensionsEvent>(OnProfileLoad);
     }
 
     // When the player is spawned in, add the nationality components selected during character creation
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args) =>
+        ApplyNationality(args.Mob, args.JobId, args.Profile,
+            _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
+
+    private void OnProfileLoad(LoadProfileExtensionsEvent args) =>
         ApplyNationality(args.Mob, args.JobId, args.Profile,
             _playTimeTracking.GetTrackerTimes(args.Player), args.Player.ContentData()?.Whitelisted ?? false);
 
@@ -48,9 +51,9 @@ public sealed class NationalitySystem : EntitySystem
 
         var jobPrototypeToUse = _prototype.Index(jobId.Value);
 
-        ProtoId<NationalityPrototype> nationality = profile.Nationality != string.Empty? profile.Nationality : SharedHumanoidAppearanceSystem.DefaultNationality;
+        ProtoId<NationalityPrototype> nationality = profile.Nationality != string.Empty ? profile.Nationality : SharedHumanoidAppearanceSystem.DefaultNationality;
 
-        if(!_prototype.TryIndex<NationalityPrototype>(nationality, out var nationalityPrototype))
+        if (!_prototype.TryIndex(nationality, out var nationalityPrototype))
         {
             DebugTools.Assert($"Nationality '{nationality}' not found!");
             return;

--- a/Content.Server/_Shitmed/StatusEffects/ScrambleDnaEffectSystem.cs
+++ b/Content.Server/_Shitmed/StatusEffects/ScrambleDnaEffectSystem.cs
@@ -24,7 +24,7 @@ public sealed class ScrambleDnaEffectSystem : EntitySystem
         if (TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
         {
             var newProfile = HumanoidCharacterProfile.RandomWithSpecies(humanoid.Species);
-            _humanoidAppearance.LoadProfile(uid, newProfile, humanoid);
+            _humanoidAppearance.LoadProfile(uid, newProfile, humanoid, loadExtensions: false, generateLoadouts: false);
             _metaData.SetEntityName(uid, newProfile.Name);
             if (TryComp<DnaComponent>(uid, out var dna))
             {

--- a/Content.Shared/Humanoid/LoadProfileExtensionsEvent.cs
+++ b/Content.Shared/Humanoid/LoadProfileExtensionsEvent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Preferences;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Humanoid;
+
+public sealed partial class LoadProfileExtensionsEvent : EntityEventArgs
+{
+    public EntityUid Mob { get; }
+    public ICommonSession Player { get; }
+    public string? JobId { get; }
+    public HumanoidCharacterProfile Profile { get; }
+    public bool GenerateLoadouts { get; }
+
+    public LoadProfileExtensionsEvent(EntityUid mob,
+        ICommonSession player,
+        string? jobId,
+        HumanoidCharacterProfile profile,
+        bool generateLoadouts)
+    {
+        Mob = mob;
+        Player = player;
+        JobId = jobId;
+        Profile = profile;
+        GenerateLoadouts = generateLoadouts;
+    }
+}

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -428,6 +428,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
 
     public void SetMarkings(EntityUid uid, HumanoidCharacterProfile profile, HumanoidAppearanceComponent humanoid)
     {
+        humanoid.MarkingSet.Clear();
         // Add markings that doesn't need coloring. We store them until we add all other markings that doesn't need it.
         var markingFColored = new Dictionary<Marking, MarkingPrototype>();
         foreach (var marking in profile.Appearance.Markings)
@@ -471,7 +472,6 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         }
 
         EnsureDefaultMarkings(uid, humanoid);
-        humanoid.MarkingSet.Clear();
     }
 
     /// <summary>

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using Content.Shared._EE.Contractors.Prototypes;
-using Content.Shared.Decals;
 using Content.Shared.Examine;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
@@ -10,7 +9,6 @@ using Content.Shared._Shitmed.Humanoid.Events; // Shitmed Change
 using Content.Shared.IdentityManagement;
 using Content.Shared.Preferences;
 using Content.Shared.HeightAdjust;
-using Microsoft.Extensions.Configuration;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects.Components.Localization;
@@ -43,6 +41,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     [Dependency] private readonly MarkingManager _markingManager = default!;
     [Dependency] private readonly ISerializationManager _serManager = default!;
     [Dependency] private readonly HeightAdjustSystem _heightAdjust = default!;
+    [Dependency] private readonly ISharedPlayerManager _sharedPlayerManager = default!;
 
     [ValidatePrototypeId<SpeciesPrototype>]
     public const string DefaultSpecies = "Human";
@@ -101,7 +100,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         if (string.IsNullOrEmpty(humanoid.Initial)
             || !_proto.TryIndex(humanoid.Initial, out HumanoidProfilePrototype? startingSet))
         {
-            LoadProfile(uid, HumanoidCharacterProfile.DefaultWithSpecies(humanoid.Species), humanoid);
+            LoadProfile(uid, HumanoidCharacterProfile.DefaultWithSpecies(humanoid.Species), humanoid, false, false);
             return;
         }
 
@@ -109,7 +108,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         foreach (var (layer, info) in startingSet.CustomBaseLayers)
             humanoid.CustomBaseLayers.Add(layer, info);
 
-        LoadProfile(uid, startingSet.Profile, humanoid);
+        LoadProfile(uid, startingSet.Profile, humanoid, false, false);
     }
 
     private void OnExamined(EntityUid uid, HumanoidAppearanceComponent component, ExaminedEvent args)
@@ -376,7 +375,11 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     /// <param name="uid">The mob's entity UID.</param>
     /// <param name="profile">The character profile to load.</param>
     /// <param name="humanoid">Humanoid component of the entity</param>
-    public virtual void LoadProfile(EntityUid uid, HumanoidCharacterProfile? profile, HumanoidAppearanceComponent? humanoid = null)
+    public virtual void LoadProfile(EntityUid uid,
+        HumanoidCharacterProfile? profile,
+        HumanoidAppearanceComponent? humanoid = null,
+        bool loadExtensions = true,
+        bool generateLoadouts = true)
     {
         if (profile == null)
             return;
@@ -386,25 +389,56 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
 
         SetSpecies(uid, profile.Species, false, humanoid);
         SetSex(uid, profile.Sex, false, humanoid);
+
+        humanoid.Gender = profile.Gender;
+        if (TryComp<GrammarComponent>(uid, out var grammar))
+            grammar.Gender = profile.Gender;
+
+        humanoid.DisplayPronouns = profile.DisplayPronouns;
+        humanoid.StationAiName = profile.StationAiName;
+        humanoid.CyborgName = profile.CyborgName;
+        humanoid.Age = profile.Age;
+
+        humanoid.CustomSpecieName = profile.Customspeciename;
+
         humanoid.EyeColor = profile.Appearance.EyeColor;
         var ev = new EyeColorInitEvent();
         RaiseLocalEvent(uid, ref ev);
 
+        humanoid.LastProfileLoaded = profile; //Set the loaded profile because Traits are about to need it
         SetSkinColor(uid, profile.Appearance.SkinColor, false);
+        if (loadExtensions && _sharedPlayerManager.TryGetSessionByEntity(uid, out var session))
+            RaiseLocalEvent(uid, new LoadProfileExtensionsEvent(uid, session, null, profile, generateLoadouts));
 
-        humanoid.MarkingSet.Clear();
+        SetMarkings(uid, profile, humanoid);
 
+        var species = _proto.Index(humanoid.Species);
+
+        if (profile.Height <= 0 || profile.Width <= 0)
+            SetScale(uid, new Vector2(species.DefaultWidth, species.DefaultHeight), true, humanoid);
+        else
+            SetScale(uid, new Vector2(profile.Width, profile.Height), true, humanoid);
+
+        _heightAdjust.SetScale(uid, new Vector2(humanoid.Width, humanoid.Height));
+
+        humanoid.LastProfileLoaded = profile; //But traits can also modify the profile so we need to set it again.
+        Dirty(uid, humanoid);
+        RaiseLocalEvent(uid, new ProfileLoadFinishedEvent());
+    }
+
+    public void SetMarkings(EntityUid uid, HumanoidCharacterProfile profile, HumanoidAppearanceComponent humanoid)
+    {
         // Add markings that doesn't need coloring. We store them until we add all other markings that doesn't need it.
         var markingFColored = new Dictionary<Marking, MarkingPrototype>();
         foreach (var marking in profile.Appearance.Markings)
         {
-            if (_markingManager.TryGetMarking(marking, out var prototype))
-            {
-                if (!prototype.ForcedColoring)
-                    AddMarking(uid, marking.MarkingId, marking.MarkingColors, false);
-                else
-                    markingFColored.Add(marking, prototype);
-            }
+            if (!_markingManager.TryGetMarking(marking, out var prototype))
+                continue;
+
+            if (!prototype.ForcedColoring)
+                AddMarking(uid, marking.MarkingId, marking.MarkingColors, false);
+            else
+                markingFColored.Add(marking, prototype);
         }
 
         // Hair/facial hair - this may eventually be deprecated.
@@ -437,31 +471,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         }
 
         EnsureDefaultMarkings(uid, humanoid);
-
-        humanoid.Gender = profile.Gender;
-        if (TryComp<GrammarComponent>(uid, out var grammar))
-            grammar.Gender = profile.Gender;
-
-        humanoid.DisplayPronouns = profile.DisplayPronouns;
-        humanoid.StationAiName = profile.StationAiName;
-        humanoid.CyborgName = profile.CyborgName;
-        humanoid.Age = profile.Age;
-
-        humanoid.CustomSpecieName = profile.Customspeciename;
-
-        var species = _proto.Index(humanoid.Species);
-
-        if (profile.Height <= 0 || profile.Width <= 0)
-            SetScale(uid, new Vector2(species.DefaultWidth, species.DefaultHeight), true, humanoid);
-        else
-            SetScale(uid, new Vector2(profile.Width, profile.Height), true, humanoid);
-
-        _heightAdjust.SetScale(uid, new Vector2(humanoid.Width, humanoid.Height));
-
-        humanoid.LastProfileLoaded = profile; // DeltaV - let paradox anomaly be cloned
-
-        Dirty(uid, humanoid);
-        RaiseLocalEvent(uid, new ProfileLoadFinishedEvent());
+        humanoid.MarkingSet.Clear();
     }
 
     /// <summary>

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -153,6 +153,7 @@
     minimumPlayers: 30
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
+    allowAntagLoadouts: false
   - type: AntagObjectives
     objectives:
     - StealResearchObjective

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -17,6 +17,8 @@
     - AbductObjective
   - type: AntagLoadProfileRule
     speciesHardOverride: Abductor
+    allowProfileExtensions: false
+    allowAntagLoadouts: false
   - type: AntagSelection
     definitions:
     - spawnerPrototype: LoneAbductorSpawner
@@ -110,6 +112,8 @@
     - AbductObjective
   - type: AntagLoadProfileRule
     speciesHardOverride: Abductor
+    allowProfileExtensions: false
+    allowAntagLoadouts: false
   - type: AntagSelection
     definitions:
     - spawnerPrototype: AbductorScientistSpawner


### PR DESCRIPTION
# Description

This PR gently refactors character profile loading such that it now optionally supports directly loading all of the EE specific extensions for character profiles, such as Traits and Loadouts. This generally means that Antags now actually support antag-specific traits and loadouts. It's currently only used by Nukies, who now spawn with your Traits and Loadout selections. 

Notably, there was already a pre-existing CharacterAntagonistRequirement, but it wasn't previously useful for the loadouts menu, and now it is. We can now fully support character menu options that apply if and only if a specific antagonist is generated. There's still some underlying unwieldiness to it, since antag loadouts will always be hidden due to your character doll never being an antag. 

# Changelog

:cl:
- add: Added code support for Antag-Specific Traits & Loadouts.
- add: Nuclear Operatives now spawn with Traits & Loadouts.
- add: Added support for Nationality, Employer, and Lifepath to all directly add bonus traits.
- add: Paradox Anomalies now also spawn with the victim's full list of Traits & Loadouts. Thus a paradox anomaly duplicating the Head of Security will also spawn with the head of security's selection of "HoS Gun", and is therefore also a valid objective target.
- tweak: Markings now apply AFTER traits and loadouts, meaning that they can now go on top of cybernetic limbs.
