### PR TITLE
More Fixes For Shells

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1449,6 +1449,7 @@
         - type: Dna
         - type: Hunger
         - type: Thirst
+        - type: Internals
     - !type:TraitModifyComponent
       components:
         - type: PowerCellSlot
@@ -1587,8 +1588,6 @@
           soundTypes:
             Heat:
               collection: MetalLaserImpact
-        - type: HumanoidAppearance
-          species: IPC
         - type: Speech
           speechSounds: Pai
         - type: Vocal


### PR DESCRIPTION
# Description

This fixes a bug where the Shell trait was wiping your character's markings (it turns out that when you Dirty a humanoid appearance component, it rechecks the Marking requirements, and removes any markings no longer valid if you suddenly declare that Urist McHands is actually an IPC). 

Also removes the vestigial internals button for Shells, since they're robots that don't breathe, they therefore don't need an internals icon.

# Changelog

:cl:
- fix: Fixed the Species Swap: Shell trait wiping your character's marking selections.
- remove: Shells no longer have an icon to turn on internals since they don't have lungs to begin with.