### PR TITLE
power supply and load stuff

### DIFF
--- a/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
+++ b/Content.Client/Light/Visualizers/PoweredLightVisualizerSystem.cs
@@ -32,10 +32,16 @@ public sealed class PoweredLightVisualizerSystem : VisualizerSystem<PoweredLight
 
         if (args.Sprite.LayerExists(PoweredLightLayers.Glow))
         {
+            Color glowColor = Color.White;
             if (TryComp<PointLightComponent>(uid, out var light))
             {
-                args.Sprite.LayerSetColor(PoweredLightLayers.Glow, light.Color);
+                glowColor = light.Color;
             }
+
+            if (AppearanceSystem.TryGetData<float>(uid, PoweredLightVisuals.GlowAlpha, out var alpha, args.Component))
+                glowColor = glowColor.WithAlpha(alpha);
+
+            args.Sprite.LayerSetColor(PoweredLightLayers.Glow, glowColor);
 
             args.Sprite.LayerSetVisible(PoweredLightLayers.Glow, state == PoweredLightState.On);
         }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -61,6 +61,7 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<PoweredLightComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
 
             SubscribeLocalEvent<PoweredLightComponent, PowerChangedEvent>(OnPowerChanged);
+            SubscribeLocalEvent<PoweredLightComponent, SidePowerChangedEvent>(OnSidePowerChanged);
 
             SubscribeLocalEvent<PoweredLightComponent, PoweredLightDoAfterEvent>(OnDoAfter);
             SubscribeLocalEvent<PoweredLightComponent, EmpPulseEvent>(OnEmpPulse);
@@ -243,8 +244,7 @@ namespace Content.Server.Light.EntitySystems
         private void UpdateLight(EntityUid uid,
             PoweredLightComponent? light = null,
             ApcPowerReceiverComponent? powerReceiver = null,
-            AppearanceComponent? appearance = null,
-            float poweredFraction = 1f)
+            AppearanceComponent? appearance = null)
         {
             if (!Resolve(uid, ref light, ref powerReceiver, false))
                 return;
@@ -267,8 +267,9 @@ namespace Content.Server.Light.EntitySystems
                 case LightBulbState.Normal:
                     if (powerReceiver.Powered && light.On)
                     {
-                        SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy * poweredFraction, lightBulb.LightSoftness);
+                        SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy * powerReceiver.SideLoadFraction, lightBulb.LightSoftness);
                         _appearance.SetData(uid, PoweredLightVisuals.BulbState, PoweredLightState.On, appearance);
+                        _appearance.SetData(uid, PoweredLightVisuals.GlowAlpha, powerReceiver.SideLoadFraction, appearance);
                         var time = _gameTiming.CurTime;
                         if (time > light.LastThunk + ThunkDelay)
                         {
@@ -332,6 +333,17 @@ namespace Content.Server.Light.EntitySystems
             args.Handled = true;
         }
 
+        private void OnSidePowerChanged(EntityUid uid, PoweredLightComponent comp, ref SidePowerChangedEvent args)
+        {
+            if (!comp.On || GetBulb(uid, comp) is not EntityUid bulbUid ||
+                !TryComp<LightBulbComponent>(bulbUid, out var bulb) ||
+                bulb.State != LightBulbState.Normal)
+                return;
+
+            _pointLight.SetEnergy(uid, bulb.LightEnergy * args.SideLoadFraction);
+            _appearance.SetData(uid, PoweredLightVisuals.GlowAlpha, args.SideLoadFraction);
+        }
+
         private void OnPowerChanged(EntityUid uid, PoweredLightComponent component, ref PowerChangedEvent args)
         {
             // TODO: Power moment
@@ -340,7 +352,7 @@ namespace Content.Server.Light.EntitySystems
             if (metadata.EntityPaused || TerminatingOrDeleted(uid, metadata))
                 return;
 
-            UpdateLight(uid, component, poweredFraction: args.SideLoadFraction);
+            UpdateLight(uid, component);
         }
 
         public void ToggleBlinkingLight(EntityUid uid, PoweredLightComponent light, bool isNowBlinking)

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -78,7 +78,8 @@ namespace Content.Server.Power.Components
 
 
         [ViewVariables(VVAccess.ReadOnly)]
-        public float SideLoadFraction => MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad);
+        public float SideLoadFraction => _sideLoad > 0 ? MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad) : 1;
 
+        public float LastSideLoadFraction;
     }
 }

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -78,7 +78,7 @@ namespace Content.Server.Power.Components
 
 
         [ViewVariables(VVAccess.ReadOnly)]
-        public float SideLoadFraction => _sideLoad > 0 ? MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad) : 1;
+        public float SideLoadFraction => _sideLoad > 0 && _needsPower ? MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad) : 1;
 
         public float LastSideLoadFraction;
     }

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Power.NodeGroups;
 using Content.Server.Power.Pow3r;
 using Content.Shared.Power.Components;
+using System.Runtime.CompilerServices;
 
 namespace Content.Server.Power.Components
 {
@@ -15,8 +16,24 @@ namespace Content.Server.Power.Components
         ///     Amount of charge this needs from an APC per second to function.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+
+        private float _mainLoad;
+        private float _sideLoad;
+        
         [DataField("powerLoad")]
-        public float Load { get => NetworkLoad.DesiredPower; set => NetworkLoad.DesiredPower = value; }
+        public float Load { get => _mainLoad;
+            set { _mainLoad = value; NetworkLoad.DesiredPower = _mainLoad + _sideLoad; }
+            }
+
+        [DataField("sidePowerLoad")]
+        public float SideLoad
+        {
+            get => _sideLoad;
+            set { _sideLoad = value; NetworkLoad.DesiredPower = _mainLoad + _sideLoad; }
+        }
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float FullLoad => _mainLoad + _sideLoad;
 
         public ApcPowerProviderComponent? Provider = null;
 
@@ -58,5 +75,10 @@ namespace Content.Server.Power.Components
         };
 
         public float PowerReceived => NetworkLoad.ReceivingPower;
+
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float SideLoadFraction => MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad);
+
     }
 }

--- a/Content.Server/Power/Components/ChargerComponent.cs
+++ b/Content.Server/Power/Components/ChargerComponent.cs
@@ -16,6 +16,12 @@ namespace Content.Server.Power.Components
         public float ChargeRate = 20.0f;
 
         /// <summary>
+        /// Multiplies the load this charger puts on the powernet by this amount.
+        /// </summary>
+        [DataField]
+        public float ChargeEfficiency = 1f;
+
+        /// <summary>
         /// The container ID that is holds the entities being charged.
         /// </summary>
         [DataField("slotId", required: true)]

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -371,7 +371,7 @@ namespace Content.Server.Power.EntitySystems
                 }
 
                 // If new value is the same as the old, then exit
-                if (!apcReceiver.Recalculate && apcReceiver.Powered == powered)
+                if (!apcReceiver.Recalculate && apcReceiver.Powered == powered && Math.Abs(apcReceiver.SideLoadFraction - apcReceiver.LastSideLoadFraction) < 0.01f)
                     continue;
 
                 metadata ??= MetaData(uid);
@@ -382,7 +382,7 @@ namespace Content.Server.Power.EntitySystems
                 apcReceiver.Powered = powered;
                 Dirty(uid, apcReceiver, metadata);
 
-                var ev = new PowerChangedEvent(powered, apcReceiver.NetworkLoad.ReceivingPower);
+                var ev = new PowerChangedEvent(powered, apcReceiver.NetworkLoad.ReceivingPower, apcReceiver.SideLoadFraction);
                 RaiseLocalEvent(uid, ref ev);
 
                 if (_appearanceQuery.TryComp(uid, out var appearance))

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -333,27 +333,22 @@ namespace Content.Server.Power.EntitySystems
                 // Check if the entity has an internal battery
                 if (_apcBatteryQuery.TryComp(uid, out var apcBattery) && _batteryQuery.TryComp(uid, out var battery))
                 {
-                    var partiallyPowered = !apcReceiver.PowerDisabled || !apcReceiver.NeedsPower;
-
                     apcReceiver.Load = apcBattery.IdleLoad;
 
                     // Try to draw power from the battery if there isn't sufficient external power
-                    // ̶W̶W̶D̶P EE̶ EDIT START - attempted fix of apc battery chargers fucking up
-                    // powernet by alternating between drawing power and not drawing,
-                    // thus not letting apc rampup to catch up with the load
-                    var requireBattery = !partiallyPowered || apcReceiver.PowerReceived < apcReceiver.Load;
+                    var requireBattery = !powered && !apcReceiver.PowerDisabled;
 
-                    if(requireBattery)
+                    if (requireBattery)
                     {
-                        _battery.SetCharge(uid, battery.CurrentCharge - (apcReceiver.PowerReceived - apcBattery.IdleLoad) * frameTime, battery);
+                        _battery.SetCharge(uid, battery.CurrentCharge - apcBattery.IdleLoad * frameTime, battery);
                     }
-                    else if (!_battery.IsFull(uid, battery))
+                    // Otherwise try to charge the battery
+                    else if (powered && !_battery.IsFull(uid, battery))
                     {
                         apcReceiver.Load += apcBattery.BatteryRechargeRate * apcBattery.BatteryRechargeEfficiency;
-                        float frac = apcReceiver.NeedsPower ? MathHelper.Clamp01(apcReceiver.PowerReceived / apcReceiver.Load) : 1;
-                        _battery.SetCharge(uid, battery.CurrentCharge + apcBattery.BatteryRechargeRate * frameTime * frac, battery);
+                        _battery.SetCharge(uid, battery.CurrentCharge + apcBattery.BatteryRechargeRate * frameTime, battery);
                     }
-                    // ̶W̶W̶D̶P̶ EE EDIT END
+
                     // Enable / disable the battery if the state changed
                     var enableBattery = requireBattery && battery.CurrentCharge > 0;
 

--- a/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
+++ b/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
@@ -73,7 +73,7 @@ public sealed class GasPowerReceiverSystem : EntitySystem
         if (state != comp.Powered)
         {
             comp.Powered = state;
-            var ev = new PowerChangedEvent(state, 0, float.NaN);
+            var ev = new PowerChangedEvent(state, 0);
             RaiseLocalEvent(uid, ref ev);
         }
     }

--- a/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
+++ b/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Atmos.EntitySystems;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
@@ -73,7 +73,7 @@ public sealed class GasPowerReceiverSystem : EntitySystem
         if (state != comp.Powered)
         {
             comp.Powered = state;
-            var ev = new PowerChangedEvent(state, 0);
+            var ev = new PowerChangedEvent(state, 0, float.NaN);
             RaiseLocalEvent(uid, ref ev);
         }
     }

--- a/Content.Shared/Light/SharedPoweredLightVisuals.cs
+++ b/Content.Shared/Light/SharedPoweredLightVisuals.cs
@@ -6,6 +6,7 @@ namespace Content.Shared.Light
     public enum PoweredLightVisuals : byte
     {
         BulbState,
+        GlowAlpha,
         Blinking
     }
 

--- a/Content.Shared/Power/PowerChangedEvent.cs
+++ b/Content.Shared/Power/PowerChangedEvent.cs
@@ -5,4 +5,12 @@ namespace Content.Shared.Power;
 /// Does nothing on the client.
 /// </summary>
 [ByRefEvent]
-public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower, float SideLoadFraction);
+public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower);
+
+
+/// <summary>
+/// Raised whenever power consumed as a side load changes.
+/// Does nothing on the client.
+/// </summary>
+[ByRefEvent]
+public readonly record struct SidePowerChangedEvent(float SideLoadFraction);

--- a/Content.Shared/Power/PowerChangedEvent.cs
+++ b/Content.Shared/Power/PowerChangedEvent.cs
@@ -5,4 +5,4 @@ namespace Content.Shared.Power;
 /// Does nothing on the client.
 /// </summary>
 [ByRefEvent]
-public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower);
+public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower, float SideLoadFraction);

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -11,6 +11,8 @@
   - type: Sprite
     snapCardinals: true
   - type: Appearance
+  - type: ApcPowerReceiver
+    powerLoad: 5
   - type: Charger
     slotId: charger_slot
   - type: Anchorable


### PR DESCRIPTION
# Description

Changes how `ApcPowerReceiverComponent` works a bit.
Separated the `Load` variable into main and side power loads.
If main power demand is not met, the machine is considered unpowered.
Side power demand is "optional", as can be met only partially (or not at all) and the device will continue to operate.
Depending on the device, this may have different negative effects on its operaton. such as lights dimming and weapon rechargers not charging at full speed.

This was first intended to fix an annoying bug with `ChargerComponent` and `ApcPowerReceiverBatteryComponent`, that made the powernet spaz out for a while if their power demand was too high.
This is now fixed.



---

<details><summary><h1>Media</h1></summary>
<p>

tbd

</p>
</details>

---

# Changelog

nocl (?)