### PR TITLE
Tweak: Nerfed Juggernaut Ult

### DIFF
--- a/Content.Server/Ghost/GhostReturnToRoundSystem.cs
+++ b/Content.Server/Ghost/GhostReturnToRoundSystem.cs
@@ -59,7 +59,14 @@ public sealed class GhostReturnToRoundSystem : EntitySystem
             return;
         }
 
-        var deathTime = EnsureComp<GhostComponent>(uid).TimeOfDeath;
+        if (!TryComp<GhostComponent>(uid, out var ghostComp))
+        {
+            message = Loc.GetString("ghost-respawn-error", ("players", maxPlayers));
+            wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", message));
+            return;
+        }
+
+        var deathTime = ghostComp.TimeOfDeath;
         // WD EDIT START
         if (_mindSystem.TryGetMind(uid, out _, out var mind) && mind.TimeOfDeath.HasValue)
             deathTime = mind.TimeOfDeath.Value;

--- a/Resources/Locale/en-US/ghost/ghost-respawn.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-respawn.ftl
@@ -8,7 +8,7 @@ ghost-respawn-seconds-left = Please wait {$time} {$time ->
 } before trying to respawn.
 
 ghost-respawn-max-players = Cannot respawn right now. There should be fewer than {$players} players.
-ghost-respawn-error = Something went wrong while trying to respawn. Try again and contact an admin if it persists.
+ghost-respawn-error = Something went wrong while trying to respawn. Try again and contact an admin if the issue persists.
 ghost-respawn-window-title = Respawn rules
 ghost-respawn-window-rules-footer = By respawning, you [color=#ff7700]agree[/color] [color=#ff0000]not to use any knowledge gained as your previous character[/color]. Violation of this rule may constitute a server ban. Please read the server rules for more details.
 ghost-respawn-same-character = You cannot respawn as the same character. Please select a different one in character preferences.

--- a/Resources/Locale/en-US/ghost/ghost-respawn.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-respawn.ftl
@@ -8,6 +8,7 @@ ghost-respawn-seconds-left = Please wait {$time} {$time ->
 } before trying to respawn.
 
 ghost-respawn-max-players = Cannot respawn right now. There should be fewer than {$players} players.
+ghost-respawn-error = Something went wrong while trying to respawn. Try again and contact an admin if it persists.
 ghost-respawn-window-title = Respawn rules
 ghost-respawn-window-rules-footer = By respawning, you [color=#ff7700]agree[/color] [color=#ff0000]not to use any knowledge gained as your previous character[/color]. Violation of this rule may constitute a server ban. Please read the server rules for more details.
 ghost-respawn-same-character = You cannot respawn as the same character. Please select a different one in character preferences.


### PR DESCRIPTION
# Description

The system that is responsible for letting ghosts rejoin the round does not validate the client's request properly.
The outcome is both hilarious and horrifying.

The bug can be triggered either by a modified client straight up sending the `GhostReturnToRoundRequest` message whenever, or by a client with high ping sending it after it has switched bodies (e.g. took a ghost role), but before it has received the update from the server.

---

<details><summary><h1>Media</h1></summary>
<p>

[juggernaut.zip.webm](https://github.com/user-attachments/assets/13090f95-283b-4841-9fa3-da723642c3a3)

</p>



it does this now instead

<img width="461" height="85" alt="image" src="https://github.com/user-attachments/assets/28958282-6c23-4f72-9822-69d90ce4360b" />


</details>

---

nocl