### PR TITLE
Fixes For Shell Species Swap

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -69,6 +69,12 @@ public sealed class VocalSystem : EntitySystem
             || TryComp<ReplacementAccentComponent>(uid, out var replacement) && replacement.Accent == MuzzleAccent) // This is not ideal, but it works.
             return;
 
+        if (_proto.TryIndex(component.ForceEmoteSounds, out var emoteSoundsPrototype, false))
+        {
+            component.EmoteSounds = emoteSoundsPrototype;
+            component.ForceEmoteSounds = null;
+        }
+
         // snowflake case for wilhelm scream easter egg
         if (args.Emote.ID == component.ScreamId)
         {

--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -43,6 +43,9 @@ public sealed partial class VocalComponent : Component
     [AutoNetworkedField]
     public EntityUid? ScreamActionEntity;
 
+    [DataField, AutoNetworkedField]
+    public ProtoId<EmoteSoundsPrototype>? ForceEmoteSounds = null;
+
     /// <summary>
     ///     Currently loaded emote sounds prototype, based on entity sex.
     ///     Null if no valid prototype for entity sex was found.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1433,7 +1433,11 @@
       components:
         - type: Mood
         - type: Perishable
-        - type: Butcherable
+        - type: Butcherable # I hate that required fields are required on components that aren't real.
+          butcheringType: Spike
+          spawned:
+          - id: FoodMeatHuman
+            amount: 5
         - type: Respirator
         - type: Absorbable
         - type: Dna

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1439,6 +1439,12 @@
           - id: FoodMeatHuman
             amount: 5
         - type: Respirator
+          damage:
+            types:
+              Asphyxiation: 2
+          damageRecovery:
+            types:
+              Asphyxiation: -1.0
         - type: Absorbable
         - type: Dna
         - type: Hunger

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1278,9 +1278,14 @@
   category: Physical
   points: -4
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
   functions:
     - !type:TraitAddArmor
       damageModifierSets:
@@ -1291,9 +1296,14 @@
   category: Physical
   points: -5
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
   functions:
     - !type:TraitAddComponent
       components:
@@ -1310,9 +1320,14 @@
   category: Physical
   points: -3
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -1417,6 +1432,13 @@
     - !type:TraitRemoveComponent
       components:
         - type: Mood
+        - type: Perishable
+        - type: Butcherable
+        - type: Respirator
+        - type: Absorbable
+        - type: Dna
+        - type: Hunger
+        - type: Thirst
     - !type:TraitModifyComponent
       components:
         - type: PowerCellSlot
@@ -1565,6 +1587,7 @@
             Male: UnisexIPC
             Female: UnisexIPC
             Unsexed: UnisexIPC
+          forceEmoteSounds: UnisexIPC
         - type: LightningTarget
           priority: 1
           lightningExplode: false

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -148,7 +148,7 @@
   category: Physical
   points: 3
   functions:
-    - !type:TraitReplaceComponent
+    - !type:TraitModifyComponent
       components:
         - type: Silicon
           entityType: enum.SiliconType.Player
@@ -164,9 +164,14 @@
             1: 0.45
             0: 0.00
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
 
 - type: trait
   id: IPCBrittleBoneDisease
@@ -182,9 +187,14 @@
         - type: DeadModifier
           deadThresholdModifier: -60
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
 
 - type: trait
   id: IPCFragileCircuits
@@ -195,9 +205,14 @@
       components:
         - type: KillOnDamage
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
 
 - type: trait
   id: IPCFaultyWaterproofing
@@ -230,9 +245,14 @@
                   messages: [ "faultyWaterproofing-damage-popup" ]
                   probability: 1
   requirements:
-    - !type:CharacterSpeciesRequirement
-      species:
-        - IPC
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          species:
+            - IPC
+        - !type:CharacterTraitRequirement
+          traits:
+            - Shell
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
# Description

Vocal emotes were broken for Shells, and there were a few leftover components that they shouldn't have still had which were obtained from other entries in the parent hierarchy. 

# Changelog

:cl:
- tweak: Most traits that were previously IPC exclusive can now also be taken by Shells. 
- fix: Fixed Shells not having any emote sounds.
