### PR TITLE
Species Swap: Shell

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -984,12 +984,17 @@ public sealed partial class TraitMultiplyToComponent : TraitFunction
                     var setValue = field.GetValue(entry.Component);
                     var targetValue = field.GetValue(targetComp);
                     if (setValue == field.GetValue(refComp)
-                        || setValue is null || targetValue is null
-                        || !targetValue.GetType().IsValueType
-                        || !setValue.GetType().IsValueType)
+                        || setValue is null || targetValue is null)
                         continue;
 
-                    field.SetValue(targetComp, (float) targetValue * (float) setValue);
+                    if (targetValue is float targetFloat && setValue is float setFloat)
+                        field.SetValue(targetComp, targetFloat * setFloat);
+                    else if (targetValue is double targetDouble && setValue is double setDouble)
+                        field.SetValue(targetComp, targetDouble * setDouble);
+                    else if (targetValue is int targetInt && setValue is int setInt)
+                        field.SetValue(targetComp, targetInt * setInt);
+                    else if (targetValue is FixedPoint2 targetFixed && setValue is FixedPoint2 setFixed)
+                        field.SetValue(targetComp, targetFixed * setFixed);
                 }
                 if (!targetComp.GetType().HasCustomAttribute<NetworkedComponentAttribute>())
                     continue;
@@ -1042,12 +1047,17 @@ public sealed partial class TraitAddToComponent : TraitFunction
                     var setValue = field.GetValue(entry.Component);
                     var targetValue = field.GetValue(targetComp);
                     if (setValue == field.GetValue(refComp)
-                        || setValue is null || targetValue is null
-                        || !targetValue.GetType().IsValueType
-                        || !setValue.GetType().IsValueType)
+                        || setValue is null || targetValue is null)
                         continue;
 
-                    field.SetValue(targetComp, (float) targetValue + (float) setValue);
+                    if (targetValue is float targetFloat && setValue is float setFloat)
+                        field.SetValue(targetComp, targetFloat + setFloat);
+                    else if (targetValue is double targetDouble && setValue is double setDouble)
+                        field.SetValue(targetComp, targetDouble + setDouble);
+                    else if (targetValue is int targetInt && setValue is int setInt)
+                        field.SetValue(targetComp, targetInt + setInt);
+                    else if (targetValue is FixedPoint2 targetFixed && setValue is FixedPoint2 setFixed)
+                        field.SetValue(targetComp, targetFixed + setFixed);
                 }
                 if (!targetComp.GetType().HasCustomAttribute<NetworkedComponentAttribute>())
                     continue;

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -718,3 +718,9 @@ trait-description-ForkedTongue =
 trait-name-StuntedSnout = Stunted Snout
 trait-description-StuntedSnout =
     Your sense of smell is stunted for one reason or another. You lack the ability to pick up scents.
+
+trait-name-Shell = Species Swap: Shell
+trait-description-Shell =
+    You are a highly sophisticated positronic brain inside a construct consisting of living tissue over a metal endoskeleton.
+    On the exterior you look like a human, but the lack of humanity is plainly evident in the empty eyes and calculating stare.
+    Nearly all of your character's Human features are swapped for those of an IPC, effectively making this a species swap "under the hood".

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1468,9 +1468,6 @@
         - type: SiliconDownOnDead
         - type: Inventory
           templateId: ipc
-        - type: SiliconDownOnDead
-        - type: Inventory
-          templateId: ipc
         - type: GuideHelp
           guides:
             - IPC

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1526,9 +1526,6 @@
           bloodRegenerationThirst: 0
           bloodReagent: IPCCoolant
           cauterizeMessage: null
-        - type: Damageable
-          damageContainer: Silicon
-          damageModifierSet: IPC
         - type: Temperature
           heatDamageThreshold: 1800 # GoobStation: Roughly the melting point of mild steels
           coldDamageThreshold: 260

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -392,7 +392,6 @@
             types:
               Blunt: 0
 
-
 - type: trait
   id: Claws
   category: Physical
@@ -412,14 +411,16 @@
       traits:
         - Talons
   functions:
-    - !type:TraitModifyUnarmed
-      soundHit:
-        collection: AlienClaw
-      animation: WeaponArcClaw
-      damage:
-        types:
-          Slash: 5 # Trade stamina damage on hit for a very minor amount of extra bleed.
-                  # Blunt also deals bleed damage, so this is more of a sidegrade.
+    - !type:TraitModifyComponent
+      components:
+        - type: MeleeWeapon
+          soundHit:
+            collection: AlienClaw
+          animation: WeaponArcClaw
+          damage:
+            types:
+              Slash: 5 # Trade stamina damage on hit for a very minor amount of extra bleed.
+                      # Blunt also deals bleed damage, so this is more of a sidegrade.
     - !type:TraitRemoveComponent
       components:
         - type: DamageOnHit
@@ -1397,3 +1398,179 @@
     - !type:TraitRemoveComponent
       components:
         - type: ScentTracker
+
+- type: trait
+  id: Shell
+  category: Physical
+  points: -2
+  slots: 0
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Human
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - RobotTalk
+      languagesUnderstood:
+        - RobotTalk
+    - !type:TraitRemoveComponent
+      components:
+        - type: Mood
+    - !type:TraitModifyComponent
+      components:
+        - type: PowerCellSlot
+          cellSlotId: cell_slot
+          fitsInCharger: true
+        - type: ItemSlots
+          slots:
+            cell_slot:
+              name: power-cell-slot-component-slot-name-default
+              startingItem: PowerCellMedium
+        - type: ItemSlotsRequirePanel
+          slots:
+            cell_slot: true
+        - type: EncryptionHolderRequiresLock
+        - type: SiliconEmitSoundOnDrained
+          sound: "/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg"
+          minInterval: 15
+          maxInterval: 30
+          popUp: "silicon-power-low"
+        - type: WiresPanel
+          openDelay: 5
+        - type: LockedWiresPanel
+        - type: Lock
+          locked: true
+          lockOnClick: false
+          unlockOnClick: false
+          breakOnEmag: false
+        - type: AccessReader
+          breakOnEmag: true
+          ownerHasAccess: true
+        - type: MobState
+          allowedStates:
+            - Alive
+            - Dead
+        - type: MobThresholds
+          thresholds:
+            0: Alive
+            120: Dead
+          stateAlertDict:
+            Alive: BorgHealth
+            Dead: BorgDead
+        - type: TypingIndicator
+          proto: robot
+        - type: SlowOnDamage
+          speedModifierThresholds:
+            60: 0.75
+            90: 0.5
+            120: 0.3
+        - type: SiliconDownOnDead
+        - type: Inventory
+          templateId: ipc
+        - type: SiliconDownOnDead
+        - type: Inventory
+          templateId: ipc
+        - type: GuideHelp
+          guides:
+            - IPC
+        - type: Silicon
+          entityType: enum.SiliconType.Player
+          batteryPowered: true
+          drainPerSecond: 1.5
+          chargeThresholdMid: 0.80
+          chargeThresholdLow: 0.35
+          chargeThresholdCritical: 0.10
+          speedModifierThresholds:
+            4: 1
+            3: 1
+            2: 0.80
+            1: 0.45
+            0: 0.00
+        - type: BatteryDrinker
+        - type: EncryptionKeyHolder
+          keySlots: 4
+          examineWhileLocked: false
+          keysExtractionMethod: Cutting
+          keysUnlocked: false
+        - type: ActiveRadio
+        - type: IntrinsicRadioReceiver
+        - type: IntrinsicRadioTransmitter
+        - type: DeadStartupButton
+          sound:
+            path: /Audio/Effects/Silicon/startup.ogg
+        - type: EmitBuzzWhileDamaged
+        - type: ProtectedFromStepTriggers
+          whitelist:
+            types:
+            - Shard
+        - type: Tag
+          tags:
+          - CanPilot
+          - FootstepSound
+          - DoorBumpOpener
+          - SiliconEmotes
+          - SiliconMob
+        - type: Damageable
+          damageContainer: SiliconUnshielded
+          damageModifierSet: IPC
+        - type: Barotrauma
+          damage:
+            types:
+              Heat: 0.55 #per second, scales with pressure and other constants. Uniquely Heat instead of blunt, to simulate mechanical overheating in vacuum. IPCs are normally air cooled.
+        - type: Bloodstream
+          bloodlossDamage:
+            types:
+              Bloodloss: 0
+          bloodlossHealDamage:
+            types:
+              Bloodloss: 0
+          bloodRegenerationHunger: 0
+          bloodRegenerationThirst: 0
+          bloodReagent: IPCCoolant
+          cauterizeMessage: null
+        - type: Damageable
+          damageContainer: Silicon
+          damageModifierSet: IPC
+        - type: Temperature
+          heatDamageThreshold: 1800 # GoobStation: Roughly the melting point of mild steels
+          coldDamageThreshold: 260
+          currentTemperature: 310.15
+          specificHeat: 42
+          coldDamage:
+            types:
+              Cold: 0.1 #per second, scales with temperature & other constants
+          heatDamage:
+            types:
+              Heat: 3 #per second, scales with temperature & other constants
+          atmosTemperatureTransferEfficiency: 0.05
+        - type: KillOnOverheat # GoobStation
+        - type: Deathgasp
+          prototype: SiliconDeathgasp
+          needsCritical: false
+        - type: Flammable
+          fireSpread: true
+          canResistFire: true
+          damage:
+            types:
+              Heat: 0 # GoobStation: Replaced fire damage with overheating shutdown
+        - type: RangedDamageSound
+          soundGroups:
+            Brute:
+              collection: MetalBulletImpact
+          soundTypes:
+            Heat:
+              collection: MetalLaserImpact
+        - type: HumanoidAppearance
+          species: IPC
+        - type: Speech
+          speechSounds: Pai
+        - type: Vocal
+          wilhelm: "/Audio/Voice/IPC/wilhelm.ogg"
+          sounds:
+            Male: UnisexIPC
+            Female: UnisexIPC
+            Unsexed: UnisexIPC
+        - type: LightningTarget
+          priority: 1
+          lightningExplode: false


### PR DESCRIPTION
# Description

This PR implements a long since highly demanded and stupidly complicated to implement trait function, which enables me to trivially do something I have been wanting to do for awhile, make a subspecies swapper. This new function is called TraitModifyComponent, and it allows one to directly write to any field of any trait, overwriting said field with a specific value. To make use of this, I created the Species Swap: Shell trait to demonstrate its awesome power.

This trait turns a human into an IPC, while retaining their entire system of humanoid appearance, effectively turning them into a Shell. https://wiki.aurorastation.org/index.php/IPC#Shell_Model_IPCs

You can now play a Hazel. 

# TODO

<details><summary><h1>Media</h1></summary>
<p>

<img width="395" height="269" alt="image" src="https://github.com/user-attachments/assets/37a663c2-568c-4cc0-9887-5bdb786f5795" />

<img width="1898" height="985" alt="image" src="https://github.com/user-attachments/assets/4f6747ca-2381-4dc0-85c9-076300d27e75" />

</p>
</details>

# Changelog
I have actually tested this PR and verified that it works.

:cl:
- add: Added a new trait, Species Swap: Shell. This trait turns a human character into an IPC made to look like a human, complete with all of the mechanical features of an IPC. Hazel enthusiasts rejoice.
