### PR TITLE
Fix Traits Anticheat

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -101,7 +101,7 @@ public sealed class TraitSystem : EntitySystem
 
             // To check for cheaters. :FaridaBirb.png:
             pointsTotal += traitPrototype.Points;
-            --traitSelections;
+            traitSelections -= traitPrototype.Slots;
             traitsToAdd.Add(traitPrototype);
         }
 


### PR DESCRIPTION
# Description

Traits Anticheat was not accounting for traits having variable slot occupancy, and was treating the "0 slot traits" as if they always had a slot cost of 1. This PR corrects this by making it count the actual slot costs of traits for the purpose of checking for illegal totals.

# Changelog

:cl:
- fix: Fixed a bug with Traits Anticheat incorrectly triggering if the player had selected enough 0 slot traits.
