### PR TITLE
Hive SM Atmosfix, Cryogenics Setup

### DIFF
--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -116291,8 +116291,6 @@ entities:
       pos: 64.5,-15.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8
     - type: AtmosPipeColor


### PR DESCRIPTION
# Description

Placed atmosfix coolant markers inside SM chamber, added plasma and ammonia miners, tweaked cryogenics setup, and replaced medical records computer in medbay with crew monitoring computer.

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="197" height="359" alt="image" src="https://github.com/user-attachments/assets/b043b513-d492-4103-9e97-4fc8af5226e9" />
<img width="605" height="558" alt="image" src="https://github.com/user-attachments/assets/f46e22fb-772b-4822-b175-563821a539cc" />

</p>
</details>

---

# Changelog

:cl: mrs
- add: Hive: Crew monitoring computer in medbay.
- fix: Hive: SM round start delamination risk lowered significantly.
- tweak: Hive: Cryogenics setup changed slightly to allow drawing from distro and managing pod pressure more reliably.