### PR TITLE
Make All Jetpacks Go on Suit Storage + Combat First Aid Kit Easier to Find

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -89,7 +89,7 @@
     heldPrefix: radkit
 
 - type: entity
-  name: combat medical kit
+  name: combat medical first aid kit
   description: "For the big weapons among us."
   parent: Medkit
   id: MedkitCombat

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -47,6 +47,7 @@
     quickEquip: false
     slots:
     - Back
+    - suitStorage
   - type: GasTank
     outputPressure: 21.3
     air:
@@ -91,8 +92,6 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
   - type: Clothing
     sprite: Objects/Tanks/Jetpacks/blue.rsi
-    slots:
-    - Back
 
 # Filled blue
 - type: entity
@@ -124,8 +123,6 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
   - type: Clothing
     sprite: Objects/Tanks/Jetpacks/black.rsi
-    slots:
-    - Back
 
 # Filled black
 - type: entity
@@ -155,9 +152,6 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
   - type: Clothing
     sprite: Objects/Tanks/Jetpacks/captain.rsi
-    slots:
-    - Back
-    - SuitStorage
   - type: Item
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     size: Normal
@@ -241,8 +235,6 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
   - type: Clothing
     sprite: Objects/Tanks/Jetpacks/security.rsi
-    slots:
-    - Back
 
 #Filled security
 - type: entity


### PR DESCRIPTION
# Description
Makes the combat first aid kit easier to find in sandbox and makes all jetpacks go on suit storage

# Changelog

:cl: Ghost581
- tweak: Jetpacks can go on suit storage slot
