### PR TITLE
Fix Wizden's Division By Zero Error

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -198,7 +198,7 @@ public sealed partial class GunComponent : Component
     /// <seealso cref="GunRefreshModifiersEvent"/>
     /// </summary>
     [AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public float FireRateModified;
+    public float FireRateModified = 1;
 
     /// <summary>
     /// Starts fire cooldown when equipped if true.


### PR DESCRIPTION
# Description

This datafield is a multiplier, not additive, it shouldn't have been defaulted to 0. 